### PR TITLE
[_]: fix/blank-screen-on-signup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import FileViewer from './app/drive/components/FileViewer/FileViewer';
 import NewsletterDialog from './app/newsletter/components/NewsletterDialog/NewsletterDialog';
 import { SdkFactory } from './app/core/factory/sdk';
 import localStorageService from './app/core/services/local-storage.service';
+import PreparingWorkspaceAnimation from './app/auth/components/PreparingWorkspaceAnimation/PreparingWorkspaceAnimation';
 
 interface AppProps {
   isAuthenticated: boolean;
@@ -92,7 +93,7 @@ class App extends Component<AppProps> {
     const { isInitialized, isAuthenticated, isFileViewerOpen, isNewsletterDialogOpen, fileViewerItem, dispatch } =
       this.props;
     const pathName = window.location.pathname.split('/')[1];
-    let template: JSX.Element = <div></div>;
+    let template = <PreparingWorkspaceAnimation />;
 
     if (window.location.pathname) {
       if ((pathName === 'new' || pathName === 'appsumo') && window.location.search !== '') {

--- a/src/app/auth/components/PreparingWorkspaceAnimation/PreparingWorkspaceAnimation.tsx
+++ b/src/app/auth/components/PreparingWorkspaceAnimation/PreparingWorkspaceAnimation.tsx
@@ -3,38 +3,48 @@ import folderFront from '../../../../assets/images/signup-animation/folder-front
 import fileZIP from '../../../../assets/images/signup-animation/zip.svg';
 import fileDOC from '../../../../assets/images/signup-animation/doc.svg';
 import filePDF from '../../../../assets/images/signup-animation/pdf.svg';
+import { useEffect, useState } from 'react';
 
-const SignUpAnimation = ({ step }: { step: number }): JSX.Element => {
+const PreparingWorkspaceAnimation = (): JSX.Element => {
+  const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setStep((steps) => (steps >= 18 ? 0 : steps + 1));
+    }, 100);
+    return () => clearInterval(interval);
+  }, [step]);
+
   return (
     <div className="flex flex-col h-screen w-screen justify-center items-center cursor-default">
-      <div className='relative h-32 w-40 mb-4 pointer-events-none'>
+      <div className="relative h-32 w-40 mb-4 pointer-events-none">
         <img className="absolute top-0 left-0 object-contain w-full h-full" src={folderBack} alt="" />
         <img
           className={`absolute object-contain w-16 h-16 transition-all duration-250 ease-in-out
-          ${step >= 3 ?
-            '-top-3 left-1/3 transform -translate-x-10 -rotate-12 scale-90'
-            :
-            'top-12 left-1/3 transform -translate-x-2 -rotate-12 scale-50'
+          ${
+            step >= 3
+              ? '-top-3 left-1/3 transform -translate-x-10 -rotate-12 scale-90'
+              : 'top-12 left-1/3 transform -translate-x-2 -rotate-12 scale-50'
           }`}
           src={filePDF}
           alt=""
         />
         <img
           className={`absolute object-contain w-16 h-16 transition-all duration-250 ease-in-out
-          ${step >= 6 ?
-            '-top-2 left-1/2 transform -translate-x-7 rotate-3 scale-90'
-            :
-            'top-10 left-1/2 transform -translate-x-8 rotate-3 scale-50'
+          ${
+            step >= 6
+              ? '-top-2 left-1/2 transform -translate-x-7 rotate-3 scale-90'
+              : 'top-10 left-1/2 transform -translate-x-8 rotate-3 scale-50'
           }`}
           src={fileDOC}
           alt=""
         />
         <img
           className={`absolute object-contain w-16 h-16 transition-all duration-250 ease-in-out
-          ${step >= 9 ?
-            'top-0 left-1/2 transform translate-x-2 rotate-30 scale-90'
-            :
-            'top-10 left-1/2 transform -translate-x-6 rotate-30 scale-50'
+          ${
+            step >= 9
+              ? 'top-0 left-1/2 transform translate-x-2 rotate-30 scale-90'
+              : 'top-10 left-1/2 transform -translate-x-6 rotate-30 scale-50'
           }`}
           src={fileZIP}
           alt=""
@@ -44,12 +54,10 @@ const SignUpAnimation = ({ step }: { step: number }): JSX.Element => {
 
       <div className="flex flex-col items-center justify-center">
         <p className="text-2xl font-semibold text-cool-gray-90">Preparing your workspace</p>
-        <div className="relative text-base font-medium text-cool-gray-40">
-          This may take a few seconds...
-        </div>
+        <div className="relative text-base font-medium text-cool-gray-40">This may take a few seconds...</div>
       </div>
     </div>
   );
 };
 
-export default SignUpAnimation;
+export default PreparingWorkspaceAnimation;


### PR DESCRIPTION
- What's happening currently is that If at any moment the user is authenticated but is not initialised, an empty div shows (the blank screen)
- In this PR that div is replaced by the animation that @aboredvaro made.
- The animation has some steps that were previously controlled by props, I put it inside instead as it doesn't rely on any particular external logic.
- The animation has been renamed as it is not used in SignUp anymore, but instead when an uninitialised user is authenticated.

We could also plan a refactor for the sign up page as it is critical for bounces and is extremely confusing right now, it is scary to modify it.