### PR TITLE
[PB-472]: feat/add url and history navigation to drive folders

### DIFF
--- a/src/app/core/config/app.json
+++ b/src/app/core/config/app.json
@@ -103,6 +103,13 @@
       "hideSearch": true
     },
     {
+      "id": "drive-item",
+      "layout": "header-and-sidenav",
+      "path": "/app/:name/:id",
+      "exact": false,
+      "auth": true
+    },
+    {
       "id": "preferences",
       "layout": "header-and-sidenav",
       "path": "/preferences",

--- a/src/app/core/config/views.ts
+++ b/src/app/core/config/views.ts
@@ -46,6 +46,7 @@ const views: Array<{
   { id: AppView.ButtonAuth, component: ButtonAuth },
   { id: AppView.Recover, component: RecoverView },
   { id: AppView.Drive, component: DriveView },
+  { id: AppView.DriveItem, component: DriveView },
   { id: AppView.Recents, component: RecentsView },
   { id: AppView.Trash, component: TrashView },
   { id: AppView.Backups, component: BackupsView },

--- a/src/app/core/types.ts
+++ b/src/app/core/types.ts
@@ -111,6 +111,7 @@ export enum AppView {
   ButtonAuth = 'buttonAuth',
   Recover = 'recover',
   Drive = 'drive',
+  DriveItem = 'drive-item',
   Recents = 'recents',
   Trash = 'trash',
   Backups = 'backups',

--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -194,6 +194,19 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
     },
   );
 
+  const currentUrl = window.location.pathname;
+
+  useEffect(() => {
+    const splitUrl = currentUrl.split('/');
+    const pathUrl = splitUrl.slice(-2);
+    const isANumber = /^\d+$/;
+    if (isANumber.test(pathUrl[1])) {
+      const folderName = pathUrl[0];
+      const folderId = Number(pathUrl[1]);
+      dispatch(storageThunks.goToFolderThunk({ name: folderName, id: folderId }));
+    }
+  }, [currentUrl]);
+
   useEffect(() => {
     if (!isSignUpTutorialCompleted && currentTutorialStep === 1 && successNotifications.length > 0) {
       setShowSecondTutorialStep(true);

--- a/src/app/drive/components/DriveExplorer/DriveExplorerItem/hooks/useDriveItemActions.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerItem/hooks/useDriveItemActions.tsx
@@ -185,6 +185,7 @@ const useDriveItemActions = (item: DriveItemData): DriveItemActions => {
 
   const onItemDoubleClicked = (): void => {
     if (item.isFolder) {
+      window.history.pushState(null, '', `/app/${item.name}/${item.id}`);
       dispatch(storageThunks.goToFolderThunk({ name: item.name, id: item.id }));
     } else {
       dispatch(uiActions.setIsFileViewerOpen(true));

--- a/src/app/shared/components/Breadcrumbs/BreadcrumbsItem/BreadcrumbsItem.tsx
+++ b/src/app/shared/components/Breadcrumbs/BreadcrumbsItem/BreadcrumbsItem.tsx
@@ -140,6 +140,7 @@ const BreadcrumbsItem = (props: BreadcrumbsItemProps): JSX.Element => {
   );
   const onItemClicked = (item: BreadcrumbItemData): void => {
     dispatch(uiActions.setCurrentEditingBreadcrumbNameDirty(''));
+    window.history.pushState(null, '', `/app/${item.label}/${item.id}`);
     if (item.active) {
       item.onClick && item.onClick();
     }


### PR DESCRIPTION
- Users can navigate between drive folders using the back and forward navigation keys.
- Users can access a folder directly by URL