### PR TITLE
[_]: Load stripe script only when needed

### DIFF
--- a/src/app/payment/services/payment.service.ts
+++ b/src/app/payment/services/payment.service.ts
@@ -3,7 +3,8 @@ import { encryptPGP } from '../../crypto/services/utilspgp';
 import httpService from '../../core/services/http.service';
 import envService from '../../core/services/env.service';
 import { LifetimeTier, StripeSessionMode } from '../types';
-import { loadStripe, RedirectToCheckoutServerOptions, Stripe, StripeError } from '@stripe/stripe-js';
+import { loadStripe } from '@stripe/stripe-js/pure';
+import { RedirectToCheckoutServerOptions, Stripe, StripeError } from '@stripe/stripe-js';
 import { SdkFactory } from '../../core/factory/sdk';
 import {
   CreateCheckoutSessionPayload,


### PR DESCRIPTION
This change improves drive-web load speed and makes website's iframe not include stripe on the website when it's not really needed, improving load speed and privacy scores while reducing cookie count.