### PR TITLE
[_]: feature/efficient-download-folder

### DIFF
--- a/src/app/core/config/app.json
+++ b/src/app/core/config/app.json
@@ -9,7 +9,7 @@
   "fileExplorer": {
     "download": {
       "folder": {
-        "method": "stream-saver"
+        "method": "file-system-access-api"
       }
     },
     "recentsLimit": 10

--- a/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
+++ b/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
@@ -18,10 +18,11 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
   const onDownload = () => file && dispatch(storageThunks.downloadItemsThunk([file as DriveItemData]));
 
   const downloader = file
-    ? () =>
+    ? (abortController: AbortController) => 
         downloadService.fetchFileBlob({ ...file, bucketId: file.bucket }, {
           updateProgressCallback: () => undefined,
           isTeam,
+          abortController
         })
     : null;
 

--- a/src/app/drive/services/download.service/downloadBackup.ts
+++ b/src/app/drive/services/download.service/downloadBackup.ts
@@ -1,6 +1,5 @@
 import { getEnvironmentConfig } from '../network.service';
 import { DeviceBackup } from '../../../backups/types';
-import { Abortable } from 'app/network/Abortable';
 import { downloadFile } from 'app/network/download';
 
 export default async function downloadBackup(
@@ -9,12 +8,14 @@ export default async function downloadBackup(
     progressCallback,
     finishedCallback,
     errorCallback,
+    abortController
   }: {
     progressCallback: (progress: number) => void;
     finishedCallback: () => void;
     errorCallback: (err: Error) => void;
+    abortController?: AbortController
   },
-): Promise<Abortable | undefined> {
+): Promise<void> {
   if (!('showSaveFilePicker' in window)) {
     const err = new Error('File System Access API not available');
     err.name = 'FILE_SYSTEM_API_NOT_AVAILABLE';
@@ -33,7 +34,7 @@ export default async function downloadBackup(
   const writable = await handle.createWritable();
   const { bridgeUser, bridgePass, encryptionKey } = getEnvironmentConfig();
 
-  const [downloadStreamPromise, abortable] = downloadFile({
+  const downloadStream = await downloadFile({
     bucketId: backup.bucket,
     fileId: backup.fileId,
     creds: {
@@ -44,17 +45,14 @@ export default async function downloadBackup(
     options: {
       notifyProgress: (totalBytes, downloadedBytes) => {
         progressCallback(downloadedBytes / totalBytes);
-      }
+      },
+      abortController
     }
   });
-
-  const downloadStream = await downloadStreamPromise;
 
   downloadStream.pipeTo(writable).then(() => {
     finishedCallback();
   }).catch((err) => {
     errorCallback(err);
   });
-
-  return abortable;
 }

--- a/src/app/drive/services/download.service/downloadFolder/downloadFolderUsingBlobs.ts
+++ b/src/app/drive/services/download.service/downloadFolder/downloadFolderUsingBlobs.ts
@@ -47,7 +47,7 @@ export default async function downloadFolderUsingBlobs({
         name: fileDecryptedNames[file.id],
         type: file.type,
       });
-      const [fileBlobPromise] = fetchFileBlob({ ...file, bucketId: file.bucket }, {
+      const fileBlobPromise = fetchFileBlob({ ...file, bucketId: file.bucket }, {
         isTeam,
         updateProgressCallback: (fileProgress) => {
           const totalProgress = (downloadedSize + file.size * fileProgress) / size;

--- a/src/app/drive/services/download.service/downloadFolder/downloadFolderUsingFileSystemAccessAPI.ts
+++ b/src/app/drive/services/download.service/downloadFolder/downloadFolderUsingFileSystemAccessAPI.ts
@@ -5,7 +5,6 @@ import { DriveFolderData, FolderTree } from '../../../types';
 import folderService from '../../folder.service';
 import { FlatFolderZip } from 'app/core/services/stream.service';
 import network from 'app/network';
-import { Abortable } from 'app/network/Abortable';
 
 /**
  * @description Downloads a folder using File System Access API
@@ -41,7 +40,6 @@ async function downloadFolder(
     updateProgress?: (progress: number) => void
   }
 ) {
-  const abortables: Abortable[] = [];
   const { abortController, updateProgress } = opts;
   const { bridgeUser, bridgePass, encryptionKey } = environment;
   const { tree, folderDecryptedNames, fileDecryptedNames, size } = await folderService.fetchFolderTree(folder.id);

--- a/src/app/drive/services/download.service/downloadFolder/downloadFolderUsingFileSystemAccessAPI.ts
+++ b/src/app/drive/services/download.service/downloadFolder/downloadFolderUsingFileSystemAccessAPI.ts
@@ -70,18 +70,21 @@ async function downloadFolder(
         type: file.type,
       });
 
-      const [fileStreamPromise, abortable] = network.downloadFile({
+      const fileStreamPromise = network.downloadFile({
         bucketId: file.bucket,
         fileId: file.fileId,
         creds: {
           pass: bridgePass,
           user: bridgeUser
         },
-        mnemonic: encryptionKey
+        mnemonic: encryptionKey,
+        options: {
+          notifyProgress: () => null,
+          abortController: opts.abortController
+        }
       });
 
       zip.addFile(folderPath + '/' + displayFilename, await fileStreamPromise);
-      abortables && abortables.push(abortable);
     }
 
     pendingFolders.push(...folders.map(tree => ({ path: folderPath, data: tree })));

--- a/src/app/drive/services/download.service/downloadFolder/downloadFolderUsingFileSystemAccessAPI.ts
+++ b/src/app/drive/services/download.service/downloadFolder/downloadFolderUsingFileSystemAccessAPI.ts
@@ -1,128 +1,95 @@
-import JSZip from 'jszip';
 import { items } from '@internxt/lib';
-import { ActionState } from '@internxt/inxt-js/build/api/ActionState';
 
-import errorService from 'app/core/services/error.service';
-import { getEnvironmentConfig, Network } from '../../network.service';
-import { DriveFileData, DriveFolderData, FolderTree } from '../../../types';
+import { getEnvironmentConfig } from '../../network.service';
+import { DriveFolderData, FolderTree } from '../../../types';
 import folderService from '../../folder.service';
-import internal from 'stream';
+import { FlatFolderZip } from 'app/core/services/stream.service';
+import network from 'app/network';
+import { Abortable } from 'app/network/Abortable';
 
 /**
  * @description Downloads a folder using File System Access API
- *
- * ! Not available already in all browsers: https://caniuse.com/native-filesystem-api
- * ! Using 'jszip' 3.2.0 due to a bug with nodeStream in later versions
- *
+ * TODO: Load levels paginated instead of loading the entire tree at once.
  * @param folderData
  * @param isTeam
  */
-export default async function downloadFolderUsingFileSystemAccessAPI({
+export default function downloadFolderUsingFileSystemAccessAPI({
   folder,
-  decryptedCallback,
   updateProgressCallback,
-  errorCallback,
   isTeam,
+  abortController
 }: {
   folder: DriveFolderData;
-  decryptedCallback?: () => void;
   updateProgressCallback?: (progress: number) => void;
-  errorCallback?: (err: Error) => void;
   isTeam: boolean;
-}): Promise<[Promise<void>, ActionState[]]> {
-  const downloadingSize: Record<number, number> = {};
-  const fileStreams: { file: DriveFileData; stream: internal.Readable }[] = [];
-  const actionStates: ActionState[] = [];
-  const handle = await window.showSaveFilePicker({
-    suggestedName: `${folder.name}.zip`,
-    types: [{ accept: { 'application/zip': ['.zip'] } }],
+  abortController?: AbortController
+}): Promise<void> {
+  const { bridgeUser, bridgePass, encryptionKey } = getEnvironmentConfig(isTeam);
+
+  return downloadFolder(
+    folder,
+    { bridgeUser, bridgePass, encryptionKey },
+    { abortController, updateProgress: updateProgressCallback }
+  );
+}
+
+async function downloadFolder(
+  folder: DriveFolderData,
+  environment: { bridgeUser: string, bridgePass: string, encryptionKey: string },
+  opts: {
+    abortController?: AbortController,
+    updateProgress?: (progress: number) => void
+  }
+) {
+  const abortables: Abortable[] = [];
+  const { abortController, updateProgress } = opts;
+  const { bridgeUser, bridgePass, encryptionKey } = environment;
+  const { tree, folderDecryptedNames, fileDecryptedNames, size } = await folderService.fetchFolderTree(folder.id);
+  const pendingFolders: { path: string, data: FolderTree }[] = [{ path: '', data: tree }];
+
+  const zip = new FlatFolderZip(folder.name, {
+    abortController: opts.abortController,
+    progress: (loadedBytes) => updateProgress?.(loadedBytes / size)
   });
 
-  if (!handle) {
-    throw new Error();
-  }
+  while (pendingFolders.length > 0 && !abortController?.signal.aborted) {
+    const currentFolder = pendingFolders.shift() as { path: string, data: FolderTree };
+    const folderPath = currentFolder.path + (currentFolder.path === '' ? '' : '/') + folderDecryptedNames[currentFolder.data.id];
 
-  const writable = await handle.createWritable();
-  const { bridgeUser, bridgePass, encryptionKey } = getEnvironmentConfig(isTeam);
-  const network = new Network(bridgeUser, bridgePass, encryptionKey);
-  const { tree, folderDecryptedNames, fileDecryptedNames, size } = await folderService.fetchFolderTree(folder.id);
-  const zip = new JSZip();
-  decryptedCallback?.();
+    zip.addFolder(folderPath);
 
-  try {
-    // * Renames files iterating over folders
-    const pendingFolders: { parentFolder: JSZip | null; data: FolderTree }[] = [{ parentFolder: null, data: tree }];
-    while (pendingFolders.length > 0) {
-      const currentFolder = pendingFolders[0];
-      const currentFolderZip = currentFolder.parentFolder?.folder(folderDecryptedNames[currentFolder.data.id]) || zip;
-      const { files, folders } = {
-        files: currentFolder.data.files,
-        folders: currentFolder.data.children,
-      };
+    const { files, children: folders } = currentFolder.data;
 
-      pendingFolders.shift();
-
-      // * Downloads current folder files
-      for (const file of files) {
-        const displayFilename = items.getItemDisplayName({
-          name: fileDecryptedNames[file.id],
-          type: file.type,
-        });
-        const [fileStreamPromise, actionState] = network.getFileDownloadStream(file.bucket, file.fileId, {
-          progressCallback: (fileProgress) => {
-            downloadingSize[file.id] = file.size * fileProgress;
-            const totalDownloadedSize = Object.values(downloadingSize).reduce((t, x) => t + x, 0);
-            const totalProgress = totalDownloadedSize / size;
-
-            (updateProgressCallback || (() => undefined))(totalProgress);
-          },
-        });
-        const fileStream = await fileStreamPromise;
-
-        currentFolderZip?.file(displayFilename, fileStream, { compression: 'DEFLATE' });
-
-        fileStreams.push({ file, stream: fileStream });
-        actionState && actionStates.push(actionState);
+    for (const file of files) {
+      if (abortController?.signal.aborted) {
+        throw new Error('Download cancelled');
       }
 
-      // * Adds current folder folders to pending
-      pendingFolders.push(
-        ...folders.map((data) => ({
-          parentFolder: currentFolderZip,
-          data,
-        })),
-      );
+      const displayFilename = items.getItemDisplayName({
+        name: fileDecryptedNames[file.id],
+        type: file.type,
+      });
+
+      const [fileStreamPromise, abortable] = network.downloadFile({
+        bucketId: file.bucket,
+        fileId: file.fileId,
+        creds: {
+          pass: bridgePass,
+          user: bridgeUser
+        },
+        mnemonic: encryptionKey
+      });
+
+      zip.addFile(folderPath + '/' + displayFilename, await fileStreamPromise);
+      abortables && abortables.push(abortable);
     }
 
-    return [
-      new Promise<void>((resolve, reject) => {
-        const folderStream = zip.generateInternalStream({
-          type: 'uint8array',
-          streamFiles: true,
-          compression: 'DEFLATE',
-        }) as internal.Readable;
-        folderStream
-          ?.on('data', (chunk: Buffer) => {
-            writable.write(chunk);
-          })
-          .on('end', () => {
-            writable.close();
-            resolve();
-          })
-          .on('error', (err) => {
-            errorCallback?.(err);
-            reject(err);
-          });
-
-        folderStream.resume();
-      }),
-      actionStates,
-    ];
-  } catch (err) {
-    const castedError = errorService.castError(err);
-
-    writable.abort();
-
-    throw castedError;
+    pendingFolders.push(...folders.map(tree => ({ path: folderPath, data: tree })));
   }
+
+  if (abortController?.signal.aborted) {
+    throw new Error('Download cancelled');
+  }
+
+  return zip.close();
 }

--- a/src/app/drive/services/download.service/downloader.ts
+++ b/src/app/drive/services/download.service/downloader.ts
@@ -80,14 +80,12 @@ async function downloadFiles(
         type: file.type,
       });
 
-      const [readablePromise] = downloadFile({
+      const readable = await downloadFile({
         bucketId: bucket,
         fileId: file.id,
         encryptionKey: Buffer.from(file.encryptionKey, 'hex'),
         token
       });
-
-      const readable = await readablePromise;
 
       await new Promise((resolve, reject) => {
         opts.onFileRetrieved({

--- a/src/app/drive/services/download.service/fetchFileStream.ts
+++ b/src/app/drive/services/download.service/fetchFileStream.ts
@@ -1,43 +1,31 @@
-import { ActionState } from '@internxt/inxt-js/build/api';
 import { getEnvironmentConfig } from '../network.service';
 import { downloadFile, Downloadable } from 'app/network/download';
-import { Abortable } from 'app/network/Abortable';
 
-type FetchFileStreamOptions = { updateProgressCallback: (progress: number) => void; isTeam?: boolean };
+type FetchFileStreamOptions = {
+  updateProgressCallback: (progress: number) => void;
+  isTeam?: boolean,
+  abortController?: AbortController
+};
 
 export default function fetchFileStream(
   item: Downloadable,
   options: FetchFileStreamOptions,
-): [Promise<ReadableStream<Uint8Array>>, ActionState | undefined] {
-  let abortable: Abortable;
+): Promise<ReadableStream<Uint8Array>> {
+  const { bridgeUser, bridgePass, encryptionKey } = getEnvironmentConfig(!!options.isTeam);
 
-  const downloadPromise = (async () => {
-    const { bridgeUser, bridgePass, encryptionKey } = getEnvironmentConfig(!!options.isTeam);
-
-    const [fileStreamPromise, fileStreamAbortable] = downloadFile({
-      bucketId: item.bucketId,
-      fileId: item.fileId,
-      creds: {
-        pass: bridgePass,
-        user: bridgeUser
+  return downloadFile({
+    bucketId: item.bucketId,
+    fileId: item.fileId,
+    creds: {
+      pass: bridgePass,
+      user: bridgeUser
+    },
+    mnemonic: encryptionKey,
+    options: {
+      notifyProgress: (totalBytes: number, downloadedBytes: number) => {
+        options.updateProgressCallback(downloadedBytes / totalBytes);
       },
-      mnemonic: encryptionKey,
-      options: {
-        notifyProgress: (totalBytes: number, downloadedBytes: number) => {
-          options.updateProgressCallback(downloadedBytes / totalBytes);
-        }
-      }
-    });
-
-    abortable = fileStreamAbortable;
-
-    return fileStreamPromise;
-  })();
-
-  // TODO: When inxt-js is removed, use always Abortable interface
-  return [downloadPromise, {
-    stop: () => {
-      abortable?.abort();
+      abortController: options.abortController
     }
-  } as ActionState];
+  });
 }

--- a/src/app/network/NetworkFacade.ts
+++ b/src/app/network/NetworkFacade.ts
@@ -17,6 +17,7 @@ interface UploadOptions {
 interface DownloadOptions {
   key?: Buffer;
   token?: string;
+  abortController?: AbortController;
   downloadingCallback?: DownloadProgressCallback;
 }
 

--- a/src/app/share/views/ShareView/SharePhotosView.tsx
+++ b/src/app/share/views/ShareView/SharePhotosView.tsx
@@ -77,7 +77,7 @@ const SharePhotosView = (props: SharePhotosProps): JSX.Element => {
     try {
       if (info?.photos.length === 1) {
         const [photo] = info.photos;
-        const [readablePromise] = network.downloadFile({
+        const readablePromise = network.downloadFile({
           bucketId: info.bucket,
           fileId: photo.fileId,
           encryptionKey: Buffer.from(photo.decryptionKey, 'hex'),
@@ -125,7 +125,7 @@ const SharePhotosView = (props: SharePhotosProps): JSX.Element => {
 
         for (const photo of info.photos) {
           const photoName = `${photo.name}.${photo.type}`;
-          const [photoStreamPromise] = network.downloadFile({
+          const photoStreamPromise = network.downloadFile({
             bucketId: info.bucket,
             fileId: photo.fileId,
             encryptionKey: Buffer.from(photo.decryptionKey, 'hex'),

--- a/src/app/store/slices/backups/index.ts
+++ b/src/app/store/slices/backups/index.ts
@@ -68,7 +68,12 @@ export const downloadBackupThunk = createAsyncThunk<void, DeviceBackup, { state:
       showNotification: true,
       cancellable: true,
     });
+
+    const abortController = new AbortController();
+
     const onProgress = (progress: number) => {
+      if (abortController.signal.aborted) return;
+
       tasksService.updateTask({
         taskId,
         merge: {
@@ -79,6 +84,8 @@ export const downloadBackupThunk = createAsyncThunk<void, DeviceBackup, { state:
     };
 
     const onFinished = () => {
+      if (abortController.signal.aborted) return;
+
       tasksService.updateTask({
         taskId,
         merge: {
@@ -88,6 +95,8 @@ export const downloadBackupThunk = createAsyncThunk<void, DeviceBackup, { state:
     };
 
     const onError = () => {
+      if (abortController.signal.aborted) return;
+
       tasksService.updateTask({
         taskId,
         merge: {
@@ -97,19 +106,28 @@ export const downloadBackupThunk = createAsyncThunk<void, DeviceBackup, { state:
     };
 
     try {
-      const actionState = await downloadService.downloadBackup(backup, {
-        progressCallback: onProgress,
-        finishedCallback: onFinished,
-        errorCallback: onError,
-      });
-
       tasksService.updateTask({
         taskId,
         merge: {
-          stop: async () => actionState?.abort(),
+          stop: async () => abortController.abort()
         },
       });
+
+      await downloadService.downloadBackup(backup, {
+        progressCallback: onProgress,
+        finishedCallback: onFinished,
+        errorCallback: onError,
+        abortController
+      });
     } catch (err) {
+      if (abortController.signal.aborted) {
+        return tasksService.updateTask({
+          taskId,
+          merge: {
+            status: TaskStatus.Cancelled
+          },
+        });
+      }
       if (err instanceof Error && err.name === 'FILE_SYSTEM_API_NOT_AVAILABLE')
         notificationsService.show({
           text: 'To download backups you need to use a Chromium based browser\

--- a/src/app/store/slices/storage/storage.thunks/downloadFolderThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadFolderThunk.ts
@@ -99,6 +99,8 @@ export const downloadFolderThunk = createAsyncThunk<void, DownloadFolderThunkPay
         });
       }
 
+      (abortController as { abort: (message: string) => void }).abort((err as Error).message);
+
       const castedError = errorService.castError(err);
       const task = tasksService.findTask(options.taskId);
 

--- a/src/app/store/slices/storage/storage.thunks/downloadFolderThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadFolderThunk.ts
@@ -11,6 +11,7 @@ import { TaskStatus } from 'app/tasks/types';
 import tasksService from 'app/tasks/services/tasks.service';
 import AppError from 'app/core/types';
 import { DriveFolderData } from 'app/drive/types';
+import downloadFolderUsingBlobs from 'app/drive/services/download.service/downloadFolder/downloadFolderUsingBlobs';
 
 interface DownloadFolderThunkOptions {
   taskId: string;
@@ -76,7 +77,11 @@ export const downloadFolderThunk = createAsyncThunk<void, DownloadFolderThunkPay
         },
       });
 
-      await downloadService.downloadFolder({ folder, updateProgressCallback, isTeam, abortController });
+      if (navigator.brave?.isBrave()) {
+        await downloadFolderUsingBlobs({ folder, updateProgressCallback, isTeam });
+      } else {
+        await downloadService.downloadFolder({ folder, updateProgressCallback, isTeam, abortController });
+      }
 
       tasksService.updateTask({
         taskId: options.taskId,

--- a/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
@@ -16,8 +16,6 @@ export const downloadItemsThunk = createAsyncThunk<void, DriveItemData[], { stat
     const taskGroupId = requestId;
     const tasksIds: string[] = [];
 
-    console.log('downloadITEEEEMs');
-
     // * 1. Creates tasks
     for (const item of items) {
       if (item.isFolder) {

--- a/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
@@ -16,6 +16,8 @@ export const downloadItemsThunk = createAsyncThunk<void, DriveItemData[], { stat
     const taskGroupId = requestId;
     const tasksIds: string[] = [];
 
+    console.log('downloadITEEEEMs');
+
     // * 1. Creates tasks
     for (const item of items) {
       if (item.isFolder) {

--- a/src/app/store/slices/storage/storage.thunks/uploadFolderThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadFolderThunk.ts
@@ -77,26 +77,22 @@ export const uploadFolderThunk = createAsyncThunk<void, UploadFolderThunkPayload
         rootFolderItem = createdFolder;
 
         if (level.childrenFiles) {
-          const slicesOf = 3;
+          for (const childrenFile of level.childrenFiles) {
+            await dispatch(
+              uploadItemsThunk({
+                files: [childrenFile],
+                parentFolderId: createdFolder.id,
+                options: { relatedTaskId: taskId, showNotifications: false, showErrors: false },
+              }),
+            ).unwrap();
 
-          for (let i = 0; i < level.childrenFiles.length; i += slicesOf) {
-            await Promise.all(level.childrenFiles.slice(i, i + slicesOf).map((file) => {
-              return dispatch(
-                uploadItemsThunk({
-                  files: [file],
-                  parentFolderId: createdFolder.id,
-                  options: { relatedTaskId: taskId, showNotifications: false, showErrors: false }
-                }),
-              ).unwrap().then(() => {
-                tasksService.updateTask({
-                  taskId: taskId,
-                  merge: {
-                    status: TaskStatus.InProcess,
-                    progress: ++alreadyUploaded / itemsUnderRoot,
-                  },
-                });
-              });
-            }));
+            tasksService.updateTask({
+              taskId: taskId,
+              merge: {
+                status: TaskStatus.InProcess,
+                progress: ++alreadyUploaded / itemsUnderRoot,
+              },
+            });
           }
         }
 

--- a/src/app/store/slices/storage/storage.thunks/uploadFolderThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadFolderThunk.ts
@@ -77,22 +77,26 @@ export const uploadFolderThunk = createAsyncThunk<void, UploadFolderThunkPayload
         rootFolderItem = createdFolder;
 
         if (level.childrenFiles) {
-          for (const childrenFile of level.childrenFiles) {
-            await dispatch(
-              uploadItemsThunk({
-                files: [childrenFile],
-                parentFolderId: createdFolder.id,
-                options: { relatedTaskId: taskId, showNotifications: false, showErrors: false },
-              }),
-            ).unwrap();
+          const slicesOf = 3;
 
-            tasksService.updateTask({
-              taskId: taskId,
-              merge: {
-                status: TaskStatus.InProcess,
-                progress: ++alreadyUploaded / itemsUnderRoot,
-              },
-            });
+          for (let i = 0; i < level.childrenFiles.length; i += slicesOf) {
+            await Promise.all(level.childrenFiles.slice(i, i + slicesOf).map((file) => {
+              return dispatch(
+                uploadItemsThunk({
+                  files: [file],
+                  parentFolderId: createdFolder.id,
+                  options: { relatedTaskId: taskId, showNotifications: false, showErrors: false }
+                }),
+              ).unwrap().then(() => {
+                tasksService.updateTask({
+                  taskId: taskId,
+                  merge: {
+                    status: TaskStatus.InProcess,
+                    progress: ++alreadyUploaded / itemsUnderRoot,
+                  },
+                });
+              });
+            }));
           }
         }
 
@@ -102,6 +106,8 @@ export const uploadFolderThunk = createAsyncThunk<void, UploadFolderThunkPayload
 
         levels.push(...level.childrenFolders);
       }
+
+      console.timeEnd('folder');
 
       tasksService.updateTask({
         taskId: taskId,

--- a/src/app/store/slices/storage/storage.thunks/uploadFolderThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadFolderThunk.ts
@@ -107,8 +107,6 @@ export const uploadFolderThunk = createAsyncThunk<void, UploadFolderThunkPayload
         levels.push(...level.childrenFolders);
       }
 
-      console.timeEnd('folder');
-
       tasksService.updateTask({
         taskId: taskId,
         merge: {


### PR DESCRIPTION
Changes introduced: 
- Download folders without Blobs usage on Firefox as a native download.
- Download larger folders on Drive without overloading RAM. 
- Abort downloads instantly thanks to the introduction of the AbortController on each performable download. (Drive, Backups, Photos)
- Fixes a bug on Photos that shows the last previous cached photo when a preview of a photo is clicked instead of showing the desired photo. 