### PR TITLE
[WT-375]  bugfix/Download desktop app popup appears too soon

### DIFF
--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -70,6 +70,8 @@ import { Tutorial } from '../../../shared/components/Tutorial/Tutorial';
 import { userSelectors } from '../../../store/slices/user';
 import localStorageService, { STORAGE_KEYS } from '../../../core/services/local-storage.service';
 import { getSignUpSteps } from '../../../shared/components/Tutorial/signUpSteps';
+import { useTaskManagerGetNotifications } from '../../../tasks/hooks';
+import { TaskStatus } from '../../../tasks/types';
 
 const PAGINATION_LIMIT = 50;
 const TRASH_PAGINATION_OFFSET = 50;
@@ -153,8 +155,24 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
     setCurrentTutorialStep(currentTutorialStep + 1);
   };
 
+  const isSignUpTutorialCompleted = localStorageService.getIsSignUpTutorialCompleted();
+  const successNotifications = useTaskManagerGetNotifications({
+    status: [TaskStatus.Success],
+  });
+
+  const [showSecondTutorialStep, setShowSecondTutorialStep] = useState(false);
+
+  useEffect(() => {
+    if (!isSignUpTutorialCompleted && currentTutorialStep === 1 && successNotifications.length > 0) {
+      setShowSecondTutorialStep(true);
+    }
+  }, [successNotifications]);
+
   const showTutorial =
-    useAppSelector(userSelectors.hasSignedToday) && !localStorageService.getIsSignUpTutorialCompleted();
+    useAppSelector(userSelectors.hasSignedToday) &&
+    !isSignUpTutorialCompleted &&
+    (showSecondTutorialStep || currentTutorialStep === 0);
+
   const stepOneTutorialRef = useRef(null);
   const signupSteps = getSignUpSteps(
     {


### PR DESCRIPTION
- Added that second step of onboarding is displayed only when a file is uploaded successfully