### PR TITLE
Fix limit api call

### DIFF
--- a/src/components/StorageProgressBar.tsx
+++ b/src/components/StorageProgressBar.tsx
@@ -15,7 +15,7 @@ class StorageProgressBar extends React.Component<StorageProgressBarState, Storag
     }
 
     componentDidUpdate(newProps: StorageProgressBarState) {
-      if (newProps.max !== this.state.max || newProps.now !== this.state.now) {
+      if (this.props.max !== this.state.max || this.props.now !== this.state.now) {
         this.setState(newProps);
       }
     }

--- a/src/components/StorageProgressBar.tsx
+++ b/src/components/StorageProgressBar.tsx
@@ -14,9 +14,9 @@ class StorageProgressBar extends React.Component<StorageProgressBarState, Storag
       now: 0
     }
 
-    componentDidUpdate(newProps: StorageProgressBarState) {
+    componentDidUpdate() {
       if (this.props.max !== this.state.max || this.props.now !== this.state.now) {
-        this.setState(newProps);
+        this.setState(this.props);
       }
     }
 

--- a/src/components/navigationBar/NavigationBar.tsx
+++ b/src/components/navigationBar/NavigationBar.tsx
@@ -132,26 +132,6 @@ class NavigationBar extends React.Component<NavigationBarProps, NavigationBarSta
       });
     }
 
-    fetch('/api/limit', {
-      method: 'get',
-      headers: getHeaders(true, false)
-    }).then(res => res.json()).then(res2 => {
-      this.setState({ barLimit: res2.maxSpaceBytes });
-    }).catch(err => {
-      console.log('Error on fetch limit', err);
-    });
-
-    fetch('/api/usage', {
-      method: 'get',
-      headers: getHeaders(true, false)
-    }
-    ).then(res => {
-      return res.json();
-    }).then(res2 => {
-      this.setState({ barUsage: res2.total });
-    }).catch(err => {
-      console.log('Error on fetch usage', err);
-    });
     this.getUsage(this.state.isTeam);
   }
 


### PR DESCRIPTION
The use of this lifecycle was wrong. The first parameter was to know the previous props not the new


https://es.reactjs.org/docs/react-component.html#componentdidupdate

componentDidUpdate()

componentDidUpdate(prevProps, prevState, snapshot)

componentDidUpdate() is invoked immediately after updating occurs. This method is not called for the initial render.

Use this as an opportunity to operate on the DOM when the component has been updated. This is also a good place to do network requests as long as you compare the current props to previous props (e.g. a network request may not be necessary if the props have not changed).
