### PR TITLE
add private key decrypted base64 into localstorage when register

### DIFF
--- a/src/components/forms/New.tsx
+++ b/src/components/forms/New.tsx
@@ -209,7 +209,9 @@ class New extends React.Component<NewProps, NewState> {
 
           Settings.set('xToken', token);
           user.mnemonic = decryptTextWithKey(user.mnemonic, this.state.register.password);
-          Settings.set('xUser', JSON.stringify(user));
+          const privkeyDecrypted = Buffer.from(AesUtil.decrypt(user.privateKey, this.state.register.password)).toString('base64');
+
+          user.privateKey = privkeyDecrypted;
           Settings.set('xMnemonic', user.mnemonic);
 
           return initializeUser(this.state.register.email, user.mnemonic).then((rootFolderInfo) => {


### PR DESCRIPTION
Add when the fetch to registration is complete, the private key is decrypted in base64 into localstorage, If it is not decrypted in the localstorage, the stripe session fails