### PR TITLE
[WT-313]:(feature) Download multiple items as zip file

### DIFF
--- a/src/app/core/services/error.service.ts
+++ b/src/app/core/services/error.service.ts
@@ -1,8 +1,21 @@
 import { AxiosError } from 'axios';
-
+import * as Sentry from '@sentry/react';
+import { CaptureContext } from '@sentry/types';
 import AppError from '../types';
 
 const errorService = {
+  /**
+   * Reports an error to Sentry
+   *
+   * @param exception Excetion to report
+   * @param context Context to attach to the exception
+   */
+  reportError(exception: unknown, context?: CaptureContext): void {
+    if (process.env.NODE_ENV === 'development') {
+      console.info('[ERROR_CATCHED]: This error has been catched and is being reported to Sentry');
+    }
+    Sentry.captureException(exception, context);
+  },
   castError(err: unknown): AppError {
     let castedError: AppError = new AppError('Unknown error');
 

--- a/src/app/core/services/socket.service.ts
+++ b/src/app/core/services/socket.service.ts
@@ -22,7 +22,8 @@ export default class RealtimeService {
       auth: {
         token: getToken(),
       },
-      withCredentials: true
+      reconnection: isProduction(),
+      withCredentials: true,
     });
 
     this.socket.on('connect', () => {
@@ -40,8 +41,7 @@ export default class RealtimeService {
     });
 
     this.socket.on('connect_error', (error) => {
-      if (!isProduction())
-        console.error('[REALTIME] CONNECTION ERROR:', error);
+      if (!isProduction()) console.error('[REALTIME] CONNECTION ERROR:', error);
     });
   }
 

--- a/src/app/store/slices/storage/storage.thunks/downloadFileThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadFileThunk.ts
@@ -32,13 +32,13 @@ const defaultDownloadFileThunkOptions = {
   showErrors: true,
 };
 
-const checkIfCachedSourceIsOlder = ({
+export const checkIfCachedSourceIsOlder = ({
   cachedFile,
   file,
 }: {
   cachedFile: DriveItemBlobData | undefined;
   file: DriveFileData;
-}) => {
+}): boolean => {
   const isCachedFileOlder = !cachedFile?.updatedAt
     ? true
     : dateService.isDateOneBefore({

--- a/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
@@ -1,70 +1,134 @@
 import { ActionReducerMapBuilder, createAsyncThunk } from '@reduxjs/toolkit';
-
-import storageThunks from '.';
 import { StorageState } from '../storage.model';
 import { RootState } from '../../..';
-import { DriveFileData, DriveFolderData, DriveItemData } from 'app/drive/types';
 import i18n from 'app/i18n/services/i18n.service';
 import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
-import { DownloadFileTask, DownloadFolderTask, TaskType } from 'app/tasks/types';
+import date from 'app/core/services/date.service';
+import { FlatFolderZip } from 'app/core/services/zip.service';
+import { downloadFile } from 'app/network/download';
+import { DriveItemData } from 'app/drive/types';
+import localStorageService from 'app/core/services/local-storage.service';
 import tasksService from 'app/tasks/services/tasks.service';
+import { DownloadFileTask, TaskStatus, TaskType } from 'app/tasks/types';
+import folderService from 'app/drive/services/folder.service';
+import errorService from 'app/core/services/error.service';
 
 export const downloadItemsThunk = createAsyncThunk<void, DriveItemData[], { state: RootState }>(
   'storage/downloadItems',
-  async (items: DriveItemData[], { dispatch, requestId, rejectWithValue }) => {
+  async (items: DriveItemData[], { rejectWithValue }) => {
     const errors: unknown[] = [];
-    const taskGroupId = requestId;
-    const tasksIds: string[] = [];
+    const downloadProgress: number[] = [];
+    const abortController = new AbortController();
+    const formattedDate = date.format(new Date(), 'DD/MM/YYYY - HH:MM');
+    const folderName = `Internxt (${formattedDate})`;
+    const folder = new FlatFolderZip(folderName, {});
 
-    // * 1. Creates tasks
-    for (const item of items) {
-      if (item.isFolder) {
-        const taskId = tasksService.create<DownloadFolderTask>({
-          action: TaskType.DownloadFolder,
-          relatedTaskId: taskGroupId,
-          folder: item,
-          compressionFormat: 'zip',
-          showNotification: true,
-          cancellable: true,
-        });
+    const user = localStorageService.getUser();
+    if (!user) throw new Error('User not found');
 
-        tasksIds.push(taskId);
-      } else {
-        const taskId = tasksService.create<DownloadFileTask>({
-          action: TaskType.DownloadFile,
-          file: item,
-          showNotification: true,
-          cancellable: true,
-          relatedTaskId: taskGroupId,
-        });
+    const taskId = tasksService.create<DownloadFileTask>({
+      action: TaskType.DownloadFile,
 
-        tasksIds.push(taskId);
-      }
-    }
+      showNotification: true,
+      stop: async () => {
+        abortController.abort();
+        folder.abort();
+      },
+      cancellable: true,
 
-    // * 2. Executes tasks
-    for (const [index, item] of items.entries()) {
-      const taskId = tasksIds[index];
+      file: {
+        name: folderName,
+        type: 'zip',
+      },
+    });
 
-      if (item.isFolder) {
-        await dispatch(
-          storageThunks.downloadFolderThunk({
-            folder: item as DriveFolderData,
-            options: { taskId },
-          }),
-        );
-      } else {
-        await dispatch(
-          storageThunks.downloadFileThunk({
-            file: item as DriveFileData,
-            options: { taskId },
-          }),
-        );
+    tasksService.updateTask({
+      taskId,
+      merge: {
+        status: TaskStatus.InProcess,
+      },
+    });
+
+    const calculateProgress = () => {
+      const totalProgress = downloadProgress.reduce((previous, current) => {
+        return previous + current;
+      });
+
+      return totalProgress / downloadProgress.length;
+    };
+
+    const updateProgressCallback = (progress: number) => {
+      tasksService.updateTask({
+        taskId,
+        merge: {
+          progress,
+        },
+      });
+    };
+
+    items.forEach((_, index) => {
+      downloadProgress[index] = 0;
+    });
+
+    for (const [index, driveItem] of items.entries()) {
+      try {
+        if (driveItem.isFolder) {
+          await folderService.downloadFolderAsZip(
+            driveItem.id,
+            driveItem.name,
+            (progress) => {
+              downloadProgress[index] = progress;
+              updateProgressCallback(calculateProgress());
+            },
+            { destination: folder, closeWhenFinished: false },
+          );
+          downloadProgress[index] = 1;
+        } else {
+          const fileStream = await downloadFile({
+            fileId: driveItem.fileId,
+            bucketId: driveItem.bucket,
+            creds: {
+              user: user.bridgeUser,
+              pass: user.userId,
+            },
+            mnemonic: user.mnemonic,
+            options: {
+              abortController,
+              notifyProgress: (totalBytes, downloadedBytes) => {
+                const progress = downloadedBytes / totalBytes;
+
+                downloadProgress[index] = progress;
+
+                updateProgressCallback(calculateProgress());
+              },
+            },
+          });
+
+          folder.addFile(`${driveItem.name}.${driveItem.type}`, fileStream);
+        }
+      } catch (e) {
+        errorService.reportError(e);
+        errors.push(e);
       }
     }
 
     if (errors.length > 0) {
+      tasksService.updateTask({
+        taskId,
+        merge: {
+          status: TaskStatus.Error,
+        },
+      });
+      await folder.abort();
       return rejectWithValue(errors);
+    } else {
+      await folder.close();
+      tasksService.updateTask({
+        taskId,
+        merge: {
+          status: TaskStatus.Success,
+        },
+      });
     }
   },
 );

--- a/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
@@ -19,7 +19,7 @@ export const downloadItemsThunk = createAsyncThunk<void, DriveItemData[], { stat
     const errors: unknown[] = [];
     const downloadProgress: number[] = [];
     const abortController = new AbortController();
-    const formattedDate = date.format(new Date(), 'DD/MM/YYYY - HH:MM');
+    const formattedDate = date.format(new Date(), 'DD/MM/YYYY - HH:mm');
     const folderName = `Internxt (${formattedDate})`;
     const folder = new FlatFolderZip(folderName, {});
 


### PR DESCRIPTION
Allow to download multiple selected files as a single zip with the files inside, including folders.

Tested on:

- Safari
- Brave
- Microsoft Edge
- Chrome
- Firefox
