### PR TITLE
[PB-869]: feat/download files as owner/editor/reader

### DIFF
--- a/src/app/core/services/media.service.ts
+++ b/src/app/core/services/media.service.ts
@@ -1,4 +1,4 @@
-import { VideoExtensions, AudioExtensions, videoExtensions, audioExtensions } from '../../drive/types/file-types';
+import { VideoExtensions, AudioExtensions } from '../../drive/types/file-types';
 
 type VideoTypes = Record<keyof VideoExtensions, string>;
 type AudioTypes = Record<keyof AudioExtensions, string>;

--- a/src/app/crypto/services/utils.ts
+++ b/src/app/crypto/services/utils.ts
@@ -68,6 +68,22 @@ function renameFile(file: File, newName: string): File {
   return new File([file], newName);
 }
 
+const getItemPlainName = (item: DriveItemData) => {
+  if (item.plainName && item.plainName.length > 0) {
+    return item.plainName;
+  }
+  try {
+    if (item.isFolder) {
+      return aes.decrypt(item.name, `${process.env.REACT_APP_CRYPTO_SECRET2}-${item.parentId}`);
+    } else {
+      return aes.decrypt(item.name, `${process.env.REACT_APP_CRYPTO_SECRET2}-${item.folderId}`);
+    }
+  } catch (err) {
+    //Decrypt has failed because item.name is not encrypted
+    return item.name;
+  }
+};
+
 export {
   passToHash,
   encryptText,
@@ -77,4 +93,5 @@ export {
   decryptTextWithKey,
   excludeHiddenItems,
   renameFile,
+  getItemPlainName,
 };

--- a/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveItemContextMenu.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveItemContextMenu.tsx
@@ -484,12 +484,12 @@ const contextMenuMultipleSharedViewAFS = ({
 }: {
   deleteLink: (item: AdvancedSharedItem) => void;
   downloadItem: (item: AdvancedSharedItem) => void;
-  moveToTrash: (item: AdvancedSharedItem) => void;
+  moveToTrash?: (item: AdvancedSharedItem) => void;
 }): ListItemMenu<AdvancedSharedItem> => [
   ...(isProduction ? [getDeleteLinkMenuItem(deleteLink)] : []),
   getDownloadMenuItem(downloadItem),
-  { name: '', action: () => false, separator: true },
-  getMoveToTrashMenuItem(moveToTrash),
+  moveToTrash && { name: '', action: () => false, separator: true },
+  moveToTrash && getMoveToTrashMenuItem(moveToTrash),
 ];
 
 export {

--- a/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveItemContextMenu.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveItemContextMenu.tsx
@@ -428,7 +428,7 @@ const contextMenuDriveItemSharedAFS = ({
   deleteLink: (item: AdvancedSharedItem) => void;
   renameItem?: (item: AdvancedSharedItem) => void;
   moveItem?: (item: AdvancedSharedItem) => void;
-  downloadItem: (item: AdvancedSharedItem) => void;
+  downloadItem: (item: AdvancedSharedItem) => Promise<void>;
   moveToTrash?: (item: AdvancedSharedItem) => void;
 }): ListItemMenu<AdvancedSharedItem> => [
   ...(isProduction
@@ -463,7 +463,7 @@ const contextMenuDriveFolderSharedAFS = ({
   deleteLink: (item: AdvancedSharedItem) => void;
   renameItem?: (item: AdvancedSharedItem) => void;
   moveItem?: (item: AdvancedSharedItem) => void;
-  downloadItem: (item: AdvancedSharedItem) => void;
+  downloadItem: (item: AdvancedSharedItem) => Promise<void>;
   moveToTrash?: (item: AdvancedSharedItem) => void;
 }): ListItemMenu<AdvancedSharedItem> => [
   ...(isProduction
@@ -483,7 +483,7 @@ const contextMenuMultipleSharedViewAFS = ({
   moveToTrash,
 }: {
   deleteLink: (item: AdvancedSharedItem) => void;
-  downloadItem: (item: AdvancedSharedItem) => void;
+  downloadItem: (item: AdvancedSharedItem) => Promise<void>;
   moveToTrash?: (item: AdvancedSharedItem) => void;
 }): ListItemMenu<AdvancedSharedItem> => [
   ...(isProduction ? [getDeleteLinkMenuItem(deleteLink)] : []),

--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -65,7 +65,6 @@ const cropSharedName = (name: string) => {
 
 type ShareDialogProps = {
   user: UserSettings;
-  selectedItems: DriveItemData[];
 };
 
 const ShareDialog = (props: ShareDialogProps) => {
@@ -76,7 +75,6 @@ const ShareDialog = (props: ShareDialogProps) => {
   const roles = useAppSelector((state: RootState) => state.shared.roles);
 
   const itemToShare = useAppSelector((state) => state.storage.itemToShare);
-  const selectedFolder = props.selectedItems[0];
 
   const localUserData: InvitedUserProps = {
     avatar: props.user.avatar,
@@ -541,7 +539,7 @@ const ShareDialog = (props: ShareDialogProps) => {
           >
             <p className="text-2xl font-medium">{translate('modals.shareModal.stopSharing.title')}</p>
             <p className="text-lg text-gray-80">
-              {translate('modals.shareModal.stopSharing.subtitle', { name: props.selectedItems[0]?.name ?? '' })}
+              {translate('modals.shareModal.stopSharing.subtitle', { name: itemToShare?.item.name ?? '' })}
             </p>
             <div className="flex items-center justify-end space-x-2">
               <Button
@@ -568,7 +566,7 @@ const ShareDialog = (props: ShareDialogProps) => {
             }, 500);
           }}
           onInviteUser={onInviteUser}
-          folderUUID={selectedFolder?.uuid as string}
+          folderUUID={itemToShare?.item.uuid as string}
           roles={roles}
         />
       ),
@@ -691,7 +689,6 @@ const ShareDialog = (props: ShareDialogProps) => {
 
 export default connect((state: RootState) => ({
   user: state.user.user as UserSettings,
-  selectedItems: state.storage.selectedItems,
 }))(ShareDialog);
 
 const UserOptions = ({

--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -134,13 +134,13 @@ const ShareDialog = (props: ShareDialogProps) => {
   // TODO: BEFORE FINISH ALL THE AFS EPIC MOVE THIS LOGIC OUT OF THE VIEW
   const getAndUpdateInvitedUsers = useCallback(async () => {
     try {
-      const usersList = await shareService.getSharedFolderUsers(selectedFolder?.uuid as string, 0, 50);
+      const usersList = await shareService.getSharedFolderUsers(itemToShare?.item.uuid as string, 0, 50);
       const parsedUsersList = usersList.users.map((user) => ({ ...user, roleName: user.role.name.toLowerCase() }));
       setInvitedUsers(parsedUsersList);
     } catch (error) {
       errorService.reportError(error);
     }
-  }, [selectedFolder]);
+  }, [itemToShare]);
 
   const loadShareInfo = async () => {
     // TODO -> Load access mode
@@ -238,7 +238,7 @@ const ShareDialog = (props: ShareDialogProps) => {
     if (invitedUserUUID) {
       const hasBeenRemoved = await dispatch(
         sharedThunks.removeUserFromSharedFolder({
-          folderUUID: selectedFolder.uuid as string,
+          folderUUID: itemToShare?.item.uuid as string,
           userUUID: invitedUserUUID,
           userEmail: email,
         }),

--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -267,8 +267,8 @@ const ShareDialog = (props: ShareDialogProps) => {
   const onStopSharing = async () => {
     setIsLoading(true);
 
-    const folderName = cropSharedName(selectedFolder.name);
-    await dispatch(sharedThunks.stopSharingFolder({ folderUUID: selectedFolder?.uuid as string, folderName }));
+    const folderName = cropSharedName(itemToShare?.item.name as string);
+    await dispatch(sharedThunks.stopSharingFolder({ folderUUID: itemToShare?.item.uuid as string, folderName }));
 
     setShowStopSharingConfirmation(false);
     onClose();
@@ -283,7 +283,7 @@ const ShareDialog = (props: ShareDialogProps) => {
       if (roleId && userUUID) {
         await shareService.updateUserRoleOfSharedFolder({
           userUUID,
-          folderUUID: selectedFolder?.uuid as string,
+          folderUUID: itemToShare?.item.uuid as string,
           roleId,
         });
 
@@ -323,9 +323,9 @@ const ShareDialog = (props: ShareDialogProps) => {
         <>
           <span
             className="max-w-full overflow-hidden overflow-ellipsis whitespace-nowrap text-xl font-medium"
-            title={translate('modals.shareModal.title', { name: props.selectedItems[0]?.name ?? '' })}
+            title={translate('modals.shareModal.title', { name: itemToShare?.item.name ?? '' })}
           >
-            {translate('modals.shareModal.title', { name: props.selectedItems[0]?.name ?? '' })}
+            {translate('modals.shareModal.title', { name: itemToShare?.item.name ?? '' })}
           </span>
           <div className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-md bg-black bg-opacity-0 transition-all duration-200 ease-in-out hover:bg-opacity-4 active:bg-opacity-8">
             <X onClick={() => (isLoading ? null : onClose())} size={22} />

--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -3,7 +3,7 @@ import { Popover } from '@headlessui/react';
 import { connect } from 'react-redux';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { RootState } from 'app/store';
-import { uiActions } from 'app/store/slices/ui';
+import { setIsShareItemDialogOpen, uiActions } from 'app/store/slices/ui';
 import Button from 'app/shared/components/Button/Button';
 // import Input from 'app/shared/components/Input';
 import Modal from 'app/shared/components/Modal';
@@ -18,6 +18,7 @@ import './ShareDialog.scss';
 import shareService from '../../../share/services/share.service';
 import errorService from '../../../core/services/error.service';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
+import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
 
 type AccessMode = 'public' | 'restricted';
 type UserRole = 'owner' | 'editor' | 'reader';
@@ -68,7 +69,7 @@ type ShareDialogProps = {
   selectedItems: DriveItemData[];
 };
 
-const ShareDialog = (props: ShareDialogProps) => {
+const ShareDialog = (props: ShareDialogProps): JSX.Element => {
   const { translate } = useTranslationContext();
   const dispatch = useAppDispatch();
   const isOpen = useAppSelector((state: RootState) => state.ui.isShareDialogOpen);
@@ -76,6 +77,18 @@ const ShareDialog = (props: ShareDialogProps) => {
   const roles = useAppSelector((state: RootState) => state.shared.roles);
 
   const itemToShare = useAppSelector((state) => state.storage.itemToShare);
+
+  if (!itemToShare || !itemToShare.item) {
+    if (isOpen) {
+      dispatch(uiActions.setIsShareDialogOpen(false));
+      notificationsService.show({
+        type: ToastType.Error,
+        text: 'Something went wrong, please try again later',
+      });
+    }
+    return <></>;
+  }
+
   const selectedFolder = props.selectedItems[0];
 
   const localUserData: InvitedUserProps = {
@@ -134,7 +147,7 @@ const ShareDialog = (props: ShareDialogProps) => {
   // TODO: BEFORE FINISH ALL THE AFS EPIC MOVE THIS LOGIC OUT OF THE VIEW
   const getAndUpdateInvitedUsers = useCallback(async () => {
     try {
-      const usersList = await shareService.getSharedFolderUsers(itemToShare?.item.uuid as string, 0, 50);
+      const usersList = await shareService.getSharedFolderUsers(itemToShare.item.uuid as string, 0, 50);
       const parsedUsersList = usersList.users.map((user) => ({ ...user, roleName: user.role.name.toLowerCase() }));
       setInvitedUsers(parsedUsersList);
     } catch (error) {
@@ -219,7 +232,7 @@ const ShareDialog = (props: ShareDialogProps) => {
 
   const onCopyLink = (): void => {
     // TODO -> Copy share link
-    dispatch(sharedThunks.getSharedLinkThunk({ item: itemToShare?.item as DriveItemData }));
+    dispatch(sharedThunks.getSharedLinkThunk({ item: itemToShare.item }));
     closeSelectedUserPopover();
   };
 
@@ -238,7 +251,7 @@ const ShareDialog = (props: ShareDialogProps) => {
     if (invitedUserUUID) {
       const hasBeenRemoved = await dispatch(
         sharedThunks.removeUserFromSharedFolder({
-          folderUUID: itemToShare?.item.uuid as string,
+          folderUUID: itemToShare.item.uuid as string,
           userUUID: invitedUserUUID,
           userEmail: email,
         }),
@@ -267,8 +280,8 @@ const ShareDialog = (props: ShareDialogProps) => {
   const onStopSharing = async () => {
     setIsLoading(true);
 
-    const folderName = cropSharedName(itemToShare?.item.name as string);
-    await dispatch(sharedThunks.stopSharingFolder({ folderUUID: itemToShare?.item.uuid as string, folderName }));
+    const folderName = cropSharedName(itemToShare.item.name);
+    await dispatch(sharedThunks.stopSharingFolder({ folderUUID: itemToShare.item.uuid as string, folderName }));
 
     setShowStopSharingConfirmation(false);
     onClose();
@@ -283,7 +296,7 @@ const ShareDialog = (props: ShareDialogProps) => {
       if (roleId && userUUID) {
         await shareService.updateUserRoleOfSharedFolder({
           userUUID,
-          folderUUID: itemToShare?.item.uuid as string,
+          folderUUID: itemToShare.item.uuid as string,
           roleId,
         });
 
@@ -323,9 +336,9 @@ const ShareDialog = (props: ShareDialogProps) => {
         <>
           <span
             className="max-w-full overflow-hidden overflow-ellipsis whitespace-nowrap text-xl font-medium"
-            title={translate('modals.shareModal.title', { name: itemToShare?.item.name ?? '' })}
+            title={translate('modals.shareModal.title', { name: itemToShare.item.name })}
           >
-            {translate('modals.shareModal.title', { name: itemToShare?.item.name ?? '' })}
+            {translate('modals.shareModal.title', { name: itemToShare.item.name })}
           </span>
           <div className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-md bg-black bg-opacity-0 transition-all duration-200 ease-in-out hover:bg-opacity-4 active:bg-opacity-8">
             <X onClick={() => (isLoading ? null : onClose())} size={22} />

--- a/src/app/drive/services/folder.service.ts
+++ b/src/app/drive/services/folder.service.ts
@@ -150,7 +150,7 @@ interface GetDirectoryFoldersResponse {
   last: boolean;
 }
 
-export class DirectoryFolderIterator implements Iterator<DriveFolderData> {
+class DirectoryFolderIterator implements Iterator<DriveFolderData> {
   private offset: number;
   private limit: number;
   private readonly queryValues: { directoryId: number };
@@ -177,7 +177,8 @@ interface GetDirectoryFilesResponse {
   files: DriveFileData[];
   last: boolean;
 }
-export class DirectoryFilesIterator implements Iterator<DriveFileData> {
+
+class DirectoryFilesIterator implements Iterator<DriveFileData> {
   private offset: number;
   private limit: number;
   private readonly queryValues: { directoryId: number };
@@ -199,6 +200,14 @@ export class DirectoryFilesIterator implements Iterator<DriveFileData> {
     return { value: files, done: last };
   }
 }
+
+export const createFoldersIterator = (directoryId: number): Iterator<DriveFolderData> => {
+  return new DirectoryFolderIterator({ directoryId }, 20, 0);
+};
+
+export const createFilesIterator = (directoryId: number): Iterator<DriveFileData> => {
+  return new DirectoryFilesIterator({ directoryId }, 20, 0);
+};
 
 interface FolderRef {
   name: string;

--- a/src/app/drive/services/folder.service.ts
+++ b/src/app/drive/services/folder.service.ts
@@ -73,6 +73,11 @@ export interface FetchFolderContentResponse {
 export interface DownloadFolderAsZipOptions {
   destination: FlatFolderZip;
   closeWhenFinished?: boolean;
+  credentials?: {
+    user: string;
+    pass: string;
+  };
+  mnemonic?: string;
 }
 
 export function createFolder(
@@ -343,10 +348,10 @@ async function downloadFolderAsZip(
             bucketId: file.bucket,
             fileId: file.fileId,
             creds: {
-              user: user.bridgeUser,
-              pass: user.userId,
+              user: options?.credentials?.user || user.bridgeUser,
+              pass: options?.credentials?.pass || user.userId,
             },
-            mnemonic: user.mnemonic,
+            mnemonic: options?.mnemonic || user.mnemonic,
           });
           analyticsService.trackFileDownloadCompleted(trackingDownloadProperties);
 

--- a/src/app/drive/services/folder.service.ts
+++ b/src/app/drive/services/folder.service.ts
@@ -277,8 +277,8 @@ export async function addAllFoldersToZip(
 async function downloadFolderAsZip(
   folderId: DriveFolderData['id'],
   folderName: DriveFolderData['name'],
-  foldersIterator: Iterator<DriveFolderData>,
-  filesIterator: Iterator<DriveFileData>,
+  foldersIterator: (directoryId: number) => Iterator<DriveFolderData>,
+  filesIterator: (directoryId: number) => Iterator<DriveFileData>,
   updateProgress: (progress: number) => void,
   options?: DownloadFolderAsZipOptions,
 ): Promise<void> {
@@ -367,13 +367,13 @@ async function downloadFolderAsZip(
 
           return sourceBlob.stream();
         },
-        filesIterator,
+        filesIterator(folderToDownload.folderId),
         zip,
       );
 
       totalSize += files.reduce((a, f) => f.size + a, 0);
 
-      const folders = await addAllFoldersToZip(folderToDownload.name, foldersIterator, zip);
+      const folders = await addAllFoldersToZip(folderToDownload.name, foldersIterator(folderToDownload.folderId), zip);
 
       pendingFolders.push(
         ...folders.map((f) => {

--- a/src/app/drive/services/folder.service.ts
+++ b/src/app/drive/services/folder.service.ts
@@ -150,7 +150,7 @@ interface GetDirectoryFoldersResponse {
   last: boolean;
 }
 
-class DirectoryFolderIterator implements Iterator<DriveFolderData> {
+export class DirectoryFolderIterator implements Iterator<DriveFolderData> {
   private offset: number;
   private limit: number;
   private readonly queryValues: { directoryId: number };
@@ -177,7 +177,7 @@ interface GetDirectoryFilesResponse {
   files: DriveFileData[];
   last: boolean;
 }
-class DirectoryFilesIterator implements Iterator<DriveFileData> {
+export class DirectoryFilesIterator implements Iterator<DriveFileData> {
   private offset: number;
   private limit: number;
   private readonly queryValues: { directoryId: number };
@@ -268,6 +268,8 @@ export async function addAllFoldersToZip(
 async function downloadFolderAsZip(
   folderId: DriveFolderData['id'],
   folderName: DriveFolderData['name'],
+  foldersIterator: Iterator<DriveFolderData>,
+  filesIterator: Iterator<DriveFileData>,
   updateProgress: (progress: number) => void,
   options?: DownloadFolderAsZipOptions,
 ): Promise<void> {
@@ -307,17 +309,6 @@ async function downloadFolderAsZip(
   try {
     do {
       const folderToDownload = pendingFolders.shift() as FolderRef;
-
-      const foldersIterator: Iterator<DriveFolderData> = new DirectoryFolderIterator(
-        { directoryId: folderToDownload.folderId },
-        20,
-        0,
-      );
-      const filesIterator: Iterator<DriveFileData> = new DirectoryFilesIterator(
-        { directoryId: folderToDownload.folderId },
-        20,
-        0,
-      );
 
       const files = await addAllFilesToZip(
         folderToDownload.name,

--- a/src/app/network/download.ts
+++ b/src/app/network/download.ts
@@ -133,7 +133,7 @@ async function getFileDownloadStream(
   return getDecryptedStream(encryptedContentParts, decipher);
 }
 
-interface NetworkCredentials {
+export interface NetworkCredentials {
   user: string;
   pass: string;
 }

--- a/src/app/share/services/share.service.ts
+++ b/src/app/share/services/share.service.ts
@@ -305,7 +305,7 @@ export async function downloadSharedFiles({
   selectedItems,
   dispatch,
 }: {
-  creds: { user: string; pass: string };
+  creds: { user: string | undefined; pass: string | undefined };
   encryptionKey: string;
   selectedItems: any[];
   dispatch: any;
@@ -326,8 +326,8 @@ export async function downloadSharedFiles({
         bucketId: selectedItems[0].bucket,
         fileId: selectedItems[0].fileId,
         creds: {
-          pass: creds.pass,
-          user: creds.user,
+          pass: creds.pass as string,
+          user: creds.user as string,
         },
         mnemonic: decryptedKey, // DECRYPTED
       });

--- a/src/app/share/services/share.service.ts
+++ b/src/app/share/services/share.service.ts
@@ -1,7 +1,7 @@
 import errorService from '../../core/services/error.service';
 import { ShareTypes } from '@internxt/sdk/dist/drive';
 import { SdkFactory } from '../../core/factory/sdk';
-import httpService from 'app/core/services/http.service';
+import httpService from '../../core/services/http.service';
 import { aes } from '@internxt/lib';
 import {
   ListAllSharedFoldersResponse,
@@ -16,20 +16,17 @@ import {
 } from '@internxt/sdk/dist/drive/share/types';
 import { domainManager } from './DomainManager';
 import _ from 'lodash';
-import { binaryStreamToBlob } from 'app/core/services/stream.service';
-import downloadService from 'app/drive/services/download.service';
-import network from 'app/network';
-import { decryptMessageWithPrivateKey } from 'app/crypto/services/pgp.service';
-import localStorageService from 'app/core/services/local-storage.service';
-import {
-  createFilesIterator,
-  createFoldersIterator,
-  downloadItemsAsZipThunk,
-} from 'app/store/slices/storage/storage.thunks/downloadItemsThunk';
-import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
+import { binaryStreamToBlob } from '../../core/services/stream.service';
+import downloadService from '../../drive/services/download.service';
+import network from '../../network';
+import { decryptMessageWithPrivateKey } from '../../crypto/services/pgp.service';
+import localStorageService from '../../core/services/local-storage.service';
+import { downloadItemsAsZipThunk } from '../../store/slices/storage/storage.thunks/downloadItemsThunk';
+import notificationsService, { ToastType } from '../../notifications/services/notifications.service';
 import { t } from 'i18next';
-import { DriveFileData, DriveFolderData } from '@internxt/sdk/dist/drive/storage/types';
+import { DriveFileData } from '@internxt/sdk/dist/drive/storage/types';
 import { Iterator } from '../../core/collections';
+import { createFilesIterator, createFoldersIterator } from '../../drive/services/folder.service';
 
 interface CreateShareResponse {
   created: boolean;

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -130,9 +130,8 @@ export default function SharedView(): JSX.Element {
   };
 
   const fetchFolders = async () => {
-    setIsLoading(true);
-
     if (currentFolderId) {
+      setIsLoading(true);
       try {
         const response: ListSharedItemsResponse = await shareService.getSharedFolderContent(
           currentFolderId,
@@ -163,14 +162,15 @@ export default function SharedView(): JSX.Element {
         }
       } catch (error) {
         errorService.reportError(error);
+      } finally {
+        setIsLoading(false);
       }
     }
   };
 
   const fetchFiles = async () => {
-    setIsLoading(true);
-
     if (currentFolderId) {
+      setIsLoading(true);
       try {
         const response: ListSharedItemsResponse = await shareService.getSharedFolderContent(
           currentFolderId,

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -45,7 +45,7 @@ function copyShareLink(type: string, code: string, token: string) {
   notificationsService.show({ text: t('shared-links.toast.copy-to-clipboard'), type: ToastType.Success });
 }
 
-const ITEMS_PER_PAGE = 15;
+export const ITEMS_PER_PAGE = 15;
 
 // TODO: FINISH LOGIC WHEN ADD MORE ADVANCED SHARING FEATURES
 export default function SharedView(): JSX.Element {
@@ -331,7 +331,7 @@ export default function SharedView(): JSX.Element {
   const downloadItem = async (props: AdvancedSharedItem) => {
     try {
       if (props.isRootLink) {
-        const { credentials } = await shareService.getSharedFolderContent(
+        const { credentials, token } = await shareService.getSharedFolderContent(
           props.uuid,
           'files',
           '',
@@ -347,6 +347,7 @@ export default function SharedView(): JSX.Element {
           dispatch,
           selectedItems,
           encryptionKey: props.encryptionKey,
+          token,
         });
       } else {
         if (userCredentials) {
@@ -355,6 +356,7 @@ export default function SharedView(): JSX.Element {
             dispatch,
             selectedItems,
             encryptionKey: encryptionKey,
+            token: '',
           });
         }
       }

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -362,8 +362,8 @@ export default function SharedView(): JSX.Element {
 
   const downloadItem = async () => {
     const ownerCredentials = {
-      user: credentials?.networkUser || '',
-      pass: credentials?.networkPass || '',
+      user: credentials?.networkUser || undefined,
+      pass: credentials?.networkPass || undefined,
     };
 
     try {

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -35,6 +35,7 @@ import ShareDialog from '../../../drive/components/ShareDialog/ShareDialog';
 import Avatar from '../../../shared/components/Avatar';
 import envService from '../../../core/services/env.service';
 import { AdvancedSharedItem, OrderBy } from '../../../../app/share/types';
+import { getItemPlainName } from '../../../../app/crypto/services/utils';
 
 const REACT_APP_SHARE_LINKS_DOMAIN = process.env.REACT_APP_SHARE_LINKS_DOMAIN || window.location.origin;
 
@@ -94,10 +95,6 @@ export default function SharedView(): JSX.Element {
     }
   }, [page]);
 
-  useEffect(() => {
-    localStorageService.set('xResourcesToken', nextResourcesToken);
-  }, [nextResourcesToken]);
-
   const fetchRootItems = async () => {
     setIsLoading(true);
 
@@ -115,6 +112,7 @@ export default function SharedView(): JSX.Element {
         const shareItem = folder as AdvancedSharedItem;
         shareItem.isFolder = true;
         shareItem.isRootLink = true;
+        shareItem.name = getItemPlainName(shareItem as unknown as DriveItemData);
         return shareItem;
       });
 
@@ -152,6 +150,7 @@ export default function SharedView(): JSX.Element {
           const shareItem = folder as AdvancedSharedItem;
           shareItem.isFolder = true;
           shareItem.isRootLink = false;
+          shareItem.name = getItemPlainName(shareItem as unknown as DriveItemData);
           return shareItem;
         });
 
@@ -191,6 +190,7 @@ export default function SharedView(): JSX.Element {
           const shareItem = file as AdvancedSharedItem;
           shareItem.isFolder = false;
           shareItem.isRootLink = false;
+          shareItem.name = getItemPlainName(shareItem as unknown as DriveItemData);
           return shareItem;
         });
 
@@ -301,7 +301,7 @@ export default function SharedView(): JSX.Element {
   };
 
   const openShareAccessSettings = (shareItem: AdvancedSharedItem) => {
-    dispatch(storageActions.setItemToShare({ item: shareItem as any as DriveItemData }));
+    dispatch(storageActions.setItemToShare({ item: shareItem as unknown as DriveItemData }));
 
     envService.isProduction()
       ? dispatch(uiActions.setIsShareItemDialogOpen(true))
@@ -318,7 +318,7 @@ export default function SharedView(): JSX.Element {
 
   const moveToTrash = async (shareItem: AdvancedSharedItem) => {
     const itemToTrash = {
-      ...(shareItem as any as DriveItemData),
+      ...(shareItem as unknown as DriveItemData),
       isFolder: shareItem.isFolder,
     };
     await moveItemsToTrash([itemToTrash]);
@@ -346,7 +346,7 @@ export default function SharedView(): JSX.Element {
 
   const moveItem = (shareItem: AdvancedSharedItem) => {
     const itemToMove = {
-      ...(shareItem as any as DriveItemData),
+      ...(shareItem as unknown as DriveItemData),
       isFolder: shareItem.isFolder,
     };
     dispatch(storageActions.setItemsToMove([itemToMove]));
@@ -354,7 +354,7 @@ export default function SharedView(): JSX.Element {
   };
 
   const renameItem = (shareItem: AdvancedSharedItem) => {
-    setEditNameItem(shareItem as any as DriveItemData);
+    setEditNameItem(shareItem as unknown as DriveItemData);
     setIsEditNameDialogOpen(true);
   };
 
@@ -363,7 +363,7 @@ export default function SharedView(): JSX.Element {
       const editNameItemUuid = newItem.uuid || '';
       setShareItems(
         shareItems.map((shareItem) => {
-          const shareItemUuid = (shareItem as any as DriveItemData).uuid || '';
+          const shareItemUuid = (shareItem as unknown as DriveItemData).uuid || '';
           if (
             shareItemUuid.length > 0 &&
             editNameItemUuid.length > 0 &&
@@ -476,7 +476,7 @@ export default function SharedView(): JSX.Element {
           }}
           itemComposition={[
             (shareItem: AdvancedSharedItem) => {
-              const Icon = iconService.getItemIcon(shareItem.isFolder, (shareItem as any as DriveFileData)?.type);
+              const Icon = iconService.getItemIcon(shareItem.isFolder, (shareItem as unknown as DriveFileData)?.type);
               return (
                 <div className={'flex w-full flex-row items-center space-x-6 overflow-hidden'}>
                   <div className="my-5 flex h-8 w-8 flex-shrink items-center justify-center">
@@ -552,7 +552,7 @@ export default function SharedView(): JSX.Element {
               : contextMenuDriveItemSharedAFS({
                   openPreview: (shareItem: AdvancedSharedItem) => {
                     const previewItem: DriveFileData = {
-                      ...(shareItem as any as DriveItemData),
+                      ...(shareItem as unknown as DriveItemData),
                       name: shareItem.plainName,
                     };
                     dispatch(uiActions.setIsFileViewerOpen(true));
@@ -573,7 +573,7 @@ export default function SharedView(): JSX.Element {
               if (selectedItems.length === 1) {
                 const selectedItem = selectedItems[0];
                 const itemToRename = {
-                  ...(selectedItem as any as DriveItemData),
+                  ...(selectedItem as unknown as DriveItemData),
                   name: selectedItem.plainName ? selectedItem.plainName : '',
                 };
                 setEditNameItem(itemToRename);
@@ -590,7 +590,7 @@ export default function SharedView(): JSX.Element {
       </div>
       <MoveItemsDialog
         items={shareItems.map((shareItem) => ({
-          ...(shareItem as any as DriveItemData),
+          ...(shareItem as unknown as DriveItemData),
           isFolder: shareItem.isFolder,
         }))}
         isTrash={false}

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -26,7 +26,6 @@ import {
   contextMenuDriveItemSharedAFS,
   contextMenuMultipleSharedViewAFS,
 } from '../../../drive/components/DriveExplorer/DriveExplorerList/DriveItemContextMenu';
-import folderService from 'app/drive/services/folder.service';
 import moveItemsToTrash from '../../../../use_cases/trash/move-items-to-trash';
 import MoveItemsDialog from '../../../drive/components/MoveItemsDialog/MoveItemsDialog';
 import EditItemNameDialog from '../../../drive/components/EditItemNameDialog/EditItemNameDialog';
@@ -35,11 +34,6 @@ import errorService from '../../../core/services/error.service';
 import ShareDialog from '../../../drive/components/ShareDialog/ShareDialog';
 import Avatar from '../../../shared/components/Avatar';
 import envService from '../../../core/services/env.service';
-import { decryptMessageWithPrivateKey } from 'app/crypto/services/pgp.service';
-import network from 'app/network';
-import { binaryStreamToBlob } from 'app/core/services/stream.service';
-import downloadService from 'app/drive/services/download.service';
-import { downloadItemsAsZipThunk } from 'app/store/slices/storage/storage.thunks/downloadItemsThunk';
 import { AdvancedSharedItem, OrderBy } from '../../../../app/share/types';
 
 const REACT_APP_SHARE_LINKS_DOMAIN = process.env.REACT_APP_SHARE_LINKS_DOMAIN || window.location.origin;

--- a/src/app/store/slices/storage/storage.thunks/downloadFolderThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadFolderThunk.ts
@@ -8,13 +8,12 @@ import { t } from 'i18next';
 import { TaskStatus } from 'app/tasks/types';
 import tasksService from 'app/tasks/services/tasks.service';
 import AppError from 'app/core/types';
-import { DriveFolderData } from 'app/drive/types';
+import { DriveFileData, DriveFolderData } from '../../../../drive/types';
 import folderService from 'app/drive/services/folder.service';
 import downloadFolderUsingBlobs from '../../../../drive/services/download.service/downloadFolder/downloadFolderUsingBlobs';
 import { isFirefox } from 'react-device-detect';
 import { ConnectionLostError } from '../../../../network/requests';
 import { Iterator } from 'app/core/collections';
-import { DriveFileData } from '@internxt/sdk/dist/drive/storage/types';
 
 interface DownloadFolderThunkOptions {
   taskId: string;

--- a/src/app/store/slices/storage/storage.thunks/downloadFolderThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadFolderThunk.ts
@@ -23,8 +23,8 @@ interface DownloadFolderThunkOptions {
 
 interface DownloadFolderThunkPayload {
   folder: DriveFolderData;
-  fileIterator: Iterator<DriveFileData>;
-  folderIterator: Iterator<DriveFolderData>;
+  fileIterator: (directoryId: number) => Iterator<DriveFileData>;
+  folderIterator: (directoryId: number) => Iterator<DriveFolderData>;
   options: DownloadFolderThunkOptions;
 }
 

--- a/src/app/store/slices/storage/storage.thunks/downloadFolderThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadFolderThunk.ts
@@ -13,6 +13,8 @@ import folderService from 'app/drive/services/folder.service';
 import downloadFolderUsingBlobs from '../../../../drive/services/download.service/downloadFolder/downloadFolderUsingBlobs';
 import { isFirefox } from 'react-device-detect';
 import { ConnectionLostError } from '../../../../network/requests';
+import { Iterator } from 'app/core/collections';
+import { DriveFileData } from '@internxt/sdk/dist/drive/storage/types';
 
 interface DownloadFolderThunkOptions {
   taskId: string;
@@ -22,6 +24,8 @@ interface DownloadFolderThunkOptions {
 
 interface DownloadFolderThunkPayload {
   folder: DriveFolderData;
+  fileIterator: Iterator<DriveFileData>;
+  folderIterator: Iterator<DriveFolderData>;
   options: DownloadFolderThunkOptions;
 }
 
@@ -81,9 +85,15 @@ export const downloadFolderThunk = createAsyncThunk<void, DownloadFolderThunkPay
       if (isFirefox) {
         await downloadFolderUsingBlobs({ folder, updateProgressCallback });
       } else {
-        await folderService.downloadFolderAsZip(folder.id, folder.name, (progress) => {
-          updateProgressCallback(progress);
-        });
+        await folderService.downloadFolderAsZip(
+          folder.id,
+          folder.name,
+          payload.folderIterator,
+          payload.fileIterator,
+          (progress) => {
+            updateProgressCallback(progress);
+          },
+        );
       }
 
       tasksService.updateTask({

--- a/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
@@ -101,7 +101,10 @@ export const downloadItemsThunk = createAsyncThunk<void, DownloadItemsThunkPaylo
 
 type DownloadItemsAsZipThunkType = {
   items: DriveItemData[];
-  credentials?: Record<string, string>;
+  credentials?: {
+    user: string;
+    pass: string;
+  };
   mnemonic?: string;
   existingTaskId?: string;
 };
@@ -190,7 +193,7 @@ export const downloadItemsAsZipThunk = createAsyncThunk<void, DownloadItemsAsZip
               downloadProgress[index] = progress;
               updateProgressCallback(calculateProgress());
             },
-            { destination: folder, closeWhenFinished: false },
+            { destination: folder, closeWhenFinished: false, credentials: credentials, mnemonic: mnemonic },
           );
           downloadProgress[index] = 1;
         } else {

--- a/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
@@ -9,10 +9,7 @@ import notificationsService, { ToastType } from 'app/notifications/services/noti
 import { DownloadFileTask, DownloadFolderTask, TaskStatus, TaskType } from 'app/tasks/types';
 import tasksService from 'app/tasks/services/tasks.service';
 import errorService from 'app/core/services/error.service';
-import folderService, {
-  DirectoryFolderIterator,
-  DirectoryFilesIterator,
-} from '../../../../drive/services/folder.service';
+import folderService, { createFilesIterator, createFoldersIterator } from '../../../../drive/services/folder.service';
 import { downloadFile } from 'app/network/download';
 import localStorageService from 'app/core/services/local-storage.service';
 import { FlatFolderZip } from 'app/core/services/zip.service';
@@ -26,13 +23,6 @@ import analyticsService from '../../../../analytics/services/analytics.service';
 import { Iterator } from 'app/core/collections';
 
 type DownloadItemsThunkPayload = (DriveItemData & { taskId?: string })[];
-export const createFoldersIterator = (directoryId) => {
-  return new DirectoryFolderIterator({ directoryId }, 20, 0);
-};
-
-export const createFilesIterator = (directoryId) => {
-  return new DirectoryFilesIterator({ directoryId }, 20, 0);
-};
 
 export const downloadItemsThunk = createAsyncThunk<void, DownloadItemsThunkPayload, { state: RootState }>(
   'storage/downloadItems',
@@ -90,12 +80,13 @@ export const downloadItemsThunk = createAsyncThunk<void, DownloadItemsThunkPaylo
       const taskId = tasksIds[index];
 
       if (item.isFolder) {
+        console.log({ item });
         await dispatch(
           storageThunks.downloadFolderThunk({
             folder: item as DriveFolderData,
             options: { taskId },
-            fileIterator: createFilesIterator,
-            folderIterator: createFoldersIterator,
+            fileIterator: createFilesIterator(item.id),
+            folderIterator: createFoldersIterator(item.id),
           }),
         );
       } else {

--- a/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
@@ -80,7 +80,6 @@ export const downloadItemsThunk = createAsyncThunk<void, DownloadItemsThunkPaylo
       const taskId = tasksIds[index];
 
       if (item.isFolder) {
-        console.log({ item });
         await dispatch(
           storageThunks.downloadFolderThunk({
             folder: item as DriveFolderData,

--- a/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
@@ -85,8 +85,8 @@ export const downloadItemsThunk = createAsyncThunk<void, DownloadItemsThunkPaylo
           storageThunks.downloadFolderThunk({
             folder: item as DriveFolderData,
             options: { taskId },
-            fileIterator: createFilesIterator(item.id),
-            folderIterator: createFoldersIterator(item.id),
+            fileIterator: createFilesIterator,
+            folderIterator: createFoldersIterator,
           }),
         );
       } else {
@@ -202,8 +202,8 @@ export const downloadItemsAsZipThunk = createAsyncThunk<void, DownloadItemsAsZip
           await folderService.downloadFolderAsZip(
             driveItem.id,
             driveItem.name,
-            folderIterator(driveItem.id),
-            fileIterator(driveItem.id),
+            folderIterator,
+            fileIterator,
             (progress) => {
               downloadProgress[index] = progress;
               updateProgressCallback(calculateProgress());

--- a/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
@@ -9,7 +9,10 @@ import notificationsService, { ToastType } from 'app/notifications/services/noti
 import { DownloadFileTask, DownloadFolderTask, TaskStatus, TaskType } from 'app/tasks/types';
 import tasksService from 'app/tasks/services/tasks.service';
 import errorService from 'app/core/services/error.service';
-import folderService, { DirectoryFolderIterator } from 'app/drive/services/folder.service';
+import folderService, {
+  DirectoryFolderIterator,
+  DirectoryFilesIterator,
+} from '../../../../drive/services/folder.service';
 import { downloadFile } from 'app/network/download';
 import localStorageService from 'app/core/services/local-storage.service';
 import { FlatFolderZip } from 'app/core/services/zip.service';
@@ -20,15 +23,14 @@ import { updateDatabaseFileSourceData } from 'app/drive/services/database.servic
 import { binaryStreamToBlob } from 'app/core/services/stream.service';
 import { TrackingPlan } from '../../../../analytics/TrackingPlan';
 import analyticsService from '../../../../analytics/services/analytics.service';
-
-import { DirectoryFilesIterator } from 'app/drive/services/folder.service';
+import { Iterator } from 'app/core/collections';
 
 type DownloadItemsThunkPayload = (DriveItemData & { taskId?: string })[];
-const createFoldersIterator = (directoryId) => {
+export const createFoldersIterator = (directoryId) => {
   return new DirectoryFolderIterator({ directoryId }, 20, 0);
 };
 
-const createFilesIterator = (directoryId) => {
+export const createFilesIterator = (directoryId) => {
   return new DirectoryFilesIterator({ directoryId }, 20, 0);
 };
 
@@ -92,6 +94,8 @@ export const downloadItemsThunk = createAsyncThunk<void, DownloadItemsThunkPaylo
           storageThunks.downloadFolderThunk({
             folder: item as DriveFolderData,
             options: { taskId },
+            fileIterator: createFilesIterator,
+            folderIterator: createFoldersIterator,
           }),
         );
       } else {
@@ -112,8 +116,8 @@ export const downloadItemsThunk = createAsyncThunk<void, DownloadItemsThunkPaylo
 
 type DownloadItemsAsZipThunkType = {
   items: DriveItemData[];
-  folderIterator: (directoryId: any) => DirectoryFolderIterator;
-  fileIterator: (directoryId: any) => DirectoryFilesIterator;
+  folderIterator: (directoryId: any) => Iterator<DriveFolderData>;
+  fileIterator: (directoryId: any, token?: string) => Iterator<DriveFileData>;
   credentials?: {
     user: string | undefined;
     pass: string | undefined;

--- a/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
@@ -102,8 +102,8 @@ export const downloadItemsThunk = createAsyncThunk<void, DownloadItemsThunkPaylo
 type DownloadItemsAsZipThunkType = {
   items: DriveItemData[];
   credentials?: {
-    user: string;
-    pass: string;
+    user: string | undefined;
+    pass: string | undefined;
   };
   mnemonic?: string;
   existingTaskId?: string;
@@ -119,6 +119,11 @@ export const downloadItemsAsZipThunk = createAsyncThunk<void, DownloadItemsAsZip
     const formattedDate = date.format(new Date(), 'DD/MM/YYYY - HH:mm');
     const folderName = `Internxt (${formattedDate})`;
     const folder = new FlatFolderZip(folderName, {});
+
+    const moreOptions = {
+      credentials,
+      mnemonic,
+    };
 
     const user = localStorageService.getUser();
     if (!user) throw new Error('User not found');
@@ -193,7 +198,7 @@ export const downloadItemsAsZipThunk = createAsyncThunk<void, DownloadItemsAsZip
               downloadProgress[index] = progress;
               updateProgressCallback(calculateProgress());
             },
-            { destination: folder, closeWhenFinished: false, credentials: credentials, mnemonic: mnemonic },
+            { destination: folder, closeWhenFinished: false, ...moreOptions },
           );
           downloadProgress[index] = 1;
         } else {

--- a/src/app/tasks/hooks/useRetryDownload.tsx
+++ b/src/app/tasks/hooks/useRetryDownload.tsx
@@ -2,6 +2,8 @@ import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { DriveItemData } from '../../drive/types';
 import {
+  createFilesIterator,
+  createFoldersIterator,
   downloadItemsAsZipThunk,
   downloadItemsThunk,
 } from '../../store/slices/storage/storage.thunks/downloadItemsThunk';
@@ -19,7 +21,14 @@ export const useRetryDownload = (notification: TaskNotification): RetryDownload 
     const isZipAndMultipleItems = item && 'items' in item && item?.items && item?.type === 'zip';
 
     if (isZipAndMultipleItems) {
-      dispatch(downloadItemsAsZipThunk({ items: item.items as DriveItemData[], existingTaskId: taskId }));
+      dispatch(
+        downloadItemsAsZipThunk({
+          items: item.items as DriveItemData[],
+          existingTaskId: taskId,
+          fileIterator: createFilesIterator,
+          folderIterator: createFoldersIterator,
+        }),
+      );
     } else if (item && taskId) {
       dispatch(downloadItemsThunk([{ ...(item as DriveItemData), taskId }]));
     }

--- a/src/app/tasks/hooks/useRetryDownload.tsx
+++ b/src/app/tasks/hooks/useRetryDownload.tsx
@@ -2,12 +2,11 @@ import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { DriveItemData } from '../../drive/types';
 import {
-  createFilesIterator,
-  createFoldersIterator,
   downloadItemsAsZipThunk,
   downloadItemsThunk,
 } from '../../store/slices/storage/storage.thunks/downloadItemsThunk';
 import { TaskNotification } from '../types';
+import { createFilesIterator, createFoldersIterator } from '../../drive/services/folder.service';
 
 interface RetryDownload {
   retryDownload: () => void;


### PR DESCRIPTION
- Allowed all users to download files/folders from the Shared view (regardless of role). 
- Fixed Share dialog: Copy link, Stop sharing and List all shared-with users.
- Fixed plain name received when fetching shared files&folders.
- Added [PB-906]: Allow owner to share folder inside a shared folder.
- Added [PB-901]: Show rename folder menu option only if current user is the owner


[PB-906]: https://inxt.atlassian.net/browse/PB-906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PB-901]: https://inxt.atlassian.net/browse/PB-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ