### PR TITLE
[PB-465]: bugfix/Wrong error message max file size, simply correct 1GB to 10GB in text

### DIFF
--- a/src/app/i18n/locales/cn.json
+++ b/src/app/i18n/locales/cn.json
@@ -621,7 +621,8 @@
     "emptyPassword": "Previous password must not be empty",
     "errorMovingToTrash": "An error occurred while moving the items to trash.",
     "errorDeletingFromTrash": "An error occurred while deleting the items from trash.",
-    "braveNotSupportMultiplePhotosDowload": "Brave doesn't support multiple photo downloads."
+    "braveNotSupportMultiplePhotosDowload": "Brave doesn't support multiple photo downloads.",
+    "maxSizeUploadLimitError": "File too large.\nYou can only upload or download files of up to 10GB through the web app"
   },
   "backups": {
     "backups-from": "来自 {{deviceName}} 的备份",

--- a/src/app/i18n/locales/cn.json
+++ b/src/app/i18n/locales/cn.json
@@ -622,7 +622,7 @@
     "errorMovingToTrash": "An error occurred while moving the items to trash.",
     "errorDeletingFromTrash": "An error occurred while deleting the items from trash.",
     "braveNotSupportMultiplePhotosDowload": "Brave doesn't support multiple photo downloads.",
-    "maxSizeUploadLimitError": "File too large.\nYou can only upload or download files of up to 10GB through the web app"
+    "maxSizeUploadLimitError": "File too large (greater than 10GB)"
   },
   "backups": {
     "backups-from": "来自 {{deviceName}} 的备份",

--- a/src/app/i18n/locales/en.json
+++ b/src/app/i18n/locales/en.json
@@ -627,7 +627,8 @@
     "emptyPassword": "Previous password must not be empty",
     "errorMovingToTrash": "An error occurred while moving the items to trash.",
     "errorDeletingFromTrash": "An error occurred while deleting the items from trash.",
-    "braveNotSupportMultiplePhotosDowload": "Brave doesn't support multiple photo downloads."
+    "braveNotSupportMultiplePhotosDowload": "Brave doesn't support multiple photo downloads.",
+    "maxSizeUploadLimitError": "File too large.\nYou can only upload or download files of up to 10GB through the web app"
   },
   "backups": {
     "backups-from": "Backups from {{deviceName}}",

--- a/src/app/i18n/locales/en.json
+++ b/src/app/i18n/locales/en.json
@@ -628,7 +628,7 @@
     "errorMovingToTrash": "An error occurred while moving the items to trash.",
     "errorDeletingFromTrash": "An error occurred while deleting the items from trash.",
     "braveNotSupportMultiplePhotosDowload": "Brave doesn't support multiple photo downloads.",
-    "maxSizeUploadLimitError": "File too large.\nYou can only upload or download files of up to 10GB through the web app"
+    "maxSizeUploadLimitError": "File too large (greater than 10GB)"
   },
   "backups": {
     "backups-from": "Backups from {{deviceName}}",

--- a/src/app/i18n/locales/es.json
+++ b/src/app/i18n/locales/es.json
@@ -610,7 +610,7 @@
     "errorMovingToTrash": "Ha ocurrido un error mientras se movian los items a la basura.",
     "errorDeletingFromTrash": "Ha ocurrido un error mientras se eliminaban los items de la basura.",
     "braveNotSupportMultiplePhotosDowload": "Brave no admite la descarga multiple de fotos.",
-    "maxSizeUploadLimitError": "File too large.\nYou can only upload or download files of up to 10GB through the web app"
+    "maxSizeUploadLimitError": "File too large (greater than 10GB)"
   },
   "backups": {
     "backups-from": "Copias de seguridad de {{deviceName}}",

--- a/src/app/i18n/locales/es.json
+++ b/src/app/i18n/locales/es.json
@@ -609,7 +609,8 @@
     "emptyPassword": "La contraseña no puede estar vacía.",
     "errorMovingToTrash": "Ha ocurrido un error mientras se movian los items a la basura.",
     "errorDeletingFromTrash": "Ha ocurrido un error mientras se eliminaban los items de la basura.",
-    "braveNotSupportMultiplePhotosDowload": "Brave no admite la descarga multiple de fotos."
+    "braveNotSupportMultiplePhotosDowload": "Brave no admite la descarga multiple de fotos.",
+    "maxSizeUploadLimitError": "File too large.\nYou can only upload or download files of up to 10GB through the web app"
   },
   "backups": {
     "backups-from": "Copias de seguridad de {{deviceName}}",

--- a/src/app/i18n/locales/fr.json
+++ b/src/app/i18n/locales/fr.json
@@ -563,7 +563,7 @@
     "emptyPassword": "Previous password must not be empty",
     "errorMovingToTrash": "Error lors du déplacement des éléments.",
     "braveNotSupportMultiplePhotosDowload": "Brave doesn't support multiple photo downloads.",
-    "maxSizeUploadLimitError": "File too large.\nYou can only upload or download files of up to 10GB through the web app"
+    "maxSizeUploadLimitError": "File too large (greater than 10GB)"
   },
   "backups": {
     "backups-from": "Sauvagardes de {{deviceName}}",

--- a/src/app/i18n/locales/fr.json
+++ b/src/app/i18n/locales/fr.json
@@ -562,7 +562,8 @@
     "incorrectPassword": "The current password you introduce doesn't match. Please make sure it is correct.",
     "emptyPassword": "Previous password must not be empty",
     "errorMovingToTrash": "Error lors du déplacement des éléments.",
-    "braveNotSupportMultiplePhotosDowload": "Brave doesn't support multiple photo downloads."
+    "braveNotSupportMultiplePhotosDowload": "Brave doesn't support multiple photo downloads.",
+    "maxSizeUploadLimitError": "File too large.\nYou can only upload or download files of up to 10GB through the web app"
   },
   "backups": {
     "backups-from": "Sauvagardes de {{deviceName}}",

--- a/src/app/i18n/locales/it.json
+++ b/src/app/i18n/locales/it.json
@@ -621,7 +621,7 @@
     "errorMovingToTrash": "An error occurred while moving the items to trash.",
     "errorDeletingFromTrash": "An error occurred while deleting the items from trash.",
     "braveNotSupportMultiplePhotosDowload": "Brave doesn't support multiple photo downloads.",
-    "maxSizeUploadLimitError": "File too large.\nYou can only upload or download files of up to 10GB through the web app"
+    "maxSizeUploadLimitError": "File too large (greater than 10GB)"
   },
   "backups": {
     "backups-from": "Backup da {{deviceName}}",

--- a/src/app/i18n/locales/it.json
+++ b/src/app/i18n/locales/it.json
@@ -620,7 +620,8 @@
     "emptyPassword": "Previous password must not be empty",
     "errorMovingToTrash": "An error occurred while moving the items to trash.",
     "errorDeletingFromTrash": "An error occurred while deleting the items from trash.",
-    "braveNotSupportMultiplePhotosDowload": "Brave doesn't support multiple photo downloads."
+    "braveNotSupportMultiplePhotosDowload": "Brave doesn't support multiple photo downloads.",
+    "maxSizeUploadLimitError": "File too large.\nYou can only upload or download files of up to 10GB through the web app"
   },
   "backups": {
     "backups-from": "Backup da {{deviceName}}",

--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
@@ -74,7 +74,7 @@ export const uploadItemsThunk = createAsyncThunk<void, UploadItemsPayload, { sta
 
     if (showSizeWarning) {
       notificationsService.show({
-        text: 'File too large.\nYou can only upload or download files of up to 1GB through the web app',
+        text: t('error.maxSizeUploadLimitError'),
         type: ToastType.Warning,
       });
       return;
@@ -165,7 +165,7 @@ export const uploadItemsThunkNoCheck = createAsyncThunk<void, UploadItemsPayload
 
     if (showSizeWarning) {
       notificationsService.show({
-        text: 'File too large.\nYou can only upload or download files of up to 1GB through the web app',
+        text: t('error.maxSizeUploadLimitError'),
         type: ToastType.Warning,
       });
       return;
@@ -254,7 +254,7 @@ export const uploadItemsParallelThunk = createAsyncThunk<void, UploadItemsPayloa
 
     if (showSizeWarning) {
       notificationsService.show({
-        text: 'File too large.\nYou can only upload or download files of up to 1GB through the web app',
+        text: t('error.maxSizeUploadLimitError'),
         type: ToastType.Warning,
       });
       return;
@@ -339,7 +339,7 @@ export const uploadItemsParallelThunkNoCheck = createAsyncThunk<void, UploadItem
 
     if (showSizeWarning) {
       notificationsService.show({
-        text: 'File too large.\nYou can only upload or download files of up to 1GB through the web app',
+        text: t('error.maxSizeUploadLimitError'),
         type: ToastType.Warning,
       });
       return;


### PR DESCRIPTION
- Changed the warning text when uploading files over the actual limit (10GB).