### PR TITLE
[_]: fix/writable-stream-ponyfill

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,7 @@
   <title>Internxt Drive</title>
 
   <script src="https://www.google.com/recaptcha/api.js?render=%REACT_APP_RECAPTCHA_V3%"></script>
+  <script src="https://unpkg.com/web-streams-polyfill/dist/polyfill.min.js"></script>
 
   <!-- Segment -->
   <script type="text/javascript">


### PR DESCRIPTION
Adds a ponyfill for browsers that do not support WritableStream, enabling infinite downloads in browsers like Firefox.