### PR TITLE
[]: bugfix/file viewer bug

### DIFF
--- a/src/app/drive/components/FileViewer/FileViewer.tsx
+++ b/src/app/drive/components/FileViewer/FileViewer.tsx
@@ -192,7 +192,8 @@ const FileViewer = ({
 
   useEffect(() => {
     setIsErrorWhileDownloading(false);
-    const largeFile = isLargeFile(file.size);
+    const largeFile = isLargeFile(file?.size);
+
     if (show && isTypeAllowed) {
       if (
         (fileExtensionGroup === FileExtensionGroup.Audio && !largeFile) ||


### PR DESCRIPTION
- Added optional chaining operator in order to not crash FileViewer while it is loading the file item