### PR TITLE
Add title property to item's name

### DIFF
--- a/src/components/xcloud/FileCommanderItem.js
+++ b/src/components/xcloud/FileCommanderItem.js
@@ -391,7 +391,7 @@ class FileCommanderItem extends React.Component {
         <div className="itemIcon">
           {this.props.isFolder ? this.getFolderIcon() : this.getFileIcon()}
         </div>
-        <div className="name" onClick={this.itemClickHandler}>
+        <div className="name" title={this.props.name} onClick={this.itemClickHandler}>
           {this.props.name}
         </div>
         <div className="created">


### PR DESCRIPTION
Since item's names are bound to be cropped, adding the title property to every item name allows people to see the full name on hover.