### PR TITLE
[DW2-202]: feature/display-progress-folder-upload

### DIFF
--- a/src/services/i18n.service/locales/en.json
+++ b/src/services/i18n.service/locales/en.json
@@ -57,7 +57,7 @@
     "upload-folder": {
       "pending": "Pending to upload",
       "encrypting": "Encrypting files",
-      "in-process": "Uploading folder",
+      "in-process": "{progress}% Uploading folder",
       "success": "Folder uploaded",
       "error": "Error during upload"
     },


### PR DESCRIPTION
Until now uploading a folder didn't update the notification at all and user could be waiting with no feedback for a while. 

- Added item counting under a root folder
- Update the notification after each item under root folder has been uploaded