### PR TITLE
[WT-275] fix new breadcrumb shared options

### DIFF
--- a/src/app/shared/components/Breadcrumbs/BreadcrumbsItem/BreadcrumbsItem.tsx
+++ b/src/app/shared/components/Breadcrumbs/BreadcrumbsItem/BreadcrumbsItem.tsx
@@ -156,7 +156,7 @@ const BreadcrumbsItem = (props: BreadcrumbsItemProps): JSX.Element => {
   };
 
   const currentFolder = findCurrentFolder(currentBreadcrumb);
-  const isBreadcrumbItemShared = currentFolder[0]?.shares?.length !== 0;
+  const isBreadcrumbItemShared = currentFolder[0]?.shares && currentFolder[0]?.shares?.length !== 0;
 
   const onCreateFolderButtonClicked = () => {
     dispatch(uiActions.setIsCreateFolderDialogOpen(true));


### PR DESCRIPTION
This fixes an error that occurred when creating a new folder, accessing it and displaying the dropdown of the breadcrumb was showing the actions corresponding to a shared folder when it was not.