### PR TITLE
[_]: hotfix/email-input-regex

### DIFF
--- a/src/app/auth/components/SignUp/SignUp.tsx
+++ b/src/app/auth/components/SignUp/SignUp.tsx
@@ -168,8 +168,8 @@ function SignUp(props: SignUpProps): JSX.Element {
       window._adftrack = Array.isArray(window._adftrack)
         ? window._adftrack
         : window._adftrack
-        ? [window._adftrack]
-        : [];
+          ? [window._adftrack]
+          : [];
       window._adftrack.push({
         HttpHost: 'track.adform.net',
         pm: 2370627,
@@ -218,7 +218,7 @@ function SignUp(props: SignUpProps): JSX.Element {
               register={register}
               required={true}
               minLength={{ value: 1, message: 'Email must not be empty' }}
-              pattern={{ value: emailRegexPattern, message: 'Email not valid' }}
+              /* pattern={{ value: emailRegexPattern, message: 'Email not valid' }} */
               autoFocus={true}
               error={errors.email}
             />

--- a/src/app/auth/components/SignUp/SignUpWebsite.tsx
+++ b/src/app/auth/components/SignUp/SignUpWebsite.tsx
@@ -144,8 +144,8 @@ function SignUpWebsite(props: SignUpProps): JSX.Element {
       window._adftrack = Array.isArray(window._adftrack)
         ? window._adftrack
         : window._adftrack
-        ? [window._adftrack]
-        : [];
+          ? [window._adftrack]
+          : [];
       window._adftrack.push({
         HttpHost: 'track.adform.net',
         pm: 2370627,
@@ -192,7 +192,7 @@ function SignUpWebsite(props: SignUpProps): JSX.Element {
             register={register}
             required={true}
             minLength={{ value: 1, message: 'Email must not be empty' }}
-            pattern={{ value: emailRegexPattern, message: 'Email not valid' }}
+            /* pattern={{ value: emailRegexPattern, message: 'Email not valid' }} */
             autoFocus={true}
             error={errors.email}
           />


### PR DESCRIPTION
Avoid reporting email errors when start typing an email address upon registration. Only reports whenever the user has stopped entering the email.