### PR TITLE
[_]: fix/calculate-file-download-progress

### DIFF
--- a/src/app/share/views/ShareView/ShareFileView.tsx
+++ b/src/app/share/views/ShareView/ShareFileView.tsx
@@ -203,8 +203,8 @@ export default function ShareFileView(props: ShareViewProps): JSX.Element {
             encryptionKey: Buffer.from(encryptionKey, 'hex'),
             token: fileInfo.fileToken,
             options: {
-              notifyProgress: (progress) => {
-                setProgress(progress);
+              notifyProgress: (totalProgress, downloadedBytes) => {
+                setProgress(Math.trunc((downloadedBytes / totalProgress) * 100));
               }
             }
           }


### PR DESCRIPTION
- Fixes shared file download progress not being shown properly due to a previous change on the progress notification callbacks during the v2 network API integration