### PR TITLE
[WT-293 & WT-294] Add photos preview and source to cache managed by LRU

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,8 @@ import FileViewerWrapper from './app/drive/components/FileViewer/FileViewerWrapp
 import { pdfjs } from 'react-pdf';
 import { LRUFilesCacheManager } from './app/database/services/database.service/LRUFilesCacheManager';
 import { LRUFilesPreviewCacheManager } from './app/database/services/database.service/LRUFilesPreviewCacheManager';
+import { LRUPhotosPreviewsCacheManager } from './app/database/services/database.service/LRUPhotosPreviewCacheManager';
+import { LRUPhotosCacheManager } from './app/database/services/database.service/LRUPhotosCacheManager';
 pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
 
 interface AppProps {
@@ -60,6 +62,8 @@ class App extends Component<AppProps> {
 
     await LRUFilesCacheManager.getInstance();
     await LRUFilesPreviewCacheManager.getInstance();
+    await LRUPhotosCacheManager.getInstance();
+    await LRUPhotosPreviewsCacheManager.getInstance();
 
     try {
       await this.props.dispatch(

--- a/src/app/database/services/database.service/LRUPhotosCacheManager.ts
+++ b/src/app/database/services/database.service/LRUPhotosCacheManager.ts
@@ -1,0 +1,61 @@
+import { ICacheStorage, LRUCache, LRUCacheStruture } from './LRUCache';
+import databaseService, { DatabaseCollection, PhotosData, LRUCacheTypes } from '.';
+
+class PhotosCache implements ICacheStorage<PhotosData> {
+  async getSize(key: string): Promise<number> {
+    const blobItem = await databaseService.get(DatabaseCollection.Photos, key);
+    return blobItem?.source?.size || 0;
+  }
+
+  get(key: string): Promise<PhotosData | undefined> {
+    const blobItem = databaseService.get(DatabaseCollection.Photos, key);
+    return blobItem;
+  }
+
+  set(key: string, value: PhotosData): void {
+    databaseService.put(DatabaseCollection.Photos, key, value);
+  }
+
+  delete(key: string): void {
+    databaseService.get(DatabaseCollection.Photos, key).then((databaseData) => {
+      if (databaseData?.preview) {
+        databaseService.put(DatabaseCollection.Photos, key, { ...databaseData, source: undefined });
+        return;
+      }
+      databaseService.delete(DatabaseCollection.Photos, key);
+    });
+  }
+
+  async has(key: string): Promise<boolean> {
+    const exists = !!(await databaseService.get(DatabaseCollection.Photos, key))?.source;
+    return exists;
+  }
+
+  updateLRUState(lruState: LRUCacheStruture): void {
+    databaseService.put(DatabaseCollection.LRU_cache, LRUCacheTypes.PhotosSource, lruState);
+  }
+}
+
+const MB_400_IN_BYTES = 419430400;
+
+export class LRUPhotosCacheManager {
+  private static instance: LRUCache<PhotosData>;
+
+  public static getInstance(): LRUCache<PhotosData> {
+    if (!LRUPhotosCacheManager.instance) {
+      const photosCache = new PhotosCache();
+
+      databaseService.get(DatabaseCollection.LRU_cache, LRUCacheTypes.PhotosSource).then((lruCacheState) => {
+        if (lruCacheState) {
+          LRUPhotosCacheManager.instance = new LRUCache<PhotosData>(photosCache, MB_400_IN_BYTES, {
+            lruKeyList: lruCacheState.lruKeyList,
+            itemsListSize: lruCacheState.itemsListSize,
+          });
+        } else {
+          LRUPhotosCacheManager.instance = new LRUCache<PhotosData>(photosCache, MB_400_IN_BYTES);
+        }
+      });
+    }
+    return LRUPhotosCacheManager.instance;
+  }
+}

--- a/src/app/database/services/database.service/LRUPhotosPreviewCacheManager.ts
+++ b/src/app/database/services/database.service/LRUPhotosPreviewCacheManager.ts
@@ -1,0 +1,61 @@
+import { ICacheStorage, LRUCache, LRUCacheStruture } from './LRUCache';
+import databaseService, { DatabaseCollection, PhotosData, LRUCacheTypes } from '.';
+
+class PhotosPreviewsCache implements ICacheStorage<PhotosData> {
+  async getSize(key: string): Promise<number> {
+    const blobItem = await databaseService.get(DatabaseCollection.Photos, key);
+    return blobItem?.preview?.size || 0;
+  }
+
+  get(key: string): Promise<PhotosData | undefined> {
+    const blobItem = databaseService.get(DatabaseCollection.Photos, key);
+    return blobItem;
+  }
+
+  set(key: string, value: PhotosData): void {
+    databaseService.put(DatabaseCollection.Photos, key, value);
+  }
+
+  delete(key: string): void {
+    databaseService.get(DatabaseCollection.Photos, key).then((databaseData) => {
+      if (databaseData?.source) {
+        databaseService.put(DatabaseCollection.Photos, key, { ...databaseData, preview: undefined });
+        return;
+      }
+      databaseService.delete(DatabaseCollection.Photos, key);
+    });
+  }
+
+  async has(key: string): Promise<boolean> {
+    const exists = !!(await databaseService.get(DatabaseCollection.Photos, key))?.preview;
+    return exists;
+  }
+
+  updateLRUState(lruState: LRUCacheStruture): void {
+    databaseService.put(DatabaseCollection.LRU_cache, LRUCacheTypes.PhotosPreview, lruState);
+  }
+}
+
+const MB_100_IN_BYTES = 104857600;
+
+export class LRUPhotosPreviewsCacheManager {
+  private static instance: LRUCache<PhotosData>;
+
+  public static getInstance(): LRUCache<PhotosData> {
+    if (!LRUPhotosPreviewsCacheManager.instance) {
+      const photosPreviewCache = new PhotosPreviewsCache();
+
+      databaseService.get(DatabaseCollection.LRU_cache, LRUCacheTypes.PhotosPreview).then((lruCacheState) => {
+        if (lruCacheState) {
+          LRUPhotosPreviewsCacheManager.instance = new LRUCache<PhotosData>(photosPreviewCache, MB_100_IN_BYTES, {
+            lruKeyList: lruCacheState.lruKeyList,
+            itemsListSize: lruCacheState.itemsListSize,
+          });
+        } else {
+          LRUPhotosPreviewsCacheManager.instance = new LRUCache<PhotosData>(photosPreviewCache, MB_100_IN_BYTES);
+        }
+      });
+    }
+    return LRUPhotosPreviewsCacheManager.instance;
+  }
+}

--- a/src/app/database/services/database.service/index.ts
+++ b/src/app/database/services/database.service/index.ts
@@ -17,8 +17,10 @@ export enum DatabaseCollection {
 }
 
 export enum LRUCacheTypes {
-  LevelsBlobs = 'levels_blobs', //cambiar por source?
+  LevelsBlobs = 'levels_blobs',
   LevelsBlobsPreview = 'levels_blobs_preview',
+  PhotosPreview = 'photos_preview',
+  PhotosSource = 'photos_source',
 }
 
 export type DriveItemBlobData = {
@@ -27,6 +29,11 @@ export type DriveItemBlobData = {
   preview?: Blob;
   source?: Blob;
   updatedAt?: string;
+};
+
+export type PhotosData = {
+  preview?: Blob;
+  source?: Blob;
 };
 
 export type AvatarBlobData = {
@@ -52,11 +59,8 @@ export interface AppDatabase extends DBSchema {
   };
   photos: {
     key: string;
-    value: {
-      preview?: Blob;
-      source?: Blob;
-      indexes?: Record<string, IDBValidKey>;
-    };
+    value: PhotosData;
+    indexes?: Record<string, IDBValidKey>;
   };
   account_settings: {
     key: string;

--- a/src/app/drive/services/database.service.ts
+++ b/src/app/drive/services/database.service.ts
@@ -2,9 +2,12 @@ import databaseService, {
   AvatarBlobData,
   DatabaseCollection,
   DriveItemBlobData,
+  PhotosData,
 } from '../../database/services/database.service';
 import { LRUFilesCacheManager } from '../../database/services/database.service/LRUFilesCacheManager';
 import { LRUFilesPreviewCacheManager } from '../../database/services/database.service/LRUFilesPreviewCacheManager';
+import { LRUPhotosCacheManager } from '../../database/services/database.service/LRUPhotosCacheManager';
+import { LRUPhotosPreviewsCacheManager } from '../../database/services/database.service/LRUPhotosPreviewCacheManager';
 import { DriveFileData, DriveFolderData, DriveItemData } from '../types';
 
 const updateDatabaseProfileAvatar = async ({
@@ -61,6 +64,56 @@ const getDatabaseFilePrewiewData = async ({ fileId }: { fileId: number }): Promi
   const lruFilesPreviewCacheManager = await LRUFilesPreviewCacheManager.getInstance();
 
   return lruFilesPreviewCacheManager.get(fileId.toString());
+};
+
+const updateDatabasePhotosPrewiewData = async ({
+  photoId,
+  preview,
+}: {
+  photoId: string;
+  preview: Blob;
+}): Promise<void> => {
+  const lruPhotosPreviewCacheManager = await LRUPhotosPreviewsCacheManager.getInstance();
+  const photoData = await databaseService.get(DatabaseCollection.Photos, photoId);
+
+  lruPhotosPreviewCacheManager.set(
+    photoId,
+    {
+      ...photoData,
+      preview: preview,
+    },
+    preview.size,
+  );
+};
+
+const getDatabasePhotosPrewiewData = async ({ photoId }: { photoId: string }): Promise<PhotosData | undefined> => {
+  const lruPhotosPreviewCacheManager = await LRUPhotosPreviewsCacheManager.getInstance();
+  return lruPhotosPreviewCacheManager.get(photoId);
+};
+
+const updateDatabasePhotosSourceData = async ({
+  photoId,
+  source,
+}: {
+  photoId: string;
+  source: Blob;
+}): Promise<void> => {
+  const lruPhotosCacheManager = await LRUPhotosCacheManager.getInstance();
+  const photoData = await databaseService.get(DatabaseCollection.Photos, photoId);
+  console.log({ photoData });
+  lruPhotosCacheManager.set(
+    photoId,
+    {
+      ...photoData,
+      source: source,
+    },
+    source.size,
+  );
+};
+
+const getDatabasePhotosSourceData = async ({ photoId }: { photoId: string }): Promise<PhotosData | undefined> => {
+  const lruPhotosCacheManager = await LRUPhotosCacheManager.getInstance();
+  return lruPhotosCacheManager.get(photoId);
 };
 
 const getDatabaseFileSourceData = async ({ fileId }: { fileId: number }): Promise<DriveItemBlobData | undefined> => {
@@ -134,6 +187,10 @@ export {
   updateDatabaseFilePrewiewData,
   getDatabaseFileSourceData,
   updateDatabaseFileSourceData,
+  getDatabasePhotosPrewiewData,
+  updateDatabasePhotosPrewiewData,
+  getDatabasePhotosSourceData,
+  updateDatabasePhotosSourceData,
   deleteDatabasePhotos,
   deleteDatabaseItems,
 };

--- a/src/app/drive/services/database.service.ts
+++ b/src/app/drive/services/database.service.ts
@@ -100,7 +100,7 @@ const updateDatabasePhotosSourceData = async ({
 }): Promise<void> => {
   const lruPhotosCacheManager = await LRUPhotosCacheManager.getInstance();
   const photoData = await databaseService.get(DatabaseCollection.Photos, photoId);
-  console.log({ photoData });
+
   lruPhotosCacheManager.set(
     photoId,
     {

--- a/src/app/network/download.ts
+++ b/src/app/network/download.ts
@@ -282,7 +282,7 @@ export async function getPhotoBlob({
   abortController?: AbortController;
 }): Promise<Blob> {
   const previewInCache = await getDatabasePhotosSourceData({ photoId: photo.id });
-  console.log({ previewInCache });
+
   if (previewInCache && previewInCache.source) {
     return Promise.resolve(previewInCache.source);
   }

--- a/src/app/store/slices/photos/thunks/download.ts
+++ b/src/app/store/slices/photos/thunks/download.ts
@@ -33,6 +33,7 @@ export const downloadThunk = createAsyncThunk<void, SerializablePhoto[], { state
 
       if (payload.length === 1) {
         const [photo] = payload;
+
         const photoBlob = await getPhotoBlob({ photo, bucketId, abortController });
 
         if (!abortController.signal.aborted) {
@@ -69,7 +70,7 @@ export const downloadThunk = createAsyncThunk<void, SerializablePhoto[], { state
               generalProgress[photo.id] = progress;
               updateTaskProgress();
             },
-            abortController
+            abortController,
           });
 
           if (photoSource instanceof Blob) {
@@ -88,8 +89,7 @@ export const downloadThunk = createAsyncThunk<void, SerializablePhoto[], { state
     } catch (err) {
       const error = errorService.castError(err);
 
-      if (abortController.signal.aborted)
-        tasksService.updateTask({ taskId, merge: { status: TaskStatus.Cancelled } });
+      if (abortController.signal.aborted) tasksService.updateTask({ taskId, merge: { status: TaskStatus.Cancelled } });
       else {
         console.error(error);
         tasksService.updateTask({ taskId, merge: { status: TaskStatus.Error } });

--- a/src/app/store/slices/storage/storage.thunks/downloadFileThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadFileThunk.ts
@@ -11,7 +11,6 @@ import i18n from 'app/i18n/services/i18n.service';
 import errorService from 'app/core/services/error.service';
 import { TaskStatus } from 'app/tasks/types';
 import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
-import { LRUFilesCacheManager } from '../../../../database/services/database.service/LRUFilesCacheManager';
 import { saveAs } from 'file-saver';
 import dateService from '../../../../core/services/date.service';
 import { DriveItemBlobData } from '../../../../database/services/database.service';


### PR DESCRIPTION
- Added cache to store up to 100MB of photos previews managed by LRU
- Added cache to store up to 400MB of photos content managed by LRU


Related PRs:
- ⚠️ Need to review the [[WT-291] Store up to 50MB of thumbnails #574](https://github.com/internxt/drive-web/pull/574) before this one

[WT-291]: https://inxt.atlassian.net/browse/WT-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ