### PR TITLE
fix/firefox-private-mode

### DIFF
--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -29,7 +29,7 @@ import { ChangePasswordPayload } from '@internxt/sdk/dist/drive/users/types';
 
 export async function logOut(): Promise<void> {
   analyticsService.trackSignOut();
-  await databaseService.clear();
+  await (await databaseService).clear();
   localStorageService.clear();
   navigationService.push(AppView.Login);
 }

--- a/src/app/database/services/database.service/index.ts
+++ b/src/app/database/services/database.service/index.ts
@@ -19,18 +19,20 @@ export interface AppDatabase extends DBSchema {
 }
 
 export interface DatabaseService {
-  (databaseName: string, databaseVersion: number): {
-    put: <Name extends StoreNames<AppDatabase>>(
-      collectionName: DatabaseCollection,
-      key: StoreKey<AppDatabase, Name>,
-      value: StoreValue<AppDatabase, Name>,
-    ) => Promise<void>;
-    get: <Name extends StoreNames<AppDatabase>>(
-      collectionName: DatabaseCollection,
-      key: StoreKey<AppDatabase, Name>,
-    ) => Promise<StoreValue<AppDatabase, Name> | undefined>;
-    clear: () => Promise<void>;
-  };
+  (databaseName: string, databaseVersion: number): Promise<PersistenceLayer>;
+}
+
+export interface PersistenceLayer {
+  put: <Name extends StoreNames<AppDatabase>>(
+    collectionName: DatabaseCollection,
+    key: StoreKey<AppDatabase, Name>,
+    value: StoreValue<AppDatabase, Name>,
+  ) => Promise<void>;
+  get: <Name extends StoreNames<AppDatabase>>(
+    collectionName: DatabaseCollection,
+    key: StoreKey<AppDatabase, Name>,
+  ) => Promise<StoreValue<AppDatabase, Name> | undefined>;
+  clear: () => Promise<void>;
 }
 
 const providers: { [key in DatabaseProvider]: DatabaseService } = {

--- a/src/app/drive/views/DriveView/DriveView.tsx
+++ b/src/app/drive/views/DriveView/DriveView.tsx
@@ -33,7 +33,8 @@ class DriveView extends Component<DriveViewProps, DriveViewState> {
     this.setState({
       databasePolling: pollingService.create(async () => {
         const { currentFolderId } = this.props;
-        const currentFolderItems = await databaseService.get(DatabaseCollection.Levels, this.props.currentFolderId);
+        const currentFolderItems = await (await databaseService)
+          .get(DatabaseCollection.Levels, this.props.currentFolderId);
 
         if (currentFolderItems) {
           dispatch(storageActions.setItems({ folderId: currentFolderId, items: currentFolderItems }));

--- a/src/app/store/slices/storage/index.ts
+++ b/src/app/store/slices/storage/index.ts
@@ -109,7 +109,9 @@ export const storageSlice = createSlice({
 
         state.levels[folderId] = itemsToDatabase;
 
-        databaseService.put(DatabaseCollection.Levels, folderId, itemsToDatabase);
+        databaseService.then(db => {
+          db.put(DatabaseCollection.Levels, folderId, itemsToDatabase);
+        });
       }
 
       state.recents = state.recents.map((item) => {
@@ -136,7 +138,9 @@ export const storageSlice = createSlice({
 
         state.levels[folderId] = items;
 
-        databaseService.put(DatabaseCollection.Levels, folderId, items);
+        databaseService.then(db => {
+          db.put(DatabaseCollection.Levels, folderId, items);
+        });
       });
 
       if (action.payload.updateRecents) {
@@ -159,7 +163,9 @@ export const storageSlice = createSlice({
 
         state.levels[folderId] = items;
 
-        databaseService.put(DatabaseCollection.Levels, folderId, items);
+          databaseService.then(db => {
+            db.put(DatabaseCollection.Levels, folderId, items);
+          });
       });
 
       if (action.payload.updateRecents) {

--- a/src/app/store/slices/storage/storage.thunks/fetchFolderContentThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/fetchFolderContentThunk.ts
@@ -15,7 +15,8 @@ export const fetchFolderContentThunk = createAsyncThunk<void, number, { state: R
   async (folderId, { dispatch }) => {
     const storageClient = SdkFactory.getInstance().createStorageClient();
     const [responsePromise] = storageClient.getFolderContent(folderId);
-    const databaseContent = await databaseService.get<DatabaseCollection.Levels>(DatabaseCollection.Levels, folderId);
+    const databaseContent = await (await databaseService)
+      .get<DatabaseCollection.Levels>(DatabaseCollection.Levels, folderId);
 
     dispatch(storageActions.resetOrder());
 
@@ -39,7 +40,9 @@ export const fetchFolderContentThunk = createAsyncThunk<void, number, { state: R
           items,
         }),
       );
-      databaseService.put(DatabaseCollection.Levels, folderId, items);
+      databaseService.then(db => {
+        db.put(DatabaseCollection.Levels, folderId, items);
+      });
     });
   },
 );

--- a/src/app/store/slices/storage/storage.thunks/moveItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/moveItemsThunk.ts
@@ -69,12 +69,12 @@ export const moveItemsThunk = createAsyncThunk<void, MoveItemsPayload, { state: 
           );
 
           // Updates destination folder content in local database
-          const destinationLevelDatabaseContent = await databaseService.get(
+          const destinationLevelDatabaseContent = await (await databaseService).get(
             DatabaseCollection.Levels,
             destinationFolderId,
           );
           if (destinationLevelDatabaseContent) {
-            databaseService.put(
+            (await databaseService).put(
               DatabaseCollection.Levels,
               destinationFolderId,
               itemsListService.pushItems(items, destinationLevelDatabaseContent),


### PR DESCRIPTION
We detected that on Firefox Private mode the app was crashing due to Firefox not allowing to use IndexedDB on such mode.

The only solution we came up in short notice was to check if the crash was happening and in that case create a different implementation of the storage interface.

That creates a noticeable change for the service user. Since now the instantiation of the service needs to be async because we have to try if we can instantiate the DB, in lieu of just doing it on the get/put actions as before, we now have to await the service creation. Seems far from ideal to me, but I couldn't find an easier fix to this.