### PR TITLE
[PB-593] fix/update file restored notification

### DIFF
--- a/src/app/i18n/locales/cn.json
+++ b/src/app/i18n/locales/cn.json
@@ -925,7 +925,7 @@
     "copyLink": "复制链接到剪贴板",
     "linkUpdated": "链接已更新",
     "itemsMovedToTrash": "{{item}} 已被移至回收站",
-    "restoreItems": "{{itemsToRecover}} 已移动到 {{destination}}",
+    "restoreItems": "{{itemsToRecover}} 成功恢復",
     "itemDeleted": "{{item}} 已删除",
     "itemsDeleted": "文件已删除",
     "emailNotEmpty": "电子邮件不能为空",

--- a/src/app/i18n/locales/en.json
+++ b/src/app/i18n/locales/en.json
@@ -931,7 +931,7 @@
     "copyLink": "Shared link copied to clipboard",
     "linkUpdated": "Link updated",
     "itemsMovedToTrash": "{{item}} moved to trash",
-    "restoreItems": "{{itemsToRecover}} moved to {{destination}}",
+    "restoreItems": "{{itemsToRecover}} restored successfully",
     "itemDeleted": "{{item}} deleted",
     "itemsDeleted": "Files deleted",
     "emailNotEmpty": "Email must not be empty",

--- a/src/app/i18n/locales/es.json
+++ b/src/app/i18n/locales/es.json
@@ -898,7 +898,7 @@
     "copyLink": "Enlace copiado al portapapeles",
     "linkUpdated": "Enlace actualizado",
     "itemsMovedToTrash": "{{item}} movid{{s}} a la papelera",
-    "restoreItems": "{{itemsToRecover}} movid{{s}} a {{destination}}",
+    "restoreItems": "{{itemsToRecover}} restaurad{{s}} con éxito",
     "itemDeleted": "{{item}} eliminado",
     "itemsDeleted": "Archivos eliminados",
     "emailNotEmpty": "El correo no debe estar vacío",

--- a/src/app/i18n/locales/fr.json
+++ b/src/app/i18n/locales/fr.json
@@ -867,7 +867,7 @@
     "copyLink": "Copier le lien dans le presse-papiers",
     "linkUpdated": "Lien mis à jour",
     "itemsMovedToTrash": "{{item}} déplacé vers la corbeille",
-    "restoreItems": "{{itemsToRecover}} déplacé vers {{destination}}",
+    "restoreItems": "{{itemsToRecover}} restauré avec succès",
     "itemDeleted": "{{itemsToDelete}} supprimé",
     "itemsDeleted": "Fichiers supprimés",
     "emailNotEmpty": "L'adresse électronique ne doit pas être vide",

--- a/src/app/i18n/locales/it.json
+++ b/src/app/i18n/locales/it.json
@@ -924,7 +924,7 @@
     "copyLink": "Link condiviso copiato negli appunti",
     "linkUpdated": "Link aggiornato",
     "itemsMovedToTrash": "{{item}} spostati nel cestino",
-    "restoreItems": "{{itemsToRecover}} spostato a {{destination}}",
+    "restoreItems": "{{itemsToRecover}} ripristinato correttamente",
     "itemDeleted": "{{item}} eliminate",
     "itemsDeleted": "File eliminati",
     "emailNotEmpty": "L'e-mail non deve essere vuota",

--- a/src/app/i18n/locales/ru.json
+++ b/src/app/i18n/locales/ru.json
@@ -854,7 +854,7 @@
     "copyLink": "Ссылка с общим доступом скопирована в буфер обмена",
     "linkUpdated": "Ссылка обновлена",
     "itemsMovedToTrash": "{{item}} перемещен в корзину",
-    "restoreItems": "{{itemsToRecover}} перемещен в {{destination}}",
+    "restoreItems": "{{itemsToRecover}} успешно восстановлено",
     "itemDeleted": "{{item}} удален",
     "itemsDeleted": "Файлы удалены",
     "emailNotEmpty": "Поле электронной почты не должно быть пустым",

--- a/src/use_cases/trash/recover-items-from-trash.ts
+++ b/src/use_cases/trash/recover-items-from-trash.ts
@@ -102,7 +102,7 @@ async function afterMoving(
     store.dispatch(storageActions.popItemsToDelete(itemsToRecover));
     store.dispatch(storageActions.clearSelectedItems());
 
-    const toastText = !itemsToRecover[0].deleted
+    const toastText = itemsToRecover[0].deleted
       ? t('notificationMessages.restoreItems', {
           itemsToRecover:
             itemsToRecover.length > 1
@@ -111,7 +111,6 @@ async function afterMoving(
               ? t('general.folder')
               : t('general.file'),
           s: itemsToRecover.length > 1 ? 'os' : itemsToRecover[0].isFolder ? 'a' : 'o',
-          destination: destinationLevelDatabaseContent?.[0].name,
         })
       : t('notificationMessages.itemsMovedToTrash', {
           item:


### PR DESCRIPTION
- Updated notification message over retore items
- Fix logic to restore deleted item
- details:
When restored deleted items were displayed, an incorrect message called "itemsMovedToTrash" was shown. It has been changed to the message "restoreItems."