### PR TITLE
[PB-593] fix/update restored notification

### DIFF
--- a/src/use_cases/trash/recover-items-from-trash.ts
+++ b/src/use_cases/trash/recover-items-from-trash.ts
@@ -102,25 +102,16 @@ async function afterMoving(
     store.dispatch(storageActions.popItemsToDelete(itemsToRecover));
     store.dispatch(storageActions.clearSelectedItems());
 
-    const toastText = itemsToRecover[0].deleted
-      ? t('notificationMessages.restoreItems', {
-          itemsToRecover:
-            itemsToRecover.length > 1
-              ? t('general.files')
-              : itemsToRecover[0].isFolder
-              ? t('general.folder')
-              : t('general.file'),
-          s: itemsToRecover.length > 1 ? 'os' : itemsToRecover[0].isFolder ? 'a' : 'o',
-        })
-      : t('notificationMessages.itemsMovedToTrash', {
-          item:
-            itemsToRecover.length > 1
-              ? t('general.files')
-              : itemsToRecover[0].isFolder
-              ? t('general.folder')
-              : t('general.file'),
-          s: itemsToRecover.length > 1 ? 'os' : itemsToRecover[0].isFolder ? 'a' : 'o',
-        });
+    const toastText = t('notificationMessages.restoreItems', {
+      itemsToRecover:
+        itemsToRecover.length > 1
+          ? t('general.files')
+          : itemsToRecover[0].isFolder
+          ? t('general.folder')
+          : t('general.file'),
+      s: itemsToRecover.length > 1 ? 'os' : itemsToRecover[0].isFolder ? 'a' : 'o',
+    });
+
     notificationsService.show({
       type: ToastType.Success,
       text: toastText,


### PR DESCRIPTION
Issue: 
- In the case of restoring from the 'undo' button, the items still do not have the 'deleted' field set to true, so the notification 'moved to trash' is displayed.

Details:
- I removed the logic of checking if any item has the 'deleted' field set to true because the function used is called 'recoverItemsFromTrash,' which should always display the notification for successful restoration, this was done because I see that it is not necessary to display a notification of 'files moved to trash' when the function is dedicated to restoring from the trash, and this is working well.