### PR TITLE
[PB-714]: Feat/preview videos

### DIFF
--- a/src/app/core/services/media.service.ts
+++ b/src/app/core/services/media.service.ts
@@ -1,5 +1,5 @@
 import { binaryStreamToBlob } from './stream.service';
-import { VideoExtensions, AudioExtensions, videoExtensions } from '../../drive/types/file-types';
+import { VideoExtensions, AudioExtensions, videoExtensions, audioExtensions } from '../../drive/types/file-types';
 import { DriveFileData } from 'app/drive/types';
 
 type VideoTypes = Record<keyof VideoExtensions, string>;
@@ -24,13 +24,17 @@ export function isTypeSupportedByAudioPlayer(type: keyof AudioExtensions): boole
   return Object.keys(audioTypes).includes(type);
 }
 
-export function isLargeVideo(size: number): boolean {
+export function isLargeFile(size: number): boolean {
   return size < 100 * 1024 * 1024;
 }
 
-export const isVideoExtension: string[] = Object.values(videoExtensions).flatMap((extensions) => {
-  return extensions.flat();
-});
+export const isMediaExtension: string[] =
+  Object.values(videoExtensions).flatMap((extensions) => {
+    return extensions.flat();
+  }) ||
+  Object.values(audioExtensions).flatMap((extensions) => {
+    return extensions.flat();
+  });
 
 export async function loadVideoIntoPlayer(
   videoPlayer: HTMLVideoElement,

--- a/src/app/core/services/media.service.ts
+++ b/src/app/core/services/media.service.ts
@@ -1,5 +1,6 @@
 import { binaryStreamToBlob } from './stream.service';
-import { VideoExtensions, AudioExtensions } from '../../drive/types/file-types';
+import { VideoExtensions, AudioExtensions, videoExtensions } from '../../drive/types/file-types';
+import { DriveFileData } from 'app/drive/types';
 
 type VideoTypes = Record<keyof VideoExtensions, string>;
 type AudioTypes = Record<keyof AudioExtensions, string>;
@@ -12,7 +13,7 @@ const videoTypes: Partial<VideoTypes> = {
 const audioTypes: Partial<AudioTypes> = {
   mp3: 'audio/mp3',
   wav: 'audio/wav',
-  ogg: 'audio/ogg'
+  ogg: 'audio/ogg',
 };
 
 export function isTypeSupportedByVideoPlayer(type: keyof VideoExtensions): boolean {
@@ -22,6 +23,14 @@ export function isTypeSupportedByVideoPlayer(type: keyof VideoExtensions): boole
 export function isTypeSupportedByAudioPlayer(type: keyof AudioExtensions): boolean {
   return Object.keys(audioTypes).includes(type);
 }
+
+export function isLargeVideo(size: number): boolean {
+  return size < 100 * 1024 * 1024;
+}
+
+export const isVideoExtension: string[] = Object.values(videoExtensions).flatMap((extensions) => {
+  return extensions.flat();
+});
 
 export async function loadVideoIntoPlayer(
   videoPlayer: HTMLVideoElement,

--- a/src/app/drive/components/FileViewer/FileViewer.tsx
+++ b/src/app/drive/components/FileViewer/FileViewer.tsx
@@ -16,13 +16,12 @@ import ShareItemDialog from 'app/share/components/ShareItemDialog/ShareItemDialo
 import { RootState } from 'app/store';
 import { uiActions } from 'app/store/slices/ui';
 import { setItemsToMove, storageActions } from '../../../store/slices/storage';
-import { isTypeSupportedByVideoPlayer } from 'app/core/services/media.service';
 
 interface FileViewerProps {
   file?: DriveFileData;
   onClose: () => void;
   onDownload: () => void;
-  downloader: (abortController: AbortController) => Promise<Blob>;
+  downloader: (abortController: AbortController) => Promise<Blob | undefined>;
   show: boolean;
   progress?: number;
   setCurrentFile?: (file: DriveFileData) => void;
@@ -193,6 +192,10 @@ const FileViewer = ({
     if (show && isTypeAllowed) {
       downloader(new AbortController())
         .then((blob) => {
+          if (!blob) {
+            setIsErrorWhileDownloading(true);
+            return;
+          }
           setBlob(blob);
           setIsErrorWhileDownloading(false);
         })

--- a/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
+++ b/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
@@ -24,7 +24,7 @@ import {
 import { Thumbnail } from '@internxt/sdk/dist/drive/storage/types';
 import { FileToUpload } from 'app/drive/services/file.service/uploadFile';
 import localStorageService from 'app/core/services/local-storage.service';
-import { isLargeVideo, isVideoExtension } from 'app/core/services/media.service';
+import { isLargeFile, isMediaExtension } from 'app/core/services/media.service';
 
 interface FileViewerWrapperProps {
   file: DriveFileData;
@@ -118,13 +118,13 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
     return {
       download: async (): Promise<Blob | undefined> => {
         const shouldFileBeCached = canFileBeCached(currentFile);
-        const canVideoBePlayed =
-          isVideoExtension.includes(currentFile.type.toLowerCase()) && isLargeVideo(currentFile.size);
+        const canMediaBePlayed =
+          isMediaExtension.includes(currentFile.type.toLowerCase()) && isLargeFile(currentFile.size);
         const fileSource = await getDatabaseFileSourceData({ fileId: currentFile.id });
         const isCached = !!fileSource;
         let fileContent: Blob;
 
-        if (!canVideoBePlayed) {
+        if (!canMediaBePlayed) {
           return;
         }
 

--- a/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
+++ b/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
@@ -5,8 +5,7 @@ import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import FileViewer from './FileViewer';
 import { sessionSelectors } from '../../../store/slices/session/session.selectors';
 import downloadService from '../../services/download.service';
-import { useEffect, useState } from 'react';
-import { isTypeSupportedByVideoPlayer } from '../../../core/services/media.service';
+import { useState } from 'react';
 import {
   getDatabaseFileSourceData,
   getDatabaseFilePrewiewData,
@@ -21,11 +20,11 @@ import {
   setCurrentThumbnail,
   setThumbnails,
   ThumbnailToUpload,
-  uploadThumbnail,
 } from 'app/drive/services/thumbnail.service';
 import { Thumbnail } from '@internxt/sdk/dist/drive/storage/types';
 import { FileToUpload } from 'app/drive/services/file.service/uploadFile';
 import localStorageService from 'app/core/services/local-storage.service';
+import { isLargeVideo, isVideoExtension } from 'app/core/services/media.service';
 
 interface FileViewerWrapperProps {
   file: DriveFileData;
@@ -117,11 +116,17 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
     const abortController = new AbortController();
 
     return {
-      download: async (): Promise<Blob> => {
+      download: async (): Promise<Blob | undefined> => {
         const shouldFileBeCached = canFileBeCached(currentFile);
+        const canVideoBePlayed =
+          isVideoExtension.includes(currentFile.type.toLowerCase()) && isLargeVideo(currentFile.size);
         const fileSource = await getDatabaseFileSourceData({ fileId: currentFile.id });
         const isCached = !!fileSource;
         let fileContent: Blob;
+
+        if (!canVideoBePlayed) {
+          return;
+        }
 
         if (isCached) {
           const isCacheExpired = !fileSource?.updatedAt

--- a/src/app/drive/components/FileViewer/viewers/FileVideoViewer/FileVideoViewer.tsx
+++ b/src/app/drive/components/FileViewer/viewers/FileVideoViewer/FileVideoViewer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { DriveFileData } from '@internxt/sdk/dist/drive/storage/types';
 
 const FileVideoViewer = ({
+  file,
   blob,
 }: {
   file: DriveFileData;

--- a/src/app/drive/components/FileViewer/viewers/index.tsx
+++ b/src/app/drive/components/FileViewer/viewers/index.tsx
@@ -8,6 +8,6 @@ const FileAudioViewer = lazy(() => import('./FileAudioViewer/FileAudioViewer'));
 export default {
   [FileExtensionGroup.Image]: FileImageViewer,
   [FileExtensionGroup.Pdf]: FilePdfViewer,
-  // [FileExtensionGroup.Video]: FileVideoViewer,
+  [FileExtensionGroup.Video]: FileVideoViewer,
   [FileExtensionGroup.Audio]: FileAudioViewer,
 };

--- a/src/app/drive/services/file-extension.service.ts
+++ b/src/app/drive/services/file-extension.service.ts
@@ -17,12 +17,10 @@ function computeExtensionsLists(
   return extensionsLists as Record<FileExtensionGroup, string[]>;
 }
 
-function computeExtensionsList(groupId: FileExtensionGroup, filter: string[]): string[] {
-  return Object.entries(fileExtensionGroups[groupId])
-    .filter(([formatKey]) => !filter || filter.includes(formatKey))
-    .reduce((t, [, formatExtensions]): string[] => {
-      return t.concat(formatExtensions);
-    }, [] as string[]);
+function computeExtensionsList(groupId: FileExtensionGroup, filter: string[] = []): string[] {
+  return Object.values(fileExtensionGroups[groupId])
+    .reduce((acc, formatExtensions) => acc.concat(formatExtensions), [])
+    .filter((extension) => !filter || filter.includes(extension));
 }
 
 const fileExtensionService = {

--- a/src/app/drive/types/file-types.ts
+++ b/src/app/drive/types/file-types.ts
@@ -81,7 +81,7 @@ export interface AudioExtensions {
   cda: ['cda'];
 }
 
-const audioExtensions: FileExtensionMap = {
+export const audioExtensions: FileExtensionMap = {
   '3gp': ['3gp'],
   aa: ['aa'],
   aac: ['aac'],

--- a/src/app/drive/types/file-types.ts
+++ b/src/app/drive/types/file-types.ts
@@ -118,7 +118,7 @@ const audioExtensions: FileExtensionMap = {
   wav: ['wav'],
   wma: ['wma'],
   wv: ['wv'],
-  webm: ['webm'],
+  weba: ['weba'],
   '8svx': ['8svx'],
   cda: ['cda'],
 };
@@ -182,7 +182,7 @@ const txtExtensions: FileExtensionMap = {
   txt: ['txt', 'text', 'conf', 'def', 'list', 'log', 'md', 'lock'],
 };
 
-const videoExtensions: FileExtensionMap = {
+export const videoExtensions: FileExtensionMap = {
   webm: ['webm'],
   mkv: ['mkv'],
   vob: ['vob'],
@@ -210,9 +210,44 @@ const videoExtensions: FileExtensionMap = {
   flv: ['flv', 'f4v', 'f4p', 'f4a', 'f4b'],
 };
 
-const previewVideoExtensionsGroup: string[] = Object.values(videoExtensions).flatMap((extensions) => {
-  return extensions.flat();
-});
+const excludeUnsupportedVideoExtensions: string[] = [
+  'mkv',
+  'vob',
+  'ogv',
+  'ogg',
+  'drc',
+  'avi',
+  'mts',
+  'm2ts',
+  'qt',
+  'wmv',
+  'yuv',
+  'rm',
+  'rmvb',
+  'viv',
+  'asf',
+  'amv',
+  'm4p',
+  'mpg',
+  'mp2',
+  'mpe',
+  'mpv',
+  'mpeg',
+  'm2v',
+  'svi',
+  '3g2',
+  'mxf',
+  'roq',
+  'nsv',
+  'flv',
+  'f4p',
+  'f4a',
+  'f4b',
+];
+
+const previewVideoExtensionsGroup: string[] = Object.values(videoExtensions)
+  .flatMap((extensions) => extensions.flat())
+  .filter((extension) => !excludeUnsupportedVideoExtensions.includes(extension));
 
 const excludeUnsupportedAudioExtensions: string[] = [
   'aa',
@@ -225,6 +260,7 @@ const excludeUnsupportedAudioExtensions: string[] = [
   'au',
   'awd',
   'dss',
+  '3gp',
   'dvf',
   'gsm',
   'iklax',

--- a/src/app/drive/types/file-types.ts
+++ b/src/app/drive/types/file-types.ts
@@ -214,7 +214,7 @@ const previewVideoExtensionsGroup: string[] = Object.values(videoExtensions).fla
   return extensions.flat();
 });
 
-const exludeUnsupportedAudioExtensions: string[] = [
+const excludeUnsupportedAudioExtensions: string[] = [
   'aa',
   'aax',
   'act',
@@ -251,7 +251,7 @@ const exludeUnsupportedAudioExtensions: string[] = [
 
 const previewAudioExtensionsGroup: string[] = Object.values(audioExtensions)
   .flatMap((extensions) => extensions.flat())
-  .filter((extension) => !exludeUnsupportedAudioExtensions.includes(extension));
+  .filter((extension) => !excludeUnsupportedAudioExtensions.includes(extension));
 
 const WordExtensions: FileExtensionMap = {
   doc: ['doc', 'docx'],


### PR DESCRIPTION
Now you can preview video files up to 100MB on Drive, supported video extensions are:
- 3gp
- m4v
- mp4
- mov
- webm
- f4v
