### PR TITLE
[PB-500]: fix/Usage problem when changing accounts

### DIFF
--- a/src/app/auth/components/SignUp/SignUp.tsx
+++ b/src/app/auth/components/SignUp/SignUp.tsx
@@ -161,6 +161,7 @@ function SignUp(props: SignUpProps): JSX.Element {
 
       localStorageService.removeItem(STORAGE_KEYS.SIGN_UP_TUTORIAL_COMPLETED);
 
+      localStorageService.clear();
       localStorageService.set('xToken', xToken);
       localStorageService.set('xMnemonic', mnemonic);
 


### PR DESCRIPTION
When logging in to an account with synced photos and doing the same in another tab creating a new account:
- Fixes that the new account shows pictures from the other account (as they are cached)
- Fixes usage of the old account being shown