### PR TITLE
Send conversion to payment for website payment flow

### DIFF
--- a/src/app/analytics/services/analytics.service.ts
+++ b/src/app/analytics/services/analytics.service.ts
@@ -272,37 +272,46 @@ export function trackShareLinkBucketIdUndefined(payload: { email: string }): voi
 }
 
 export async function trackPaymentConversion() {
-  window.analytics.page('Checkout Success');
-  const queryStringParsed = queryString.parse(location.search);
-  const priceId = String(queryStringParsed.price_id);
-  const priceData: PriceData = await httpService.get(`${process.env.REACT_APP_API_URL}/api/price`, {
-    params: {
-      priceId
-    }
-  });
 
-  const { username, uuid } = getUser();
-  window.analytics.identify(
-    uuid,
-    {
-      email: username,
-      plan: priceId,
-      storage_limit: priceData.metadata.maxSpaceBytes,
-      plan_name: priceData.metadata.name
-    }
-  );
-  window.analytics.track(
-    AnalyticsTrack.PaymentConversionEvent,
-    {
-      price_id: priceId,
-      email: username,
-      currency: priceData.currency.toUpperCase(),
-      value: priceData.unit_amount * 0.01,
-      type: priceData.type,
-      plan_name: priceData.metadata.name
-    }
-  );
-}
+  try {
+    window.analytics.page('Checkout Success');
+    const queryStringParsed = queryString.parse(location.search);
+    const priceId = String(queryStringParsed.price_id);
+
+    const priceData: PriceData = await httpService.get(`${process.env.REACT_APP_API_URL}/api/price`, {
+      params: {
+        priceId
+      }
+    });
+
+    const { username, uuid } = getUser();
+    window.analytics.identify(
+      uuid,
+      {
+        email: username,
+        plan: priceId,
+        storage_limit: priceData.metadata.maxSpaceBytes,
+        plan_name: priceData.metadata.name
+      }
+    );
+    window.analytics.track(
+      AnalyticsTrack.PaymentConversionEvent,
+      {
+        price_id: priceId,
+        email: username,
+        currency: priceData.currency.toUpperCase(),
+        value: priceData.unit_amount * 0.01,
+        type: priceData.type,
+        plan_name: priceData.metadata.name
+      }
+    );
+  }
+  catch (err) {
+    window.analytics.track(
+      'Signup After Payment Error'
+    );
+  }
+};
 
 const analyticsService = {
   page,

--- a/src/app/auth/views/SignUpView/SignUpView.tsx
+++ b/src/app/auth/views/SignUpView/SignUpView.tsx
@@ -156,6 +156,10 @@ const SignUpView = (props: SignUpViewProps): JSX.Element => {
           },
         });
 
+        if (activate === 'activate') {
+          analyticsService.trackPaymentConversion();
+        }
+
         return dispatch(userThunks.initializeUserThunk()).then(() => {
           localStorageService.set('xToken', xToken);
           localStorageService.set('xMnemonic', mnemonic);


### PR DESCRIPTION
Allows sending payment track whenever a user paid via the website checkout without having an account.