### PR TITLE
[DW-435] feature/unify-download-file

### DIFF
--- a/src/app/drive/services/download.service/downloadFile.ts
+++ b/src/app/drive/services/download.service/downloadFile.ts
@@ -43,7 +43,7 @@ interface BlobWritable {
   close: () => Promise<void>
 }
 
-function getBlobWritable(filename: string, onClose: (result: Blob) => void): BlobWritable {
+export function getBlobWritable(filename: string, onClose: (result: Blob) => void): BlobWritable {
   let blobParts: Uint8Array[] = [];
 
   return {
@@ -74,7 +74,7 @@ function getBlobWritable(filename: string, onClose: (result: Blob) => void): Blo
   };
 }
 
-async function pipe(readable: ReadableStream, writable: BlobWritable): Promise<void> {
+export async function pipe(readable: ReadableStream, writable: BlobWritable): Promise<void> {
   const reader = readable.getReader();
   const writer = writable.getWriter();
 

--- a/src/app/drive/services/network.service/download.ts
+++ b/src/app/drive/services/network.service/download.ts
@@ -122,7 +122,7 @@ interface NetworkCredentials {
   pass: string;
 }
 
-interface IDownloadParams {
+export interface IDownloadParams {
   bucketId: string;
   fileId: string;
   creds?: NetworkCredentials;


### PR DESCRIPTION
Use same strategy to download a shared file as the one used when downloading files from a shared folder.