### PR TITLE
[WT-280]: fix/move items dialog ux

### DIFF
--- a/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
+++ b/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
@@ -15,7 +15,7 @@ import databaseService, { DatabaseCollection } from 'app/database/services/datab
 import CreateFolderDialog from '../CreateFolderDialog/CreateFolderDialog';
 import Breadcrumbs, { BreadcrumbItemData } from 'app/shared/components/Breadcrumbs/Breadcrumbs';
 import storageSelectors from 'app/store/slices/storage/storage.selectors';
-import { fetchFolderContentThunk } from 'app/store/slices/storage/storage.thunks/fetchFolderContentThunk';
+import { fetchDialogContentThunk } from 'app/store/slices/storage/storage.thunks/fetchDialogContentThunk';
 import Spinner from 'app/shared/components/Spinner/Spinner';
 import Button from 'app/shared/components/Button/Button';
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
@@ -81,10 +81,9 @@ const MoveItemsDialog = (props: MoveItemsDialogProps): JSX.Element => {
   }, [newFolderIsOpen]);
 
   const onShowFolderContentClicked = (folderId: number, name: string): void => {
-    dispatch(fetchFolderContentThunk(folderId))
+    dispatch(fetchDialogContentThunk(folderId))
       .unwrap()
       .then(() => {
-        setIsLoading(true);
         databaseService.get(DatabaseCollection.Levels, folderId).then((items) => {
           setCurrentFolderId(folderId);
           setCurrentFolderName(name);
@@ -118,7 +117,6 @@ const MoveItemsDialog = (props: MoveItemsDialogProps): JSX.Element => {
             setCurrentFolderId(folderId);
             setCurrentFolderName(name);
           }
-          setIsLoading(false);
         });
       });
   };
@@ -247,13 +245,7 @@ const MoveItemsDialog = (props: MoveItemsDialogProps): JSX.Element => {
                 onAccept(destinationId ? destinationId : currentFolderId, currentFolderName, currentNamePaths)
               }
             >
-              {isLoading
-                ? !props.isTrash
-                  ? translate('actions.moving')
-                  : translate('actions.navigating')
-                : !props.isTrash
-                ? translate('actions.move')
-                : translate('actions.restoreHere')}
+              {!props.isTrash ? translate('actions.move') : translate('actions.restoreHere')}
             </Button>
           </div>
         </div>

--- a/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
+++ b/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
@@ -68,9 +68,10 @@ const MoveItemsDialog = (props: MoveItemsDialogProps): JSX.Element => {
 
   useEffect(() => {
     if (isOpen) {
+      setIsLoading(true);
       setCurrentNamePaths([]);
-
       onShowFolderContentClicked(props.parentFolderId ?? rootFolderID, 'Drive');
+      setIsLoading(false);
     }
   }, [isOpen]);
 

--- a/src/app/store/slices/storage/storage.thunks/fetchDialogContentThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/fetchDialogContentThunk.ts
@@ -46,7 +46,6 @@ export const fetchDialogContentThunk = createAsyncThunk<void, number, { state: R
 
 export const fetchDialogContentThunkExtraReducers = (builder: ActionReducerMapBuilder<StorageState>): void => {
   builder.addCase(fetchDialogContentThunk.rejected, (state, action) => {
-    state.loadingFolders[action.meta.arg] = false;
     notificationsService.show({ text: t('error.fetchingFolderContent'), type: ToastType.Error });
   });
 };

--- a/src/app/store/slices/storage/storage.thunks/fetchDialogContentThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/fetchDialogContentThunk.ts
@@ -1,0 +1,52 @@
+import { ActionReducerMapBuilder, createAsyncThunk } from '@reduxjs/toolkit';
+import _ from 'lodash';
+
+import { storageActions } from '..';
+import { RootState } from '../../..';
+import { StorageState } from '../storage.model';
+import notificationsService, { ToastType } from '../../../../notifications/services/notifications.service';
+import databaseService, { DatabaseCollection } from '../../../../database/services/database.service';
+import { DriveItemData } from '../../../../drive/types';
+import { SdkFactory } from '../../../../core/factory/sdk';
+import { t } from 'i18next';
+
+export const fetchDialogContentThunk = createAsyncThunk<void, number, { state: RootState }>(
+  'storage/fetchDialogContentThunk',
+  async (folderId, { dispatch }) => {
+    const storageClient = SdkFactory.getInstance().createStorageClient();
+    const [responsePromise] = storageClient.getFolderContent(folderId);
+    const databaseContent = await databaseService.get<DatabaseCollection.Levels>(DatabaseCollection.Levels, folderId);
+
+    dispatch(storageActions.resetOrder());
+
+    if (databaseContent) {
+      dispatch(
+        storageActions.setItems({
+          folderId,
+          items: databaseContent,
+        }),
+      );
+    } else {
+      await responsePromise;
+    }
+
+    responsePromise.then((response) => {
+      const folders = response.children.map((folder) => ({ ...folder, isFolder: true }));
+      const items = _.concat(folders as DriveItemData[], response.files as DriveItemData[]);
+      dispatch(
+        storageActions.setItems({
+          folderId,
+          items,
+        }),
+      );
+      databaseService.put(DatabaseCollection.Levels, folderId, items);
+    });
+  },
+);
+
+export const fetchDialogContentThunkExtraReducers = (builder: ActionReducerMapBuilder<StorageState>): void => {
+  builder.addCase(fetchDialogContentThunk.rejected, (state, action) => {
+    state.loadingFolders[action.meta.arg] = false;
+    notificationsService.show({ text: t('error.fetchingFolderContent'), type: ToastType.Error });
+  });
+};


### PR DESCRIPTION
Fixed some details that affected the UX when displaying the move item modal:

- Now it is avoided that when opening the modal the list of items is reloaded.
- Double clicking on the folders inside the modal navigates to that folder.
- Navigating to a folder in the modal does not reload the breadcrumb.
- Do not change the content of the 'move' button.
- Finally, the reloading of the folder list when closing the 'New folder' option has been avoided.
