### PR TITLE
[PB-822] fix: prevent full skeleton loader after first load

### DIFF
--- a/src/app/drive/components/DriveExplorer/DriveExplorerGrid/DriveExplorerGrid.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerGrid/DriveExplorerGrid.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
 
 import DriveExplorerGridItem from '../DriveExplorerItem/DriveExplorerGridItem/DriveExplorerGridItem';
@@ -53,9 +53,17 @@ const DriveExplorerGrid: FC<DriveExplorerGridProps> = (props: DriveExplorerGridP
 
   const { isLoading, onEndOfScroll, hasMoreItems } = props;
 
+  const isFirstLoad = useRef(true);
+
+  useEffect(() => {
+    if (!isLoading && isFirstLoad) {
+      isFirstLoad.current = false;
+    }
+  }, [isLoading, isFirstLoad]);
+
   return (
     <>
-      {isLoading ? (
+      {isLoading && isFirstLoad.current ? (
         <div className="files-grid flex-grow">{loadingSkeleton()}</div>
       ) : (
         <div id="scrollableList" className="h-full w-full overflow-y-auto py-6">


### PR DESCRIPTION
- Added a variable to track first render so default skeleton does not appear after InfiniteScroll component is rendered.

The isLoading variable is set to true when you scroll down and there are more files pending to load. So, the condition to render the skeleton was triggered everytime we fetch new files. InfiniteScroll does this automatically.


https://github.com/internxt/drive-web/assets/143480783/c9fde149-0a1c-4bbb-930d-bbf7d2318295

