### PR TITLE
[PB-734] fix/Folders show .folder extension at the end of the rename

### DIFF
--- a/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerGridItem/DriveExplorerGridItem.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerGridItem/DriveExplorerGridItem.tsx
@@ -5,6 +5,7 @@ import { items } from '@internxt/lib';
 
 import DriveItemDropdownActions from '../../../DriveItemDropdownActions/DriveItemDropdownActions';
 import iconService from '../../../../services/icon.service';
+import transformItemService from '../../../../../drive/services/item-transform.service';
 import useForceUpdate from '../../../../../core/hooks/useForceUpdate';
 import { DriveItemAction, DriveExplorerItemProps } from '..';
 import useDriveItemActions from '../hooks/useDriveItemActions';
@@ -60,7 +61,7 @@ const DriveExplorerGridItem = (props: DriveExplorerItemProps): JSX.Element => {
             onKeyDown={onNameEnterKeyDown}
             autoFocus
           />
-          <span className="ml-1">{item.type ? '.' + item.type : ''}</span>
+          <span className="ml-1">{transformItemService.showItemExtensionType(item)}</span>
         </div>
         <span
           data-test={`${item.isFolder ? 'folder' : 'file'}-name`}

--- a/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerListItem/DriveExplorerListItem.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerListItem/DriveExplorerListItem.tsx
@@ -4,6 +4,7 @@ import { items } from '@internxt/lib';
 import sizeService from '../../../../../drive/services/size.service';
 import dateService from '../../../../../core/services/date.service';
 import iconService from '../../../../services/icon.service';
+import transformItemService from '../../../../../drive/services/item-transform.service';
 import { DriveExplorerItemProps } from '..';
 import useDriveItemActions from '../hooks/useDriveItemActions';
 import { useDriveItemDrag, useDriveItemDrop } from '../hooks/useDriveItemDragAndDrop';
@@ -79,7 +80,7 @@ const DriveExplorerListItem = ({ item }: DriveExplorerItemProps): JSX.Element =>
               autoFocus
               name="fileName"
             />
-            <span className="ml-1">{item.type ? '.' + item.type : ''}</span>
+            <span className="ml-1">{transformItemService.showItemExtensionType(item)}</span>
           </div>
         )}
         <div className="file-list-item-name flex max-w-full items-center">

--- a/src/app/drive/services/item-transform.service.ts
+++ b/src/app/drive/services/item-transform.service.ts
@@ -1,0 +1,13 @@
+import { DriveItemData } from '../types';
+
+const showItemExtensionType = (item: DriveItemData) => {
+  const type = item?.type;
+  if (!type || type === 'folder') return '';
+  return '.' + type;
+};
+
+const transformItemService = {
+  showItemExtensionType,
+};
+
+export default transformItemService;


### PR DESCRIPTION
Issue:
- When rename the item, the item type was being displayed despite being a folder.
Detail:
- Added to show only the extension for items that are not folders when rename them.