### PR TITLE
[PB-760] Fix/change hotkey to meta+a

### DIFF
--- a/src/app/shared/components/List/index.tsx
+++ b/src/app/shared/components/List/index.tsx
@@ -175,7 +175,7 @@ ListProps<T, F>): JSX.Element {
   };
 
   useHotkeys(
-    'ctrl+a, cmd+a',
+    'ctrl+a, meta+a',
     (e) => {
       e.preventDefault();
       handleKeyPress(selectAllItems)();


### PR DESCRIPTION
- Added item selection with the keyboard shortcut cmd+a`