### PR TITLE
[_]:(feature) Auto submit from local credentials

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,13 +52,19 @@ class App extends Component<AppProps> {
   async componentDidMount(): Promise<void> {
     const token = localStorageService.get('xToken');
 
-    if (token) {
+    if (token && navigationService.history.location.pathname !== '/new') {
       /**
        * In case we receive a valid redirectUrl param, we return to that URL with the current token
        */
-      const redirectUrl = authService.getRedirectUrl(new URLSearchParams(window.location.search), token);
+      const redirectUrl = authService.getRedirectUrl(
+        new URLSearchParams(navigationService.history.location.search),
+        token,
+      );
 
-      redirectUrl && window.location.replace(redirectUrl);
+      if (redirectUrl) {
+        window.location.replace(redirectUrl);
+        return;
+      }
     }
 
     const currentRouteConfig: AppViewConfig | undefined = configService.getViewConfig({

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -270,7 +270,7 @@ export const getRedirectUrl = (urlSearchParams: URLSearchParams, token: string):
   const url = new URL(redirectUrl);
   const currentParams = url.searchParams;
 
-  if (!currentParams.get('auth')) {
+  if (currentParams.get('auth') !== 'true') {
     return url.origin + url.pathname + '?' + currentParams.toString();
   }
   currentParams.set('authToken', token);
@@ -295,7 +295,7 @@ const extractOneUseCredentialsForAutoSubmit = (
   credentials?: { email: string; password: string };
 } => {
   // Auto submit is not enabled;
-  if (!searchParams.get('autoSubmit')) {
+  if (searchParams.get('autoSubmit') !== 'true') {
     return { enabled: false };
   }
 

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -28,6 +28,7 @@ import { SdkFactory } from '../../core/factory/sdk';
 import { ChangePasswordPayload } from '@internxt/sdk/dist/drive/users/types';
 import httpService from '../../core/services/http.service';
 import RealtimeService from 'app/core/services/socket.service';
+import { getCookie, setCookie } from 'app/analytics/utils';
 
 export async function logOut(): Promise<void> {
   analyticsService.trackSignOut();
@@ -269,6 +270,9 @@ export const getRedirectUrl = (urlSearchParams: URLSearchParams, token: string):
   const url = new URL(redirectUrl);
   const currentParams = url.searchParams;
 
+  if (!currentParams.get('auth')) {
+    return url.origin + url.pathname + '?' + currentParams.toString();
+  }
   currentParams.set('authToken', token);
 
   return url.origin + url.pathname + '?' + currentParams.toString();
@@ -279,6 +283,42 @@ const store2FA = async (code: string, twoFactorCode: string): Promise<void> => {
   return authClient.storeTwoFactorAuthKey(code, twoFactorCode);
 };
 
+/**
+ * Obtains the credentials from a cookie for one use only
+ * @param searchParams Url search params to enable the autosubmit mode
+ * @returns The credentials and the submit mode enabled or not
+ */
+const extractOneUseCredentialsForAutoSubmit = (
+  searchParams: URLSearchParams,
+): {
+  enabled: boolean;
+  credentials?: { email: string; password: string };
+} => {
+  // Auto submit is not enabled;
+  if (!searchParams.get('autoSubmit')) {
+    return { enabled: false };
+  }
+
+  try {
+    const cookie = getCookie('cr');
+    const credentials = JSON.parse(atob(cookie));
+
+    // Delete the cookie
+    setCookie('cr', '', -999);
+    return {
+      enabled: true,
+      credentials: {
+        email: credentials.email,
+        password: credentials.password,
+      },
+    };
+  } catch (error) {
+    return {
+      enabled: true,
+    };
+  }
+};
+
 const authService = {
   logOut,
   doLogin,
@@ -286,6 +326,7 @@ const authService = {
   readReferalCookie,
   cancelAccount,
   store2FA,
+  extractOneUseCredentialsForAutoSubmit,
   getNewToken,
   getRedirectUrl,
 };


### PR DESCRIPTION
Allow to automatically submit login and signup forms

- autoSubmit param should be present in the URL
- A cookie with the credentials and scoped only to internxt.com must exists
- The cookie can be read only once, the values are stored in memory, after reload the autoSubmit won't work since no credentials will be found

