### PR TITLE
[_]: create-CODEOWNERS

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,3 @@
+/src/app/network/ @sg-gs
+/src/app/crypto/ @sg-gs
+/src/app/core/services/stream.service.ts @sg-gs


### PR DESCRIPTION
Creates a CODEOWNERS file that blocks the changes via PR to the crypto/network related to files to just the maintainers of those files.