### PR TITLE
[_]: fix/continuous-scroll-in-file-preview

### DIFF
--- a/src/app/drive/components/FileViewer/viewers/FilePdfViewer/FilePdfViewer.tsx
+++ b/src/app/drive/components/FileViewer/viewers/FilePdfViewer/FilePdfViewer.tsx
@@ -60,6 +60,7 @@ const FilePdfViewer = (props: FormatFileViewerProps): JSX.Element => {
   const [numPages, setNumPages] = useState(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [zoom, setZoom] = useState(DEFAULT_ZOOM);
+  const [renderPages, setRenderPages] = useState<number>();
 
   //useEffect to avoid flickering
   useEffect(() => {
@@ -82,6 +83,14 @@ const FilePdfViewer = (props: FormatFileViewerProps): JSX.Element => {
     setNumPages(numPages);
   }
 
+  useEffect(() => {
+    if (currentPage === currentPage + 15) {
+      setRenderPages(currentPage + 30);
+    } else {
+      setRenderPages(currentPage + 15);
+    }
+  }, [currentPage]);
+
   return (
     <div className="flex max-h-full w-full items-center justify-center pt-16">
       <Fragment>
@@ -89,7 +98,7 @@ const FilePdfViewer = (props: FormatFileViewerProps): JSX.Element => {
           <div className="flex items-center justify-center">
             <Document file={fileUrl} loading="" onLoadSuccess={onDocumentLoadSuccess}>
               <div className="flex flex-col items-center space-y-3">
-                {Array.from(new Array(numPages), (el, index) => (
+                {Array.from(new Array(renderPages), (el, index) => (
                   <PageWithObserver
                     loading=""
                     onPageVisible={setCurrentPage}

--- a/src/app/drive/components/FileViewer/viewers/FilePdfViewer/FilePdfViewer.tsx
+++ b/src/app/drive/components/FileViewer/viewers/FilePdfViewer/FilePdfViewer.tsx
@@ -88,7 +88,6 @@ const FilePdfViewer = (props: FormatFileViewerProps): JSX.Element => {
       if (currentPage + 15 <= numPages) {
         setRenderPages(currentPage + 15);
       } else {
-        console.log('rendering all pages');
         setRenderPages(currentPage + (numPages - currentPage));
       }
     } else {

--- a/src/app/drive/components/FileViewer/viewers/FilePdfViewer/FilePdfViewer.tsx
+++ b/src/app/drive/components/FileViewer/viewers/FilePdfViewer/FilePdfViewer.tsx
@@ -57,7 +57,7 @@ const DEFAULT_ZOOM = 1;
 const FilePdfViewer = (props: FormatFileViewerProps): JSX.Element => {
   const { translate } = useTranslationContext();
   const [fileUrl, setFileUrl] = useState(URL.createObjectURL(props.blob));
-  const [numPages, setNumPages] = useState(null);
+  const [numPages, setNumPages] = useState<number>(0);
   const [currentPage, setCurrentPage] = useState(1);
   const [zoom, setZoom] = useState(DEFAULT_ZOOM);
   const [renderPages, setRenderPages] = useState<number>();
@@ -84,12 +84,17 @@ const FilePdfViewer = (props: FormatFileViewerProps): JSX.Element => {
   }
 
   useEffect(() => {
-    if (currentPage === currentPage + 15) {
-      setRenderPages(currentPage + 30);
+    if (numPages > 75) {
+      if (currentPage + 15 <= numPages) {
+        setRenderPages(currentPage + 15);
+      } else {
+        console.log('rendering all pages');
+        setRenderPages(currentPage + (numPages - currentPage));
+      }
     } else {
-      setRenderPages(currentPage + 15);
+      setRenderPages(numPages);
     }
-  }, [currentPage]);
+  }, [currentPage, numPages]);
 
   return (
     <div className="flex max-h-full w-full items-center justify-center pt-16">


### PR DESCRIPTION
Prevent bugs in large PDF. 

* Render a part of the pdf (15 pages) and load more pages as the user scrolls (+15 pages). 
* If the PDF contains less than 75 pages, the entire PDF will be loaded. 