### PR TITLE
Increment fake pagination limit

### DIFF
--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -53,7 +53,7 @@ import { useAppDispatch } from 'app/store/hooks';
 import useDriveItemStoreProps from './DriveExplorerItem/hooks/useDriveStoreProps';
 import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
 
-const PAGINATION_LIMIT = 20;
+const PAGINATION_LIMIT = 60;
 
 interface DriveExplorerProps {
   title: JSX.Element | string;


### PR DESCRIPTION
The fake pagination was in 20, too low and it may cause some problems with the infinite scroll, incremented to 60 elements to avoid this problem.