### PR TITLE
[_]: feat/add-project-analysis-badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=internxt_drive-web&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=internxt_drive-web)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=internxt_drive-web&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=internxt_drive-web)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=internxt_drive-web&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=internxt_drive-web)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=internxt_drive-web&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=internxt_drive-web)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=internxt_drive-web&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=internxt_drive-web)
+[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=internxt_drive-web&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=internxt_drive-web)
+
+# Project Manteinance
+We aim to have: 
+- An 'A' score on Maintainability Rating
+- An 'A' score on Security Rating
+- A 3% of duplicated lines
+
 # Getting Started
 
 ## Installation
@@ -107,3 +120,6 @@ To speed up the development and maintenance of the project, it is recommended to
 * PostCSS Language Support
 * SCSS Formatter
 * Tailwind CSS IntelliSense
+
+
+[![SonarCloud](https://sonarcloud.io/images/project_badges/sonarcloud-white.svg)](https://sonarcloud.io/summary/new_code?id=internxt_drive-web)


### PR DESCRIPTION
These changes add the GitHub badges generated by SonarCloud about the analysis of the project to keep track of the health of the project. 