### PR TITLE
[PB-752]: fix/private-key-decryption-failure-on-login

### DIFF
--- a/src/app/auth/components/ChangePassword/ChangePassword.tsx
+++ b/src/app/auth/components/ChangePassword/ChangePassword.tsx
@@ -11,6 +11,7 @@ import { MAX_PASSWORD_LENGTH } from 'app/shared/components/ValidPassword';
 import { CaretLeft, FileArrowUp, Warning, WarningCircle, CheckCircle } from '@phosphor-icons/react';
 import { validateMnemonic } from 'bip39';
 import errorService from 'app/core/services/error.service';
+import localStorageService from 'app/core/services/local-storage.service';
 
 interface ChangePasswordProps {
   setHasBackupKey: Dispatch<SetStateAction<boolean | undefined>>;
@@ -124,6 +125,7 @@ export default function ChangePassword(props: ChangePasswordProps): JSX.Element 
 
     try {
       await authService.updateCredentialsWithToken(token, password, mnemonic, '');
+      localStorageService.clear();
       setIsEmailSent(true);
     } catch (error) {
       notificationsService.show({

--- a/src/app/crypto/services/keys.service.ts
+++ b/src/app/crypto/services/keys.service.ts
@@ -1,30 +1,96 @@
 import { aes } from '@internxt/lib';
-import { isValidBase64 } from './utilspgp';
+import { isValid } from './utilspgp';
+import { getOpenpgp } from './pgp.service';
 
-export async function validateFormat(
+export class Base64EncodedPrivateKeyError extends Error {
+  constructor() {
+    super('Key is encoded in base64');
+
+    Object.setPrototypeOf(this, Base64EncodedPrivateKeyError.prototype);
+  }
+}
+
+export class WrongIterationsToEncryptPrivateKeyError extends Error {
+  constructor() {
+    super('Key was encrypted using the wrong iterations number');
+
+    Object.setPrototypeOf(this, WrongIterationsToEncryptPrivateKeyError.prototype);
+  }
+}
+
+export class CorruptedEncryptedPrivateKeyError extends Error {
+  constructor() {
+    super('Key is corrupted');
+
+    Object.setPrototypeOf(this, CorruptedEncryptedPrivateKeyError.prototype);
+  }
+}
+
+export class KeysDoNotMatchError extends Error {
+  constructor() {
+    super('Keys do not match');
+
+    Object.setPrototypeOf(this, CorruptedEncryptedPrivateKeyError.prototype);
+  }
+}
+
+/**
+ * This function validates the private key
+ * @param privateKey The private key to validate encrypted
+ * @param password The password used for encrypting the private key
+ * @throws {Base64EncodedPrivateKeyError} If the PLAIN private key is base64 encoded (known issue introduced in the past)
+ * @throws {WrongIterationsToEncryptPrivateKeyError} If the ENCRYPTED private key was encrypted using the wrong iterations number (known issue introduced in the past)
+ * @throws {CorruptedEncryptedPrivateKeyError} If the ENCRYPTED private key is un-decryptable (corrupted)
+ * @async
+ */
+export async function assertPrivateKeyIsValid(
   privateKey: string,
   password: string,
-): Promise<{ update: boolean; newPrivKey: string; privkeyDecrypted: string }> {
-  let privkeyDecrypted, newPrivKey;
-  let update = false;
+): Promise<void> {
+  let privateKeyDecrypted: string;
 
   try {
-    privkeyDecrypted = aes.decrypt(privateKey, password);
+    privateKeyDecrypted = decryptPrivateKey(privateKey, password);
   } catch {
-    privkeyDecrypted = aes.decrypt(privateKey, password, 9999);
-    newPrivKey = aes.encrypt(privkeyDecrypted, password, getAesInitFromEnv());
-    update = true;
+    try {
+      aes.decrypt(privateKey, password, 9999);
+    } catch {
+      throw new CorruptedEncryptedPrivateKeyError();
+    }
+
+    throw new WrongIterationsToEncryptPrivateKeyError();
   }
 
-  const isBase64 = await isValidBase64(privkeyDecrypted);
+  const hasValidFormat = await isValid(privateKeyDecrypted);
 
-  if (isBase64) {
-    privkeyDecrypted = Buffer.from(privkeyDecrypted, 'base64').toString();
-    newPrivKey = aes.encrypt(privkeyDecrypted, password, getAesInitFromEnv());
-    update = true;
+  if (!hasValidFormat) throw new Base64EncodedPrivateKeyError();
+}
+
+export function decryptPrivateKey(privateKey: string, password: string): string {
+  return aes.decrypt(privateKey, password);
+}
+
+export async function assertValidateKeys(privateKey: string, publicKey: string): Promise<void> {
+  const openpgp = await getOpenpgp();
+  const publicKeyArmored = await openpgp.key.readArmored(publicKey);
+  const privateKeyArmored = await openpgp.key.readArmored(privateKey);
+
+  const plainMessage = 'validate-keys';
+  const originalText = openpgp.message.fromText(plainMessage);
+  const encryptedMessage = (await openpgp.encrypt({
+    message: originalText,
+    publicKeys: publicKeyArmored.keys,
+  })).data;
+
+  const decryptedMessage = (await openpgp.decrypt({
+    message: await openpgp.message.readArmored(encryptedMessage),
+    publicKeys: publicKeyArmored.keys,
+    privateKeys: privateKeyArmored.keys,
+  })).data;
+
+  if (decryptedMessage !== plainMessage) {
+    throw new KeysDoNotMatchError();
   }
-
-  return { update, newPrivKey, privkeyDecrypted };
 }
 
 export function getAesInitFromEnv(): { iv: string; salt: string } {


### PR DESCRIPTION
- Fix the login error happening the first time after recovering the account using the backup key
- Ensure the user's keys are properly set and formatted on login so there is no failure using them in the future, especially given the Advanced Folder Sharing feature we are currently developing

This error was happening because a credential was missing the first time. 