### PR TITLE
[WT-332]: feature/trash-pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@iconscout/react-unicons": "^1.1.6",
     "@internxt/inxt-js": "=1.2.21",
     "@internxt/lib": "^1.2.0",
-    "@internxt/sdk": "^1.4.23",
+    "@internxt/sdk": "^1.4.25",
     "@reduxjs/toolkit": "^1.6.0",
     "@sentry/react": "^7.1.0",
     "@sentry/tracing": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@iconscout/react-unicons": "^1.1.6",
     "@internxt/inxt-js": "=1.2.21",
     "@internxt/lib": "^1.2.0",
-    "@internxt/sdk": "^1.4.25",
+    "@internxt/sdk": "^1.4.26",
     "@reduxjs/toolkit": "^1.6.0",
     "@sentry/react": "^7.1.0",
     "@sentry/tracing": "^7.1.0",

--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -159,7 +159,8 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
   }, []);
 
   useEffect(() => {
-    const thereIsNotMoreFoldersAndFewerItems = !hasMoreTrashFolders && folderOnTrashLength < 50 && items.length < 50;
+    const thereIsNotMoreFoldersAndFewerItems =
+      !hasMoreTrashFolders && folderOnTrashLength < TRASH_PAGINATION_OFFSET && items.length < TRASH_PAGINATION_OFFSET;
 
     if (thereIsNotMoreFoldersAndFewerItems) {
       getMoreTrashItems();

--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -146,43 +146,45 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
   const isSelectedItemShared = selectedItems[0]?.shares?.length !== 0;
 
   useEffect(() => {
-    if (isTrash && paginatedTrashItems.length < items.length) {
+    if (isTrash && paginatedTrashItems.length !== items.length) {
       setPaginatedTrashItems(items);
     }
-  }, [items.length]);
+  }, [items]);
 
   useEffect(() => {
-    const isTrashAndNotHasItems = isTrash && items.length === 0;
+    const isTrashAndNotHasItems = isTrash;
     if (isTrashAndNotHasItems) {
-      getMoreTrashItems();
+      getMoreTrashFolders();
     }
   }, []);
 
   useEffect(() => {
     const thereIsNotMoreFoldersAndFewerItems =
-      !hasMoreTrashFolders && folderOnTrashLength < TRASH_PAGINATION_OFFSET && items.length < TRASH_PAGINATION_OFFSET;
+      !hasMoreTrashFolders && folderOnTrashLength < TRASH_PAGINATION_OFFSET && timesCalled === 1;
 
     if (thereIsNotMoreFoldersAndFewerItems) {
-      getMoreTrashItems();
+      getMoreTrashFiles();
     }
-  }, [items]);
+  }, [timesCalled]);
 
   //TODO: MOVE PAGINATED TRASH LOGIC OUT OF VIEW
-  const getMoreTrashItems = async () => {
+  const getMoreTrashFolders = async () => {
+    const result = await getTrashPaginated(TRASH_PAGINATION_OFFSET, folderOnTrashLength, 'folders', true);
+    const existsMoreFolders = !result.finished;
+
+    setHasMoreTrashFolders(existsMoreFolders);
     setTimesCalled(timesCalled + 1);
-
-    if (hasMoreTrashFolders && !timesCalled) {
-      const result = await getTrashPaginated(TRASH_PAGINATION_OFFSET, folderOnTrashLength, 'folders', true);
-
-      const existsMoreFolders = !result.finished;
-      setHasMoreTrashFolders(existsMoreFolders);
-    } else {
-      const result = await getTrashPaginated(TRASH_PAGINATION_OFFSET, filesOnTrashLength, 'files', true);
-
-      const existsMoreItems = !result.finished;
-      setHasMoreItems(existsMoreItems);
-    }
   };
+
+  const getMoreTrashFiles = async () => {
+    const result = await getTrashPaginated(TRASH_PAGINATION_OFFSET, filesOnTrashLength, 'files', true);
+
+    const existsMoreItems = !result.finished;
+    setHasMoreItems(existsMoreItems);
+    setTimesCalled(timesCalled + 1);
+  };
+
+  const getMoreTrashItems = hasMoreTrashFolders ? getMoreTrashFolders : getMoreTrashFiles;
 
   useEffect(() => {
     deviceService.redirectForMobile();

--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -61,8 +61,10 @@ import NameCollisionContainer from '../NameCollisionDialog/NameCollisionContaine
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
 import { Menu, Transition } from '@headlessui/react';
 import { useHotkeys } from 'react-hotkeys-hook';
+import { getTrashPaginated } from '../../../../use_cases/trash/get_trash';
 
-const PAGINATION_LIMIT = 100;
+const PAGINATION_LIMIT = 50;
+const TRASH_PAGINATION_OFFSET = 50;
 const UPLOAD_ITEMS_LIMIT = 1000;
 
 interface DriveExplorerProps {
@@ -93,6 +95,8 @@ interface DriveExplorerProps {
   planUsage: number;
   isOver: boolean;
   connectDropTarget: ConnectDropTarget;
+  folderOnTrashLength: number;
+  filesOnTrashLength: number;
 }
 
 const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
@@ -111,6 +115,8 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
     currentFolderId,
     onFileUploaded,
     onItemsMoved,
+    folderOnTrashLength,
+    filesOnTrashLength,
   } = props;
   const dispatch = useAppDispatch();
   const { translate } = useTranslationContext();
@@ -118,8 +124,13 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
   const [fileInputKey, setFileInputKey] = useState<number>(Date.now());
   const [folderInputRef] = useState<RefObject<HTMLInputElement>>(createRef());
   const [folderInputKey, setFolderInputKey] = useState<number>(Date.now());
+
   const [fakePaginationLimit, setFakePaginationLimit] = useState<number>(PAGINATION_LIMIT);
   const [hasMoreItems, setHasMoreItems] = useState<boolean>(true);
+  const [hasMoreTrashFolders, setHasMoreTrashFolders] = useState<boolean>(true);
+  const [paginatedTrashItems, setPaginatedTrashItems] = useState<DriveItemData[]>([]);
+  const [timesCalled, setTimesCalled] = useState<number>(0);
+
   const [isListElementsHovered, setIsListElementsHovered] = useState<boolean>(false);
 
   const menuButtonRef = useRef<HTMLButtonElement>(null);
@@ -133,6 +144,44 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
   const hasFilters = storageFilters.text.length > 0;
   const hasAnyItemSelected = selectedItems.length > 0;
   const isSelectedItemShared = selectedItems[0]?.shares?.length !== 0;
+
+  useEffect(() => {
+    if (isTrash && paginatedTrashItems.length < items.length) {
+      setPaginatedTrashItems(items);
+    }
+  }, [items.length]);
+
+  useEffect(() => {
+    const isTrashAndNotHasItems = isTrash && items.length === 0;
+    if (isTrashAndNotHasItems) {
+      getMoreTrashItems();
+    }
+  }, []);
+
+  useEffect(() => {
+    const thereIsNotMoreFoldersAndFewerItems = !hasMoreTrashFolders && folderOnTrashLength < 50 && items.length < 50;
+
+    if (thereIsNotMoreFoldersAndFewerItems) {
+      getMoreTrashItems();
+    }
+  }, [items]);
+
+  //TODO: MOVE PAGINATED TRASH LOGIC OUT OF VIEW
+  const getMoreTrashItems = async () => {
+    setTimesCalled(timesCalled + 1);
+
+    if (hasMoreTrashFolders && !timesCalled) {
+      const result = await getTrashPaginated(TRASH_PAGINATION_OFFSET, folderOnTrashLength, 'folders', true);
+
+      const existsMoreFolders = !result.finished;
+      setHasMoreTrashFolders(existsMoreFolders);
+    } else {
+      const result = await getTrashPaginated(TRASH_PAGINATION_OFFSET, filesOnTrashLength, 'files', true);
+
+      const existsMoreItems = !result.finished;
+      setHasMoreItems(existsMoreItems);
+    }
+  };
 
   useEffect(() => {
     deviceService.redirectForMobile();
@@ -370,7 +419,7 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
       <DeleteItemsDialog onItemsDeleted={onItemsDeleted} />
       <CreateFolderDialog onFolderCreated={onFolderCreated} currentFolderId={currentFolderId} />
       <NameCollisionContainer />
-      <MoveItemsDialog items={items} onItemsMoved={onItemsMoved} isTrash={isTrash} />
+      <MoveItemsDialog items={[...items]} onItemsMoved={onItemsMoved} isTrash={isTrash} />
       <ClearTrashDialog onItemsDeleted={onItemsDeleted} />
       <EditFolderNameDialog />
       <UploadItemsFailsDialog />
@@ -601,9 +650,9 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
               <div className="flex flex-grow flex-col justify-between overflow-hidden">
                 <ViewModeComponent
                   folderId={currentFolderId}
-                  items={itemsList}
+                  items={isTrash ? paginatedTrashItems : itemsList}
                   isLoading={isLoading}
-                  onEndOfScroll={getMoreItems}
+                  onEndOfScroll={isTrash ? getMoreTrashItems : getMoreItems}
                   hasMoreItems={hasMoreItems}
                   isTrash={isTrash}
                   onHoverListItems={(areHovered) => setIsListElementsHovered(areHovered)}
@@ -808,5 +857,7 @@ export default connect((state: RootState) => {
     workspace: state.session.workspace,
     planLimit: planSelectors.planLimitToShow(state),
     planUsage: state.plan.planUsage,
+    folderOnTrashLength: state.storage.folderOnTrashLength,
+    filesOnTrashLength: state.storage.filesOnTrashLength,
   };
 })(DropTarget([NativeTypes.FILE], dropTargetSpec, dropTargetCollect)(DriveExplorer));

--- a/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerListItem/DriveExplorerListItem.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerListItem/DriveExplorerListItem.tsx
@@ -73,10 +73,10 @@ const DriveExplorerListItem = ({ item }: DriveExplorerItemProps): JSX.Element =>
           <span
             data-test={`${item.isFolder ? 'folder' : 'file'}-name`}
             className={`${spanDisplayClass} file-list-item-name-span`}
-            title={items.getItemDisplayName(item)}
+            title={item?.plainName ?? items.getItemDisplayName(item)}
             onClick={!item.deleted || !item.isFolder ? onNameClicked : undefined}
           >
-            {items.getItemDisplayName(item)}
+            {item?.plainName ?? items.getItemDisplayName(item)}
           </span>
           {!isEditingName && !item.deleted && (
             <PencilSimple onClick={onEditNameButtonClicked} className="file-list-item-edit-name-button" />

--- a/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
+++ b/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
@@ -9,7 +9,6 @@ import { setItemsToMove, storageActions } from 'app/store/slices/storage';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { RootState } from 'app/store';
 import { DriveItemData, FolderPathDialog } from '../../types';
-import i18n from 'app/i18n/services/i18n.service';
 import restoreItemsFromTrash from '../../../../../src/use_cases/trash/recover-items-from-trash';
 import folderImage from 'assets/icons/light/folder.svg';
 import databaseService, { DatabaseCollection } from 'app/database/services/database.service';
@@ -26,6 +25,7 @@ interface MoveItemsDialogProps {
   onItemsMoved?: () => void;
   isTrash?: boolean;
   items: DriveItemData[];
+  parentFolderId?: number;
 }
 
 const MoveItemsDialog = (props: MoveItemsDialogProps): JSX.Element => {
@@ -70,7 +70,7 @@ const MoveItemsDialog = (props: MoveItemsDialogProps): JSX.Element => {
     if (isOpen) {
       setCurrentNamePaths([]);
 
-      onShowFolderContentClicked(rootFolderID, 'Drive');
+      onShowFolderContentClicked(props.parentFolderId ?? rootFolderID, 'Drive');
     }
   }, [isOpen]);
 

--- a/src/app/drive/types/index.ts
+++ b/src/app/drive/types/index.ts
@@ -16,6 +16,7 @@ export interface DriveFolderData {
   isFolder: boolean;
   name: string;
   plain_name: string;
+  plainName?: string | null;
   parentId: number;
   parent_id: number | null;
   updatedAt: string;
@@ -43,6 +44,7 @@ export interface DriveFileData {
   id: number;
   name: string;
   plain_name: string | null;
+  plainName?: string | null;
   size: number;
   type: string;
   updatedAt: string;

--- a/src/app/drive/views/DriveView/DriveView.tsx
+++ b/src/app/drive/views/DriveView/DriveView.tsx
@@ -1,4 +1,4 @@
-import { Component, ReactNode, useMemo } from 'react';
+import { Component, ReactNode } from 'react';
 import { connect } from 'react-redux';
 
 import Breadcrumbs, { BreadcrumbItemData } from 'app/shared/components/Breadcrumbs/Breadcrumbs';

--- a/src/app/drive/views/TrashView/TrashView.tsx
+++ b/src/app/drive/views/TrashView/TrashView.tsx
@@ -12,8 +12,6 @@ export interface TrashViewProps {
   isLoadingItemsOnTrash: boolean;
   items: DriveItemData[];
   dispatch: AppDispatch;
-  folderOnTrashLength: number;
-  filesOnTrashLength: number;
 }
 
 const TrashView = (props: TrashViewProps) => {
@@ -22,8 +20,8 @@ const TrashView = (props: TrashViewProps) => {
   useEffect(() => {
     const { dispatch } = props;
 
-    dispatch(storageActions.clearSelectedItems());
     dispatch(storageThunks.resetNamePathThunk());
+    dispatch(storageActions.clearSelectedItems());
   }, []);
 
   const { items, isLoadingItemsOnTrash } = props;

--- a/src/app/drive/views/TrashView/TrashView.tsx
+++ b/src/app/drive/views/TrashView/TrashView.tsx
@@ -1,25 +1,29 @@
-import { Component, ReactNode, useEffect } from 'react';
+import { useEffect } from 'react';
 import { connect } from 'react-redux';
 
 import DriveExplorer from 'app/drive/components/DriveExplorer/DriveExplorer';
 import { DriveItemData } from 'app/drive/types';
 import { AppDispatch, RootState } from 'app/store';
-import { storageSelectors } from 'app/store/slices/storage';
+import { storageActions } from 'app/store/slices/storage';
 import storageThunks from '../../../store/slices/storage/storage.thunks';
-import getTrash from '../../../../use_cases/trash/get_trash';
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
 
 export interface TrashViewProps {
   isLoadingItemsOnTrash: boolean;
   items: DriveItemData[];
   dispatch: AppDispatch;
+  folderOnTrashLength: number;
+  filesOnTrashLength: number;
 }
 
 const TrashView = (props: TrashViewProps) => {
   const { translate } = useTranslationContext();
+
   useEffect(() => {
-    props.dispatch(storageThunks.resetNamePathThunk());
-    getTrash();
+    const { dispatch } = props;
+
+    dispatch(storageActions.clearSelectedItems());
+    dispatch(storageThunks.resetNamePathThunk());
   }, []);
 
   const { items, isLoadingItemsOnTrash } = props;
@@ -29,6 +33,6 @@ const TrashView = (props: TrashViewProps) => {
 export default connect((state: RootState) => {
   return {
     isLoadingDeleted: state.storage.isLoadingDeleted,
-    items: storageSelectors.filteredItems(state)(state.storage.itemsOnTrash), //.itemsOnTrash),
+    items: state.storage.itemsOnTrash, //storageSelectors.filteredItems(state)(state.storage.itemsOnTrash), //.itemsOnTrash),
   };
 })(TrashView);

--- a/src/app/shared/components/List/ListItem.tsx
+++ b/src/app/shared/components/List/ListItem.tsx
@@ -126,8 +126,7 @@ export default function ListItem<T extends { id: string }>({
                   {option.keyboardShortcutOptions?.keyboardShortcutIcon && (
                     <option.keyboardShortcutOptions.keyboardShortcutIcon size={14} />
                   )}
-                  {option.keyboardShortcutOptions?.keyboardShortcutText &&
-                    option.keyboardShortcutOptions?.keyboardShortcutText}
+                  {option.keyboardShortcutOptions?.keyboardShortcutText ?? ''}
                 </span>
               </div>
             </div>
@@ -281,8 +280,7 @@ export default function ListItem<T extends { id: string }>({
                                       {option.keyboardShortcutOptions?.keyboardShortcutIcon && (
                                         <option.keyboardShortcutOptions.keyboardShortcutIcon size={14} />
                                       )}
-                                      {option.keyboardShortcutOptions?.keyboardShortcutText &&
-                                        option.keyboardShortcutOptions?.keyboardShortcutText}
+                                      {option.keyboardShortcutOptions?.keyboardShortcutText ?? ''}
                                     </span>
                                   </div>
                                 );

--- a/src/app/shared/components/List/index.tsx
+++ b/src/app/shared/components/List/index.tsx
@@ -101,11 +101,13 @@ ListProps<T, F>): JSX.Element {
       />
     ));
 
+  // Check if this is necessary, commented because it calls twice onNextPage
+  // because InfiniteScroll already manage this case
   useEffect(() => {
     if (!node || isLoading) return;
 
     if (!isScrollable && hasMoreItems) {
-      onNextPage?.();
+      // onNextPage?.();
     }
   }, [isLoading, isScrollable, hasMoreItems, node]);
 

--- a/src/app/shared/components/List/index.tsx
+++ b/src/app/shared/components/List/index.tsx
@@ -109,6 +109,10 @@ ListProps<T, F>): JSX.Element {
     }
   }, [isLoading, isScrollable, hasMoreItems, node]);
 
+  const handleNexstPage = () => {
+    onNextPage?.();
+  };
+
   function unselectAllItems() {
     const changesToMake = selectedItems.map((item) => ({ props: item, value: false }));
     onSelectedItemsChanged(changesToMake);
@@ -239,9 +243,10 @@ ListProps<T, F>): JSX.Element {
           <>
             <InfiniteScroll
               dataLength={items.length}
-              next={onNextPage ? onNextPage : () => ({})}
-              hasMore={hasMoreItems ?? false}
+              next={handleNexstPage}
+              hasMore={!!hasMoreItems}
               loader={loader}
+              scrollThreshold={0.7}
               scrollableTarget="scrollableList"
               className="h-full"
               style={{ overflow: 'visible' }}

--- a/src/app/store/slices/storage/index.ts
+++ b/src/app/store/slices/storage/index.ts
@@ -24,6 +24,8 @@ const initialState: StorageState = {
   itemsToDelete: [],
   itemsToMove: [],
   itemsOnTrash: [],
+  folderOnTrashLength: 0,
+  filesOnTrashLength: 0,
   viewMode: FileViewMode.List,
   namePath: [],
   filesToRename: [],
@@ -55,6 +57,21 @@ export const storageSlice = createSlice({
     },
     setItemsOnTrash: (state: StorageState, action: PayloadAction<DriveItemData[]>) => {
       state.itemsOnTrash = action.payload;
+    },
+    addItemsOnTrash: (state: StorageState, action: PayloadAction<DriveItemData[]>) => {
+      state.itemsOnTrash = state.itemsOnTrash.concat(action.payload);
+    },
+    setFoldersOnTrashLength: (state: StorageState, action: PayloadAction<number>) => {
+      state.folderOnTrashLength = action.payload;
+    },
+    setFilesOnTrashLength: (state: StorageState, action: PayloadAction<number>) => {
+      state.filesOnTrashLength = action.payload;
+    },
+    addFoldersOnTrashLength: (state: StorageState, action: PayloadAction<number>) => {
+      state.folderOnTrashLength += action.payload;
+    },
+    addFilesOnTrashLength: (state: StorageState, action: PayloadAction<number>) => {
+      state.filesOnTrashLength += action.payload;
     },
     setFilesToRename: (state: StorageState, action: PayloadAction<(File | DriveItemData)[]>) => {
       state.filesToRename = action.payload;

--- a/src/app/store/slices/storage/index.ts
+++ b/src/app/store/slices/storage/index.ts
@@ -67,6 +67,11 @@ export const storageSlice = createSlice({
     setFilesOnTrashLength: (state: StorageState, action: PayloadAction<number>) => {
       state.filesOnTrashLength = action.payload;
     },
+    resetTrash: (state: StorageState) => {
+      state.filesOnTrashLength = 0;
+      state.folderOnTrashLength = 0;
+      state.itemsOnTrash = [];
+    },
     addFoldersOnTrashLength: (state: StorageState, action: PayloadAction<number>) => {
       state.folderOnTrashLength += action.payload;
     },

--- a/src/app/store/slices/storage/storage.model.ts
+++ b/src/app/store/slices/storage/storage.model.ts
@@ -21,6 +21,8 @@ export interface StorageState {
   itemsToDelete: DriveItemData[];
   itemsToMove: DriveItemData[];
   itemsOnTrash: DriveItemData[];
+  folderOnTrashLength: number;
+  filesOnTrashLength: number;
   filesToRename: (File | DriveItemData)[];
   driveFilesToRename: DriveItemData[];
   foldersToRename: (DriveItemData | IRoot)[];

--- a/src/app/store/slices/storage/storage.selectors.ts
+++ b/src/app/store/slices/storage/storage.selectors.ts
@@ -61,7 +61,7 @@ const storageSelectors = {
   isItemSelected(state: RootState): (item: DriveItemData) => boolean {
     return (item) => state.storage.selectedItems.some((i) => item.id === i.id && item.isFolder === i.isFolder);
   },
-  isSomeItemSelected: (state: RootState): boolean => state.storage.selectedItems.length > 0
+  isSomeItemSelected: (state: RootState): boolean => state.storage.selectedItems.length > 0,
 };
 
 export default storageSelectors;

--- a/src/use_cases/trash/clear-trash.ts
+++ b/src/use_cases/trash/clear-trash.ts
@@ -8,7 +8,7 @@ const ClearTrash = async (): Promise<void> => {
   const trashClient = await SdkFactory.getNewApiInstance().createTrashClient();
   await trashClient.clearTrash();
 
-  store.dispatch(storageActions.setItemsOnTrash([]));
+  store.dispatch(storageActions.resetTrash());
   store.dispatch(storageActions.clearSelectedItems());
 
   notificationsService.show({

--- a/src/use_cases/trash/delete-items.ts
+++ b/src/use_cases/trash/delete-items.ts
@@ -20,6 +20,19 @@ const DeleteItems = async (itemsToDelete: DriveItemData[]): Promise<void> => {
   await deleteDatabaseItems(itemsToDelete);
 
   store.dispatch(storageActions.popItemsToDelete(itemsToDelete));
+
+  let foldersRemovedNumber = 0;
+  let filesRemovedNumber = 0;
+
+  itemsToDelete.forEach((item) => {
+    if (item.isFolder) {
+      foldersRemovedNumber = foldersRemovedNumber + 1;
+    } else {
+      filesRemovedNumber = filesRemovedNumber + 1;
+    }
+  });
+  store.dispatch(storageActions.addFoldersOnTrashLength(-foldersRemovedNumber));
+  store.dispatch(storageActions.addFilesOnTrashLength(-filesRemovedNumber));
   store.dispatch(storageActions.clearSelectedItems());
 
   notificationsService.show({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1415,10 +1415,10 @@
   resolved "https://npm.pkg.github.com/download/@internxt/prettier-config/1.0.2/9a19de23e3330a81c0e2bace1a6a0325fc8633197cf677e44ea75e54df315b5e"
   integrity sha512-t4HiqvCbC7XgQepwWlIaFJe3iwW7HCf6xOSU9nKTV0tiGqOPz7xMtIgLEloQrDA34Cx4PkOYBXrvFPV6RxSFAA==
 
-"@internxt/sdk@^1.4.23":
-  version "1.4.23"
-  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.4.23/82bdc9c36c43344aff3741bca2c44065ba650bd9#82bdc9c36c43344aff3741bca2c44065ba650bd9"
-  integrity sha512-wC6Ph4E85ibITM2iui/NRfS5okMsSwIbmF1u91rYDkQ2CPpF56k59RJeENb66Mowoa0r/kOh0TcTQdPn8CXGTg==
+"@internxt/sdk@^1.4.26":
+  version "1.4.26"
+  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.4.26/8bbf78143f56394bb0e64ef92eb4fa4e48e66238#8bbf78143f56394bb0e64ef92eb4fa4e48e66238"
+  integrity sha512-/u8vYggq9Ai53M9Cp3dP1+0rCMTNE3Bd6tnVf85ir9phZiIPim5fMIlzWtWdhx5qIK7BzgItDtz8yFKdG87xmQ==
   dependencies:
     axios "^0.24.0"
     query-string "^7.1.0"


### PR DESCRIPTION
Improved trash performance due to speed and scalability reasons

Now the trash items are loaded on the fly, therefore less items need to be loaded and load time is faster. Before, all the items where loaded, in consequence, the latency of loading the trash was higher and higher when the trash grows. Now the speed will be stable and always the same. Moreover, loading trash in chunks reduces servers load which is more efficient and less prone to failures.