### PR TITLE
hotfix/remove-forgot-password-redirection

### DIFF
--- a/src/app/core/config/app.json
+++ b/src/app/core/config/app.json
@@ -97,8 +97,7 @@
       "id": "remove",
       "layout": "empty",
       "path": "/remove",
-      "exact": true,
-      "auth": true
+      "exact": true    
     },
     {
       "id": "share-token",


### PR DESCRIPTION
Remove forgotten password redirection as this route does not require being authorized.