### PR TITLE
Improve/unauthorized-request

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@iconscout/react-unicons": "^1.1.6",
     "@internxt/inxt-js": "=1.2.19",
     "@internxt/lib": "1.1.2",
-    "@internxt/sdk": "0.3.4",
+    "@internxt/sdk": "0.3.5",
     "@reduxjs/toolkit": "^1.6.0",
     "@stripe/stripe-js": "^1.21.1",
     "axios": "^0.21.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import views from './app/core/config/views';
 import FileViewer from './app/drive/components/FileViewer/FileViewer';
 import NewsletterDialog from './app/newsletter/components/NewsletterDialog/NewsletterDialog';
 import { SdkFactory } from './app/core/factory/sdk';
+import localStorageService from './app/core/services/local-storage.service';
 
 interface AppProps {
   isAuthenticated: boolean;
@@ -45,7 +46,7 @@ class App extends Component<AppProps> {
     });
     const dispatch: AppDispatch = this.props.dispatch;
 
-    SdkFactory.initialize(dispatch);
+    SdkFactory.initialize(dispatch, localStorageService);
 
     window.addEventListener('offline', () => {
       dispatch(sessionActions.setHasConnection(false));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import views from './app/core/config/views';
 import FileViewer from './app/drive/components/FileViewer/FileViewer';
 import NewsletterDialog from './app/newsletter/components/NewsletterDialog/NewsletterDialog';
+import { SdkFactory } from './app/core/factory/sdk';
 
 interface AppProps {
   isAuthenticated: boolean;
@@ -43,6 +44,8 @@ class App extends Component<AppProps> {
       path: navigationService.history.location.pathname,
     });
     const dispatch: AppDispatch = this.props.dispatch;
+
+    SdkFactory.initialize(dispatch);
 
     window.addEventListener('offline', () => {
       dispatch(sessionActions.setHasConnection(false));

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -24,7 +24,7 @@ import { getAesInitFromEnv, validateFormat } from 'app/crypto/services/keys.serv
 import { AppView } from 'app/core/types';
 import { generateNewKeys } from 'app/crypto/services/pgp.service';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
-import { createAuthClient, createUsersClient } from '../../../factory/modules';
+import { createAuthClient, createUsersClient } from '../../core/factory/sdk';
 import { ChangePasswordPayload } from '@internxt/sdk/dist/drive/users/types';
 
 export async function logOut(): Promise<void> {

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -24,7 +24,7 @@ import { getAesInitFromEnv, validateFormat } from 'app/crypto/services/keys.serv
 import { AppView } from 'app/core/types';
 import { generateNewKeys } from 'app/crypto/services/pgp.service';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
-import { createAuthClient, createUsersClient } from '../../core/factory/sdk';
+import { createAuthClient, createUsersClient, SdkFactory } from '../../core/factory/sdk';
 import { ChangePasswordPayload } from '@internxt/sdk/dist/drive/users/types';
 
 export async function logOut(): Promise<void> {
@@ -71,7 +71,7 @@ export const doLogin = async (email: string, password: string, twoFactorCode: st
   user: UserSettings
   token: string;
 }> => {
-  const authClient = createAuthClient();
+  const authClient = SdkFactory.getInstance().createAuthClient();
   const loginDetails: LoginDetails = {
     email: email,
     password: password,

--- a/src/app/auth/services/user.service.ts
+++ b/src/app/auth/services/user.service.ts
@@ -1,5 +1,5 @@
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
-import { createAuthClient, createUsersClient } from '../../../factory/modules';
+import { createAuthClient, createUsersClient } from '../../core/factory/sdk';
 import { InitializeUserResponse } from '@internxt/sdk/dist/drive/users/types';
 
 export async function initializeUser(email: string, mnemonic: string): Promise<InitializeUserResponse> {

--- a/src/app/auth/services/user.service.ts
+++ b/src/app/auth/services/user.service.ts
@@ -1,24 +1,28 @@
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
-import { createAuthClient, createUsersClient } from '../../core/factory/sdk';
+import { SdkFactory } from '../../core/factory/sdk';
 import { InitializeUserResponse } from '@internxt/sdk/dist/drive/users/types';
 
 export async function initializeUser(email: string, mnemonic: string): Promise<InitializeUserResponse> {
-  return createUsersClient().initialize(email, mnemonic);
+  const usersClient = SdkFactory.getInstance().createUsersClient();
+  return usersClient.initialize(email, mnemonic);
 }
 
 export const sendDeactivationEmail = (email: string): Promise<void> => {
-  return createAuthClient().sendDeactivationEmail(email);
+  const authClient = SdkFactory.getInstance().createAuthClient();
+  return authClient.sendDeactivationEmail(email);
 };
 
 const inviteAFriend = (email: string): Promise<void> => {
-  return createUsersClient().sendInvitation(email);
+  const usersClient = SdkFactory.getInstance().createUsersClient();
+  return usersClient.sendInvitation(email);
 };
 
 /**
  * ! This endpoint accepts a body but is using GET method
  */
 const refreshUser = async (): Promise<{ user: UserSettings; token: string }> => {
-  return createUsersClient().refreshUser();
+  const usersClient = SdkFactory.getInstance().createUsersClient();
+  return usersClient.refreshUser();
 };
 
 const userService = {

--- a/src/app/auth/views/SignUpView/SignUpView.tsx
+++ b/src/app/auth/views/SignUpView/SignUpView.tsx
@@ -33,7 +33,7 @@ import httpService from 'app/core/services/http.service';
 import { AppView, IFormValues } from 'app/core/types';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import { referralsThunks } from 'app/store/slices/referrals';
-import { createAuthClient } from '../../../core/factory/sdk';
+import { SdkFactory } from '../../../core/factory/sdk';
 
 export interface SignUpViewProps {
   location: {
@@ -189,7 +189,7 @@ const SignUpView = (props: SignUpViewProps): JSX.Element => {
     } = await generateNewKeys();
     const encPrivateKey = aes.encrypt(privateKeyArmored, password, getAesInitFromEnv());
 
-    const authClient = createAuthClient();
+    const authClient = SdkFactory.getInstance().createAuthClient();
 
     const keys: Keys = {
       privateKeyEncrypted: encPrivateKey,

--- a/src/app/auth/views/SignUpView/SignUpView.tsx
+++ b/src/app/auth/views/SignUpView/SignUpView.tsx
@@ -33,7 +33,7 @@ import httpService from 'app/core/services/http.service';
 import { AppView, IFormValues } from 'app/core/types';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import { referralsThunks } from 'app/store/slices/referrals';
-import { createAuthClient } from '../../../../factory/modules';
+import { createAuthClient } from '../../../core/factory/sdk';
 
 export interface SignUpViewProps {
   location: {

--- a/src/app/backups/services/backups.service.ts
+++ b/src/app/backups/services/backups.service.ts
@@ -1,15 +1,17 @@
 import { aes } from '@internxt/lib';
-import { createBackupsClient } from '../../core/factory/sdk';
 import { Device, DeviceBackup } from '@internxt/sdk/dist/drive/backups/types';
+import { SdkFactory } from '../../core/factory/sdk';
 
 const backupsService = {
   async getAllDevices(): Promise<Device[]> {
-    const devices = await createBackupsClient().getAllDevices();
+    const backupsClient = SdkFactory.getInstance().createBackupsClient();
+    const devices = await backupsClient.getAllDevices();
     return devices.filter((device) => device.id);
   },
 
   async getAllBackups(mac: string): Promise<DeviceBackup[]> {
-    const backups = await createBackupsClient().getAllBackups(mac);
+    const backupsClient = SdkFactory.getInstance().createBackupsClient();
+    const backups = await backupsClient.getAllBackups(mac);
     return backups.map((backup) => {
       const path = aes.decrypt(backup.path, `${process.env.REACT_APP_CRYPTO_SECRET2}-${backup.bucket}`);
       const name = path.split(/[/\\]/).pop() as string;
@@ -22,10 +24,12 @@ const backupsService = {
   },
 
   deleteBackup(backup: DeviceBackup): Promise<void> {
-    return createBackupsClient().deleteBackup(backup.id);
+    const backupsClient = SdkFactory.getInstance().createBackupsClient();
+    return backupsClient.deleteBackup(backup.id);
   },
   deleteDevice(device: Device): Promise<void> {
-    return createBackupsClient().deleteDevice(device.id);
+    const backupsClient = SdkFactory.getInstance().createBackupsClient();
+    return backupsClient.deleteDevice(device.id);
   },
 };
 

--- a/src/app/backups/services/backups.service.ts
+++ b/src/app/backups/services/backups.service.ts
@@ -1,5 +1,5 @@
 import { aes } from '@internxt/lib';
-import { createBackupsClient } from '../../../factory/modules';
+import { createBackupsClient } from '../../core/factory/sdk';
 import { Device, DeviceBackup } from '@internxt/sdk/dist/drive/backups/types';
 
 const backupsService = {

--- a/src/app/core/factory/sdk/index.ts
+++ b/src/app/core/factory/sdk/index.ts
@@ -9,6 +9,92 @@ import localStorageService from '../../services/local-storage.service';
 import { LocalStorageItem, Workspace } from '../../types';
 import authService from '../../../auth/services/auth.service';
 import tasksService from '../../../tasks/services/tasks.service';
+import { AppDispatch } from '../../../store';
+import { userThunks } from '../../../store/slices/user';
+
+export class SdkFactory {
+  private static instance: SdkFactory;
+  private readonly dispatch: AppDispatch;
+  private readonly apiUrl: ApiUrl;
+
+  private constructor(apiUrl: ApiUrl, dispatch: AppDispatch) {
+    this.apiUrl = apiUrl;
+    this.dispatch = dispatch;
+  }
+
+  public static initialize(dispatch: AppDispatch): void {
+    this.instance = new SdkFactory(
+      process.env.REACT_APP_API_URL,
+      dispatch
+    );
+  }
+
+  public static getInstance(): SdkFactory {
+    if (this.instance === undefined) {
+      throw new Error('Factory not initialized');
+    }
+    return this.instance;
+  }
+
+  public createAuthClient(): Auth {
+    const apiUrl = this.getApiUrl();
+    const appDetails = SdkFactory.getAppDetails();
+    const apiSecurity = this.getApiSecurity();
+    return Auth.client(apiUrl, appDetails, apiSecurity);
+  }
+
+  public createStorageClient(): Storage {
+    const apiUrl = this.getApiUrl();
+    const appDetails = SdkFactory.getAppDetails();
+    const apiSecurity = this.getApiSecurity();
+    return Storage.client(apiUrl, appDetails, apiSecurity);
+  }
+
+  /** Helpers **/
+
+  private getApiSecurity(): ApiSecurity {
+    const workspace = SdkFactory.getWorkspace();
+    return {
+      mnemonic: SdkFactory.getMnemonic(workspace),
+      token: SdkFactory.getToken(workspace),
+      unauthorizedCallback: async () => {
+        this.dispatch(userThunks.logoutThunk());
+      }
+    };
+  }
+
+  private getApiUrl(): ApiUrl {
+    return this.apiUrl + '/api';
+  }
+
+  private static getAppDetails(): AppDetails {
+    return {
+      clientName: packageJson.name,
+      clientVersion: packageJson.version,
+    };
+  }
+
+  private static getMnemonic(workspace: string): string {
+    const mnemonicByWorkspace: { [key in Workspace]: string } = {
+      [Workspace.Individuals]: localStorageService.get('xMnemonic') || '',
+      [Workspace.Business]: localStorageService.getTeams()?.bridge_mnemonic || '',
+    };
+    return mnemonicByWorkspace[workspace];
+  }
+
+  private static getToken(workspace: string): Token {
+    const tokenByWorkspace: { [key in Workspace]: string } = {
+      [Workspace.Individuals]: localStorageService.get('xToken') || '',
+      [Workspace.Business]: localStorageService.get('xTokenTeam') || '',
+    };
+    return tokenByWorkspace[workspace];
+  }
+
+  private static getWorkspace(): string {
+    return (localStorageService.get(LocalStorageItem.Workspace) as Workspace) || Workspace.Individuals;
+  }
+
+}
 
 export function createAuthClient(): Auth {
   const apiUrl = getApiUrl();

--- a/src/app/core/factory/sdk/index.ts
+++ b/src/app/core/factory/sdk/index.ts
@@ -7,6 +7,8 @@ import {
 import packageJson from '../../../../../package.json';
 import localStorageService from '../../services/local-storage.service';
 import { LocalStorageItem, Workspace } from '../../types';
+import authService from '../../../auth/services/auth.service';
+import tasksService from '../../../tasks/services/tasks.service';
 
 export function createAuthClient(): Auth {
   const apiUrl = getApiUrl();
@@ -72,7 +74,11 @@ function getApiSecurity(): ApiSecurity {
   const workspace = getWorkspace();
   return {
     mnemonic: getMnemonic(workspace),
-    token: getToken(workspace)
+    token: getToken(workspace),
+    unauthorizedCallback: async () => {
+      authService.logOut();
+      tasksService.clearTasks();
+    }
   };
 }
 

--- a/src/app/core/factory/sdk/index.ts
+++ b/src/app/core/factory/sdk/index.ts
@@ -4,9 +4,9 @@ import {
   ApiSecurity, ApiUrl,
   AppDetails
 } from '@internxt/sdk/dist/shared';
-import packageJson from '../../../package.json';
-import localStorageService from '../../app/core/services/local-storage.service';
-import { LocalStorageItem, Workspace } from '../../app/core/types';
+import packageJson from '../../../../../package.json';
+import localStorageService from '../../services/local-storage.service';
+import { LocalStorageItem, Workspace } from '../../types';
 
 export function createAuthClient(): Auth {
   const apiUrl = getApiUrl();

--- a/src/app/core/factory/sdk/index.ts
+++ b/src/app/core/factory/sdk/index.ts
@@ -5,10 +5,8 @@ import {
   AppDetails
 } from '@internxt/sdk/dist/shared';
 import packageJson from '../../../../../package.json';
-import localStorageService from '../../services/local-storage.service';
-import { LocalStorageItem, Workspace } from '../../types';
-import authService from '../../../auth/services/auth.service';
-import tasksService from '../../../tasks/services/tasks.service';
+import { LocalStorageService } from '../../services/local-storage.service';
+import { Workspace } from '../../types';
 import { AppDispatch } from '../../../store';
 import { userThunks } from '../../../store/slices/user';
 
@@ -16,16 +14,19 @@ export class SdkFactory {
   private static instance: SdkFactory;
   private readonly dispatch: AppDispatch;
   private readonly apiUrl: ApiUrl;
+  private readonly localStorage: LocalStorageService;
 
-  private constructor(apiUrl: ApiUrl, dispatch: AppDispatch) {
+  private constructor(apiUrl: ApiUrl, dispatch: AppDispatch, localStorage: LocalStorageService) {
     this.apiUrl = apiUrl;
     this.dispatch = dispatch;
+    this.localStorage = localStorage;
   }
 
-  public static initialize(dispatch: AppDispatch): void {
+  public static initialize(dispatch: AppDispatch, localStorage: LocalStorageService): void {
     this.instance = new SdkFactory(
       process.env.REACT_APP_API_URL,
-      dispatch
+      dispatch,
+      localStorage
     );
   }
 
@@ -50,13 +51,48 @@ export class SdkFactory {
     return Storage.client(apiUrl, appDetails, apiSecurity);
   }
 
+  public createShareClient(): Share {
+    const apiUrl = this.getApiUrl();
+    const appDetails = SdkFactory.getAppDetails();
+    const apiSecurity = this.getApiSecurity();
+    return Share.client(apiUrl, appDetails, apiSecurity);
+  }
+
+  public createUsersClient(): Users {
+    const apiUrl = this.getApiUrl();
+    const appDetails = SdkFactory.getAppDetails();
+    const apiSecurity = this.getApiSecurity();
+    return Users.client(apiUrl, appDetails, apiSecurity);
+  }
+
+  public createReferralsClient(): Referrals {
+    const apiUrl = this.getApiUrl();
+    const appDetails = SdkFactory.getAppDetails();
+    const apiSecurity = this.getApiSecurity();
+    return Referrals.client(apiUrl, appDetails, apiSecurity);
+  }
+
+  public createPaymentsClient(): Payments {
+    const apiUrl = this.getApiUrl();
+    const appDetails = SdkFactory.getAppDetails();
+    const apiSecurity = this.getApiSecurity();
+    return Payments.client(apiUrl, appDetails, apiSecurity);
+  }
+
+  public createBackupsClient(): Backups {
+    const apiUrl = this.getApiUrl();
+    const appDetails = SdkFactory.getAppDetails();
+    const apiSecurity = this.getApiSecurity();
+    return Backups.client(apiUrl, appDetails, apiSecurity);
+  }
+
   /** Helpers **/
 
   private getApiSecurity(): ApiSecurity {
-    const workspace = SdkFactory.getWorkspace();
+    const workspace = this.localStorage.getWorkspace();
     return {
-      mnemonic: SdkFactory.getMnemonic(workspace),
-      token: SdkFactory.getToken(workspace),
+      mnemonic: this.getMnemonic(workspace),
+      token: this.getToken(workspace),
       unauthorizedCallback: async () => {
         this.dispatch(userThunks.logoutThunk());
       }
@@ -74,116 +110,20 @@ export class SdkFactory {
     };
   }
 
-  private static getMnemonic(workspace: string): string {
+  private getMnemonic(workspace: string): string {
     const mnemonicByWorkspace: { [key in Workspace]: string } = {
-      [Workspace.Individuals]: localStorageService.get('xMnemonic') || '',
-      [Workspace.Business]: localStorageService.getTeams()?.bridge_mnemonic || '',
+      [Workspace.Individuals]: this.localStorage.get('xMnemonic') || '',
+      [Workspace.Business]: this.localStorage.getTeams()?.bridge_mnemonic || '',
     };
     return mnemonicByWorkspace[workspace];
   }
 
-  private static getToken(workspace: string): Token {
+  private getToken(workspace: string): Token {
     const tokenByWorkspace: { [key in Workspace]: string } = {
-      [Workspace.Individuals]: localStorageService.get('xToken') || '',
-      [Workspace.Business]: localStorageService.get('xTokenTeam') || '',
+      [Workspace.Individuals]: this.localStorage.get('xToken') || '',
+      [Workspace.Business]: this.localStorage.get('xTokenTeam') || '',
     };
     return tokenByWorkspace[workspace];
   }
 
-  private static getWorkspace(): string {
-    return (localStorageService.get(LocalStorageItem.Workspace) as Workspace) || Workspace.Individuals;
-  }
-
-}
-
-export function createAuthClient(): Auth {
-  const apiUrl = getApiUrl();
-  const appDetails = getAppDetails();
-  const apiSecurity = getApiSecurity();
-  return Auth.client(apiUrl, appDetails, apiSecurity);
-}
-
-export function createStorageClient(): Storage {
-  const apiUrl = getApiUrl();
-  const appDetails = getAppDetails();
-  const apiSecurity = getApiSecurity();
-  return Storage.client(apiUrl, appDetails, apiSecurity);
-}
-
-export function createShareClient(): Share {
-  const apiUrl = getApiUrl();
-  const appDetails = getAppDetails();
-  const apiSecurity = getApiSecurity();
-  return Share.client(apiUrl, appDetails, apiSecurity);
-}
-
-export function createUsersClient(): Users {
-  const apiUrl = getApiUrl();
-  const appDetails = getAppDetails();
-  const apiSecurity = getApiSecurity();
-  return Users.client(apiUrl, appDetails, apiSecurity);
-}
-
-export function createReferralsClient(): Referrals {
-  const apiUrl = getApiUrl();
-  const appDetails = getAppDetails();
-  const apiSecurity = getApiSecurity();
-  return Referrals.client(apiUrl, appDetails, apiSecurity);
-}
-
-export function createPaymentsClient(): Payments {
-  const apiUrl = getApiUrl();
-  const appDetails = getAppDetails();
-  const apiSecurity = getApiSecurity();
-  return Payments.client(apiUrl, appDetails, apiSecurity);
-}
-
-export function createBackupsClient(): Backups {
-  const apiUrl = getApiUrl();
-  const appDetails = getAppDetails();
-  const apiSecurity = getApiSecurity();
-  return Backups.client(apiUrl, appDetails, apiSecurity);
-}
-
-function getApiUrl(): ApiUrl {
-  return process.env.REACT_APP_API_URL + '/api';
-}
-
-function getAppDetails(): AppDetails {
-  return {
-    clientName: packageJson.name,
-    clientVersion: packageJson.version,
-  };
-}
-
-function getApiSecurity(): ApiSecurity {
-  const workspace = getWorkspace();
-  return {
-    mnemonic: getMnemonic(workspace),
-    token: getToken(workspace),
-    unauthorizedCallback: async () => {
-      authService.logOut();
-      tasksService.clearTasks();
-    }
-  };
-}
-
-function getMnemonic(workspace: string): string {
-  const mnemonicByWorkspace: { [key in Workspace]: string } = {
-    [Workspace.Individuals]: localStorageService.get('xMnemonic') || '',
-    [Workspace.Business]: localStorageService.getTeams()?.bridge_mnemonic || '',
-  };
-  return mnemonicByWorkspace[workspace];
-}
-
-function getToken(workspace: string): Token {
-  const tokenByWorkspace: { [key in Workspace]: string } = {
-    [Workspace.Individuals]: localStorageService.get('xToken') || '',
-    [Workspace.Business]: localStorageService.get('xTokenTeam') || '',
-  };
-  return tokenByWorkspace[workspace];
-}
-
-function getWorkspace(): string {
-  return (localStorageService.get(LocalStorageItem.Workspace) as Workspace) || Workspace.Individuals;
 }

--- a/src/app/core/services/local-storage.service.ts
+++ b/src/app/core/services/local-storage.service.ts
@@ -55,3 +55,14 @@ const localStorageService = {
 };
 
 export default localStorageService;
+
+export interface LocalStorageService {
+  set: (key: string, value: string) => void
+  get: (key: string) => string | null
+  getUser: () => UserSettings | null
+  getTeams: () => TeamsSettings | null
+  getWorkspace: () => string
+  removeItem: (key: string) => void
+  exists: (key: string) => boolean
+  clear: () => void
+}

--- a/src/app/core/views/DeactivationView/DeactivationView.tsx
+++ b/src/app/core/views/DeactivationView/DeactivationView.tsx
@@ -13,7 +13,7 @@ import notificationsService, { ToastType } from '../../../notifications/services
 import { match } from 'react-router-dom';
 import navigationService from '../../services/navigation.service';
 import { AppView } from '../../types';
-import { createAuthClient } from '../../factory/sdk';
+import { SdkFactory } from '../../factory/sdk';
 
 export interface DeactivationViewProps {
   match?: match<{ token: string }>;
@@ -43,7 +43,8 @@ class DeactivationView extends React.Component<DeactivationViewProps> {
   };
 
   ConfirmDeactivateUser = (token: string) => {
-    return createAuthClient().confirmDeactivation(token)
+    const authClient = SdkFactory.getInstance().createAuthClient();
+    return authClient.confirmDeactivation(token)
       .then(() => {
         this.ClearAndRedirect();
       })

--- a/src/app/core/views/DeactivationView/DeactivationView.tsx
+++ b/src/app/core/views/DeactivationView/DeactivationView.tsx
@@ -13,7 +13,7 @@ import notificationsService, { ToastType } from '../../../notifications/services
 import { match } from 'react-router-dom';
 import navigationService from '../../services/navigation.service';
 import { AppView } from '../../types';
-import { createAuthClient } from '../../../../factory/modules';
+import { createAuthClient } from '../../factory/sdk';
 
 export interface DeactivationViewProps {
   match?: match<{ token: string }>;

--- a/src/app/drive/services/file.service/index.ts
+++ b/src/app/drive/services/file.service/index.ts
@@ -7,7 +7,7 @@ import i18n from '../../../i18n/services/i18n.service';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import uploadFile from './uploadFile';
 import * as uuid from 'uuid';
-import { createStorageClient } from '../../../../factory/modules';
+import { createStorageClient } from '../../../core/factory/sdk';
 import { StorageTypes } from '@internxt/sdk/dist/drive';
 
 export function updateMetaData(fileId: string, metadata: DriveFileMetadataPayload, bucketId: string): Promise<void> {

--- a/src/app/drive/services/file.service/index.ts
+++ b/src/app/drive/services/file.service/index.ts
@@ -7,11 +7,11 @@ import i18n from '../../../i18n/services/i18n.service';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import uploadFile from './uploadFile';
 import * as uuid from 'uuid';
-import { createStorageClient } from '../../../core/factory/sdk';
 import { StorageTypes } from '@internxt/sdk/dist/drive';
+import { SdkFactory } from '../../../core/factory/sdk';
 
 export function updateMetaData(fileId: string, metadata: DriveFileMetadataPayload, bucketId: string): Promise<void> {
-  const storageClient = createStorageClient();
+  const storageClient = SdkFactory.getInstance().createStorageClient();
   const payload: StorageTypes.UpdateFilePayload = {
     fileId: fileId,
     metadata: metadata,
@@ -31,7 +31,7 @@ export function updateMetaData(fileId: string, metadata: DriveFileMetadataPayloa
 }
 
 export function deleteFile(fileData: DriveFileData): Promise<void> {
-  const storageClient = createStorageClient();
+  const storageClient = SdkFactory.getInstance().createStorageClient();
   return storageClient.deleteFile({
     fileId: fileData.id,
     folderId: fileData.folderId
@@ -48,7 +48,7 @@ export function deleteFile(fileData: DriveFileData): Promise<void> {
 export async function moveFile(
   fileId: string, destination: number, bucketId: string
 ): Promise<StorageTypes.MoveFileResponse> {
-  const storageClient = createStorageClient();
+  const storageClient = SdkFactory.getInstance().createStorageClient();
   const payload: StorageTypes.MoveFilePayload = {
     fileId: fileId,
     destination: destination,
@@ -75,7 +75,7 @@ export async function moveFile(
 }
 
 async function fetchRecents(limit: number): Promise<DriveFileData[]> {
-  const storageClient = createStorageClient();
+  const storageClient = SdkFactory.getInstance().createStorageClient();
   return storageClient.getRecentFiles(limit);
 }
 

--- a/src/app/drive/services/file.service/uploadFile.ts
+++ b/src/app/drive/services/file.service/uploadFile.ts
@@ -9,7 +9,7 @@ import navigationService from '../../../core/services/navigation.service';
 import { getEnvironmentConfig, Network } from '../network';
 import { encryptFilename } from '../../../crypto/services/utils';
 import errorService from '../../../core/services/error.service';
-import { createStorageClient } from '../../../../factory/modules';
+import { createStorageClient } from '../../../core/factory/sdk';
 
 export interface ItemToUpload {
   name: string;

--- a/src/app/drive/services/file.service/uploadFile.ts
+++ b/src/app/drive/services/file.service/uploadFile.ts
@@ -9,7 +9,7 @@ import navigationService from '../../../core/services/navigation.service';
 import { getEnvironmentConfig, Network } from '../network';
 import { encryptFilename } from '../../../crypto/services/utils';
 import errorService from '../../../core/services/error.service';
-import { createStorageClient } from '../../../core/factory/sdk';
+import { SdkFactory } from '../../../core/factory/sdk';
 
 export interface ItemToUpload {
   name: string;
@@ -60,7 +60,7 @@ export function uploadFile(
       const name = encryptFilename(file.name, file.parentFolderId);
       const folder_id = file.parentFolderId;
 
-      const storageClient = createStorageClient();
+      const storageClient = SdkFactory.getInstance().createStorageClient();
 
       const fileEntry: StorageTypes.FileEntry = {
         id: fileId,

--- a/src/app/drive/services/folder.service.ts
+++ b/src/app/drive/services/folder.service.ts
@@ -7,7 +7,7 @@ import analyticsService from '../../analytics/services/analytics.service';
 import i18n from '../../i18n/services/i18n.service';
 import localStorageService from '../../core/services/local-storage.service';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
-import { createStorageClient } from '../../../factory/modules';
+import { createStorageClient } from '../../core/factory/sdk';
 import { StorageTypes } from '@internxt/sdk/dist/drive';
 import { RequestCanceler } from '@internxt/sdk/dist/shared/http/types';
 

--- a/src/app/drive/services/folder.service.ts
+++ b/src/app/drive/services/folder.service.ts
@@ -7,9 +7,9 @@ import analyticsService from '../../analytics/services/analytics.service';
 import i18n from '../../i18n/services/i18n.service';
 import localStorageService from '../../core/services/local-storage.service';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
-import { createStorageClient } from '../../core/factory/sdk';
 import { StorageTypes } from '@internxt/sdk/dist/drive';
 import { RequestCanceler } from '@internxt/sdk/dist/shared/http/types';
+import { SdkFactory } from '../../core/factory/sdk';
 
 export interface IFolders {
   bucket: string;
@@ -74,7 +74,7 @@ export function createFolder(
     parentFolderId: currentFolderId,
     folderName: folderName
   };
-  const storageClient = createStorageClient();
+  const storageClient = SdkFactory.getInstance().createStorageClient();
   const [createdFolderPromise, requestCanceler] = storageClient.createFolder(payload);
 
   const finalPromise = createdFolderPromise
@@ -94,7 +94,7 @@ export function createFolder(
 }
 
 export async function updateMetaData(folderId: number, metadata: DriveFolderMetadataPayload): Promise<void> {
-  const storageClient = createStorageClient();
+  const storageClient = SdkFactory.getInstance().createStorageClient();
   const payload: StorageTypes.UpdateFolderMetadataPayload = {
     folderId: folderId,
     changes: metadata
@@ -111,7 +111,7 @@ export async function updateMetaData(folderId: number, metadata: DriveFolderMeta
 }
 
 export function deleteFolder(folderData: DriveFolderData): Promise<void> {
-  const storageClient = createStorageClient();
+  const storageClient = SdkFactory.getInstance().createStorageClient();
   return storageClient.deleteFolder(folderData.id)
     .then(() => {
       const user = localStorageService.getUser() as UserSettings;
@@ -162,7 +162,7 @@ async function fetchFolderTree(folderId: number): Promise<{
 export async function moveFolder(
   folderId: number, destination: number
 ): Promise<StorageTypes.MoveFolderResponse> {
-  const storageClient = createStorageClient();
+  const storageClient = SdkFactory.getInstance().createStorageClient();
   const payload: StorageTypes.MoveFolderPayload = {
     folderId: folderId,
     destinationFolderId: destination

--- a/src/app/drive/services/limit.service.ts
+++ b/src/app/drive/services/limit.service.ts
@@ -1,5 +1,5 @@
 import { bytesToString } from './size.service';
-import { createStorageClient } from '../../../factory/modules';
+import { createStorageClient } from '../../core/factory/sdk';
 
 export const INFINITE_LIMIT = 108851651149824;
 

--- a/src/app/drive/services/limit.service.ts
+++ b/src/app/drive/services/limit.service.ts
@@ -1,10 +1,11 @@
 import { bytesToString } from './size.service';
-import { createStorageClient } from '../../core/factory/sdk';
+import { SdkFactory } from '../../core/factory/sdk';
 
 export const INFINITE_LIMIT = 108851651149824;
 
 async function fetchLimit(): Promise<number> {
-  return createStorageClient().spaceLimit()
+  const storageClient = SdkFactory.getInstance().createStorageClient();
+  return storageClient.spaceLimit()
     .then(response => {
       return response.maxSpaceBytes;
     });

--- a/src/app/drive/services/usage.service.ts
+++ b/src/app/drive/services/usage.service.ts
@@ -1,8 +1,9 @@
 import { UsageResponse } from '@internxt/sdk/dist/drive/storage/types';
-import { createStorageClient } from '../../core/factory/sdk';
+import { SdkFactory } from '../../core/factory/sdk';
 
 export async function fetchUsage(): Promise<UsageResponse> {
-  return createStorageClient().spaceUsage();
+  const storageClient = SdkFactory.getInstance().createStorageClient();
+  return storageClient.spaceUsage();
 }
 
 function getUsagePercent(usage: number, limit: number): number {

--- a/src/app/drive/services/usage.service.ts
+++ b/src/app/drive/services/usage.service.ts
@@ -1,5 +1,5 @@
 import { UsageResponse } from '@internxt/sdk/dist/drive/storage/types';
-import { createStorageClient } from '../../../factory/modules';
+import { createStorageClient } from '../../core/factory/sdk';
 
 export async function fetchUsage(): Promise<UsageResponse> {
   return createStorageClient().spaceUsage();

--- a/src/app/payment/services/payment.service.ts
+++ b/src/app/payment/services/payment.service.ts
@@ -4,7 +4,7 @@ import httpService from '../../core/services/http.service';
 import envService from '../../core/services/env.service';
 import { LifetimeTier, StripeSessionMode } from '../types';
 import { loadStripe, RedirectToCheckoutServerOptions, Stripe, StripeError } from '@stripe/stripe-js';
-import { createPaymentsClient } from '../../../factory/modules';
+import { createPaymentsClient } from '../../core/factory/sdk';
 
 export interface CreatePaymentSessionPayload {
   test?: boolean;

--- a/src/app/payment/services/payment.service.ts
+++ b/src/app/payment/services/payment.service.ts
@@ -4,7 +4,7 @@ import httpService from '../../core/services/http.service';
 import envService from '../../core/services/env.service';
 import { LifetimeTier, StripeSessionMode } from '../types';
 import { loadStripe, RedirectToCheckoutServerOptions, Stripe, StripeError } from '@stripe/stripe-js';
-import { createPaymentsClient } from '../../core/factory/sdk';
+import { SdkFactory } from '../../core/factory/sdk';
 
 export interface CreatePaymentSessionPayload {
   test?: boolean;
@@ -39,7 +39,8 @@ async function getStripe() {
 
 const paymentService = {
   async createSession(payload: CreatePaymentSessionPayload): Promise<{ id: string }> {
-    return createPaymentsClient().createSession(payload);
+    const paymentsClient = SdkFactory.getInstance().createPaymentsClient();
+    return paymentsClient.createSession(payload);
   },
 
   async redirectToCheckout(options: RedirectToCheckoutServerOptions): Promise<{ error: StripeError }> {

--- a/src/app/payment/services/products.service.ts
+++ b/src/app/payment/services/products.service.ts
@@ -1,6 +1,7 @@
 import { ProductData } from '../types';
-import { createPaymentsClient } from '../../core/factory/sdk';
+import { SdkFactory } from '../../core/factory/sdk';
 
 export const fetchProducts = async (): Promise<ProductData[]> => {
-  return createPaymentsClient().getProducts();
+  const paymentsClient = SdkFactory.getInstance().createPaymentsClient();
+  return paymentsClient.getProducts();
 };

--- a/src/app/payment/services/products.service.ts
+++ b/src/app/payment/services/products.service.ts
@@ -1,5 +1,5 @@
 import { ProductData } from '../types';
-import { createPaymentsClient } from '../../../factory/modules';
+import { createPaymentsClient } from '../../core/factory/sdk';
 
 export const fetchProducts = async (): Promise<ProductData[]> => {
   return createPaymentsClient().getProducts();

--- a/src/app/referrals/services/users-referrals.service.ts
+++ b/src/app/referrals/services/users-referrals.service.ts
@@ -1,10 +1,11 @@
 import { UserReferral, ReferralKey } from '@internxt/sdk/dist/drive/referrals/types';
-import { createReferralsClient } from '../../core/factory/sdk';
+import { SdkFactory } from '../../core/factory/sdk';
 
 
 const usersReferralsService = {
   fetch(): Promise<UserReferral[]> {
-    return createReferralsClient().getReferrals();
+    const referralsClient = SdkFactory.getInstance().createReferralsClient();
+    return referralsClient.getReferrals();
   },
   hasClickAction(referralKey: ReferralKey): boolean {
     return [ReferralKey.SubscribeToNewsletter, ReferralKey.InstallDesktopApp, ReferralKey.InviteFriends].includes(

--- a/src/app/referrals/services/users-referrals.service.ts
+++ b/src/app/referrals/services/users-referrals.service.ts
@@ -1,5 +1,5 @@
 import { UserReferral, ReferralKey } from '@internxt/sdk/dist/drive/referrals/types';
-import { createReferralsClient } from '../../../factory/modules';
+import { createReferralsClient } from '../../core/factory/sdk';
 
 
 const usersReferralsService = {

--- a/src/app/share/services/share.service.ts
+++ b/src/app/share/services/share.service.ts
@@ -1,9 +1,9 @@
 import errorService from '../../core/services/error.service';
-import { createShareClient } from '../../core/factory/sdk';
 import { ShareTypes } from '@internxt/sdk/dist/drive';
+import { SdkFactory } from '../../core/factory/sdk';
 
 export function generateShareLink(params: ShareTypes.GenerateShareLinkPayload): Promise<string> {
-  const shareClient = createShareClient();
+  const shareClient = SdkFactory.getInstance().createShareClient();
   return shareClient.createShareLink(params)
     .then(response => {
       return `${window.location.origin}/${response.token}`;
@@ -11,7 +11,7 @@ export function generateShareLink(params: ShareTypes.GenerateShareLinkPayload): 
 }
 
 export function getShareInfo(token: string): Promise<ShareTypes.GetShareInfoResponse> {
-  const shareClient = createShareClient();
+  const shareClient = SdkFactory.getInstance().createShareClient();
   return shareClient.getShareByToken(token)
     .catch(error => {
       throw errorService.castError(error);

--- a/src/app/share/services/share.service.ts
+++ b/src/app/share/services/share.service.ts
@@ -1,5 +1,5 @@
 import errorService from '../../core/services/error.service';
-import { createShareClient } from '../../../factory/modules';
+import { createShareClient } from '../../core/factory/sdk';
 import { ShareTypes } from '@internxt/sdk/dist/drive';
 
 export function generateShareLink(params: ShareTypes.GenerateShareLinkPayload): Promise<string> {

--- a/src/app/store/slices/storage/storage.thunks/fetchFolderContentThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/fetchFolderContentThunk.ts
@@ -8,7 +8,7 @@ import i18n from '../../../../i18n/services/i18n.service';
 import notificationsService, { ToastType } from '../../../../notifications/services/notifications.service';
 import databaseService, { DatabaseCollection } from '../../../../database/services/database.service';
 import { DriveItemData } from '../../../../drive/types';
-import { createStorageClient } from '../../../../../factory/modules';
+import { createStorageClient } from '../../../../core/factory/sdk';
 
 export const fetchFolderContentThunk = createAsyncThunk<void, number, { state: RootState }>(
   'storage/fetchFolderContent',

--- a/src/app/store/slices/storage/storage.thunks/fetchFolderContentThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/fetchFolderContentThunk.ts
@@ -8,12 +8,12 @@ import i18n from '../../../../i18n/services/i18n.service';
 import notificationsService, { ToastType } from '../../../../notifications/services/notifications.service';
 import databaseService, { DatabaseCollection } from '../../../../database/services/database.service';
 import { DriveItemData } from '../../../../drive/types';
-import { createStorageClient } from '../../../../core/factory/sdk';
+import { SdkFactory } from '../../../../core/factory/sdk';
 
 export const fetchFolderContentThunk = createAsyncThunk<void, number, { state: RootState }>(
   'storage/fetchFolderContent',
   async (folderId, { dispatch }) => {
-    const storageClient = createStorageClient();
+    const storageClient = SdkFactory.getInstance().createStorageClient();
     const [responsePromise] = storageClient.getFolderContent(folderId);
     const databaseContent = await databaseService.get<DatabaseCollection.Levels>(DatabaseCollection.Levels, folderId);
 

--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
@@ -1,7 +1,5 @@
 import { ActionReducerMapBuilder, createAsyncThunk } from '@reduxjs/toolkit';
 import { items as itemUtils } from '@internxt/lib';
-import { createStorageClient } from '../../../../core/factory/sdk';
-
 import { storageActions, storageSelectors } from '..';
 import { StorageState } from '../storage.model';
 import { sessionSelectors } from '../../session/session.selectors';
@@ -19,6 +17,7 @@ import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import { DriveFileData, DriveItemData } from 'app/drive/types';
 import { ItemToUpload } from 'app/drive/services/file.service/uploadFile';
 import fileService from 'app/drive/services/file.service';
+import { SdkFactory } from '../../../../core/factory/sdk';
 
 interface UploadItemsThunkOptions {
   relatedTaskId: string;
@@ -72,7 +71,7 @@ export const uploadItemsThunk = createAsyncThunk<void, UploadItemsPayload, { sta
       return;
     }
 
-    const storageClient = createStorageClient();
+    const storageClient = SdkFactory.getInstance().createStorageClient();
 
     for (const file of files) {
       const { filename, extension } = itemUtils.getFilenameAndExt(file.name);

--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
@@ -1,6 +1,6 @@
 import { ActionReducerMapBuilder, createAsyncThunk } from '@reduxjs/toolkit';
 import { items as itemUtils } from '@internxt/lib';
-import { createStorageClient } from '../../../../../factory/modules';
+import { createStorageClient } from '../../../../core/factory/sdk';
 
 import { storageActions, storageSelectors } from '..';
 import { StorageState } from '../storage.model';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1350,10 +1350,10 @@
   resolved "https://npm.pkg.github.com/download/@internxt/prettier-config/1.0.2/9a19de23e3330a81c0e2bace1a6a0325fc8633197cf677e44ea75e54df315b5e"
   integrity sha512-t4HiqvCbC7XgQepwWlIaFJe3iwW7HCf6xOSU9nKTV0tiGqOPz7xMtIgLEloQrDA34Cx4PkOYBXrvFPV6RxSFAA==
 
-"@internxt/sdk@0.3.4":
-  version "0.3.4"
-  resolved "https://npm.pkg.github.com/download/@internxt/sdk/0.3.4/74c0876b9bfdc71a921cb3f7e4478c1920c7709219a09215937821e477f03f7f#340fc21145302d254457c24bf991ad570942e4a2"
-  integrity sha512-ZKYwmQs3PWmrTvSgAuEFyEbTeSpQGLMVeeE+7NGD2MSXHrmiCRnb/bFe9SMYQWG7IIlHRPmrowmk4QCYj96W0w==
+"@internxt/sdk@0.3.5":
+  version "0.3.5"
+  resolved "https://npm.pkg.github.com/download/@internxt/sdk/0.3.5/99f40ed01372e8967a0276c3625fc5fd37d5c31c95c3c576ed50d273192c7ec3#16b66255279c4f083bdc5e5e81a2d10abb56e8cb"
+  integrity sha512-eadlO+Efvxl2HhpthTKyP4zB9J4nkihCPhtgUmwZ+oH18tNDtJE16HHzUAPyJLts2FoajFUeDqVfKvSeM/FaKg==
   dependencies:
     axios "^0.24.0"
     query-string "^7.1.0"


### PR DESCRIPTION
Since now the requests to the API are going through the SDK the behaviour that we had on the axios interceptors had to be moved too.

Now the SDK has an option to be injected a callback that will be triggered when a request gets 401 Unathenticated, so the client can do whatever it needs.