### PR TITLE
[_]: fix/incorrect-local-update

### DIFF
--- a/src/components/dialogs/CreateFolderDialog/CreateFolderDialog.tsx
+++ b/src/components/dialogs/CreateFolderDialog/CreateFolderDialog.tsx
@@ -2,19 +2,19 @@ import { useState } from 'react';
 import { connect } from 'react-redux';
 
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
-import { UserSettings } from '../../../models/interfaces';
 import { RootState } from '../../../store';
 
 import BaseDialog from '../BaseDialog/BaseDialog';
 import { uiActions } from '../../../store/slices/ui';
 import BaseButton from '../../Buttons/BaseButton';
 import storageThunks from '../../../store/slices/storage/storage.thunks';
+import storageSelectors from '../../../store/slices/storage/storage.selectors';
 interface CreateFolderDialogProps {
   onFolderCreated?: () => void;
-  user: UserSettings | undefined;
+  currentFolderId: number;
 }
 
-const CreateFolderDialog = ({ onFolderCreated, user }: CreateFolderDialogProps) => {
+const CreateFolderDialog = ({ onFolderCreated, currentFolderId }: CreateFolderDialogProps) => {
   const [folderName, setFolderName] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const dispatch = useAppDispatch();
@@ -24,7 +24,7 @@ const CreateFolderDialog = ({ onFolderCreated, user }: CreateFolderDialogProps) 
   };
   const createFolder = async () => {
     setIsLoading(true);
-    await dispatch(storageThunks.createFolderThunk(folderName))
+    await dispatch(storageThunks.createFolderThunk({ folderName, parentId: currentFolderId }))
       .unwrap()
       .then(() => {
         onClose();
@@ -66,4 +66,5 @@ const CreateFolderDialog = ({ onFolderCreated, user }: CreateFolderDialogProps) 
 
 export default connect((state: RootState) => ({
   user: state.user.user,
+  currentFolderId: storageSelectors.currentFolderId(state),
 }))(CreateFolderDialog);

--- a/src/store/slices/storage/storage.thunks/createFolderTreeStructureThunk.ts
+++ b/src/store/slices/storage/storage.thunks/createFolderTreeStructureThunk.ts
@@ -4,12 +4,12 @@ import { StorageState } from '../storage.model';
 import { RootState } from '../../..';
 import { TaskType, TaskStatus } from '../../../../models/enums';
 import { NotificationData } from '../../../../models/interfaces';
-import folderService from '../../../../services/folder.service';
 import i18n from '../../../../services/i18n.service';
 import notificationsService, { ToastType } from '../../../../services/notifications.service';
 import { tasksActions } from '../../tasks';
 import { uploadItemsThunk } from './uploadItemsThunk';
 import errorService from '../../../../services/error.service';
+import storageThunks from '.';
 
 export interface IRoot {
   name: string;
@@ -55,7 +55,9 @@ export const createFolderTreeStructureThunk = createAsyncThunk<
 
     while (levels.length > 0) {
       const level: IRoot = levels.shift() as IRoot;
-      const folderUploaded = await folderService.createFolder(level.folderId as number, level.name);
+      const folderUploaded = await dispatch(
+        storageThunks.createFolderThunk({ parentId: level.folderId as number, folderName: level.name }),
+      ).unwrap();
 
       if (level.childrenFiles) {
         for (const childrenFile of level.childrenFiles) {

--- a/src/store/slices/storage/storage.thunks/uploadItemsThunk.ts
+++ b/src/store/slices/storage/storage.thunks/uploadItemsThunk.ts
@@ -8,7 +8,7 @@ import storageService from '../../../../services/storage.service';
 import { TaskType, TaskStatus } from '../../../../models/enums';
 import { DriveFileData, DriveItemData, NotificationData, UserSettings } from '../../../../models/interfaces';
 import { tasksActions } from '../../tasks';
-import { storageActions } from '..';
+import { storageActions, storageSelectors } from '..';
 import { ItemToUpload } from '../../../../services/storage.service/storage-upload.service';
 import { StorageState } from '../storage.model';
 import { MAX_ALLOWED_UPLOAD_SIZE } from '../../../../lib/constants';
@@ -134,7 +134,8 @@ export const uploadItemsThunk = createAsyncThunk<void, UploadItemsPayload, { sta
 
       await task()
         .then((uploadedFile) => {
-          dispatch(storageActions.pushItems({ items: uploadedFile as DriveItemData }));
+          if (uploadedFile.folderId === storageSelectors.currentFolderId(getState()))
+            dispatch(storageActions.pushItems({ items: uploadedFile as DriveItemData }));
 
           if (options?.withNotifications) {
             dispatch(


### PR DESCRIPTION
- When uploading items, they were always pushed locally to the current folder, even if a tree has been dragged and dropped, all files would be pushed to the current folder instead of their proper levels.
- When creating folders in createFolderTreeStructure, they were directly created using a service and never pushed locally. Now it uses the thunk.
- Said thunk has been generalized to accept parentId as parameter to be able to create folders in other levels different than the current one.