### PR TITLE
[PB-741] - fix/File preview icons size are not consistent

### DIFF
--- a/src/app/drive/components/FileViewer/FileViewer.tsx
+++ b/src/app/drive/components/FileViewer/FileViewer.tsx
@@ -279,7 +279,9 @@ const FileViewer = ({
                         } outline-none pointer-events-none z-10 select-none flex-col items-center justify-center
                       rounded-xl font-medium`}
                       >
-                        <ItemIconComponent className="mr-3 flex" width={60} height={80} />
+                        <div className="flex h-9 w-9 items-center">
+                          <ItemIconComponent className="mr-3" width={32} height={32} />
+                        </div>
                         <span className="w-96 truncate text-center text-lg">{filename}</span>
                         <span className="text-white text-opacity-50">{translate('drive.loadingFile')}</span>
                         <div className="mt-8 h-1.5 w-56 rounded-full bg-white bg-opacity-25">
@@ -300,7 +302,9 @@ const FileViewer = ({
                       space-y-6 rounded-xl font-medium"
               >
                 <div className="flex flex-col items-center justify-center">
-                  <ItemIconComponent className="flex" width={80} height={80} />
+                  <div className="flex h-9 w-9 items-center">
+                    <ItemIconComponent className="mr-3" width={32} height={32} />
+                  </div>
                   <span className="w-96 truncate pt-2 text-center text-lg">{filename}</span>
                   <span className="text-white text-opacity-50">{translate('error.noFilePreview')}</span>
                 </div>
@@ -343,7 +347,9 @@ const FileViewer = ({
               </button>
 
               <Dialog.Title className="flex w-11/12 flex-row items-center text-lg">
-                <ItemIconComponent className="mr-3" width={32} height={32} />
+                <div className="flex h-9 w-9 items-center">
+                  <ItemIconComponent className="mr-3" width={32} height={32} />
+                </div>
                 <p className="w-full truncate">{filename}</p>
               </Dialog.Title>
             </div>

--- a/src/app/drive/components/FileViewer/FileViewer.tsx
+++ b/src/app/drive/components/FileViewer/FileViewer.tsx
@@ -279,10 +279,12 @@ const FileViewer = ({
                         } outline-none pointer-events-none z-10 select-none flex-col items-center justify-center
                       rounded-xl font-medium`}
                       >
-                        <div className="flex h-9 w-9 items-center">
-                          <ItemIconComponent className="mr-3" width={32} height={32} />
+                        <div className="flex h-20 w-20 items-center">
+                          <ItemIconComponent width={80} height={80} />
                         </div>
-                        <span className="w-96 truncate text-center text-lg">{filename}</span>
+                        <span className="w-96 truncate pt-4 text-center text-lg" title={filename}>
+                          {filename}
+                        </span>
                         <span className="text-white text-opacity-50">{translate('drive.loadingFile')}</span>
                         <div className="mt-8 h-1.5 w-56 rounded-full bg-white bg-opacity-25">
                           <div
@@ -302,15 +304,16 @@ const FileViewer = ({
                       space-y-6 rounded-xl font-medium"
               >
                 <div className="flex flex-col items-center justify-center">
-                  <div className="flex h-9 w-9 items-center">
-                    <ItemIconComponent className="mr-3" width={32} height={32} />
+                  <div className="flex h-20 w-20 items-center">
+                    <ItemIconComponent width={80} height={80} />
                   </div>
-                  <span className="w-96 truncate pt-2 text-center text-lg">{filename}</span>
+                  <span className="w-96 truncate pt-4 text-center text-lg" title={filename}>
+                    {filename}
+                  </span>
                   <span className="text-white text-opacity-50">{translate('error.noFilePreview')}</span>
                 </div>
-                <div>
-                  <DownloadFile onDownload={onDownload} translate={translate} />
-                </div>
+
+                <DownloadFile onDownload={onDownload} translate={translate} />
               </div>
             )}
             {fileIndex === totalFolderIndex - 1 ? null : (
@@ -333,7 +336,7 @@ const FileViewer = ({
           {/* Top bar controls */}
           <div
             className="fixed inset-x-0 top-0 z-20 flex h-0 w-screen max-w-full select-none flex-row
-                          items-start justify-between px-4 text-lg font-medium"
+                          items-start justify-between px-4 text-lg"
           >
             {/* Close and title */}
             <div className="mt-3 mr-6 flex h-10 flex-row items-center justify-start space-x-4 truncate md:mr-32">
@@ -347,10 +350,12 @@ const FileViewer = ({
               </button>
 
               <Dialog.Title className="flex w-11/12 flex-row items-center text-lg">
-                <div className="flex h-9 w-9 items-center">
-                  <ItemIconComponent className="mr-3" width={32} height={32} />
+                <div className="mr-3 flex h-8 w-8 items-center">
+                  <ItemIconComponent width={32} height={32} />
                 </div>
-                <p className="w-full truncate">{filename}</p>
+                <p className="w-full truncate" title={filename}>
+                  {filename}
+                </p>
               </Dialog.Title>
             </div>
 


### PR DESCRIPTION
Added a new container to the svg on the different states of the FileViewer so it wouldnt get the Title parent size as reference
![Captura de pantalla 2023-07-24 130737](https://github.com/internxt/drive-web/assets/115024778/af5385df-4d75-4b67-894c-16fde85ea898)
![Captura de pantalla 2023-07-24 130727](https://github.com/internxt/drive-web/assets/115024778/133be673-cd70-4473-892d-fb851a2adba6)
![Captura de pantalla 2023-07-24 130707](https://github.com/internxt/drive-web/assets/115024778/5f5a4a5d-279f-4a65-bfe1-997f49e7a70e)
![Captura de pantalla 2023-07-24 130637](https://github.com/internxt/drive-web/assets/115024778/b9080e92-57aa-459b-ab5b-7bfbdf360956)
![Captura de pantalla 2023-07-24 130605](https://github.com/internxt/drive-web/assets/115024778/12fdabab-bff1-4f04-98aa-d52b4f0e7365)