### PR TITLE
[PB-924] fix/replaced inline rename with rename dialog

### DIFF
--- a/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveExplorerList.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveExplorerList.tsx
@@ -25,6 +25,7 @@ import {
   contextMenuDriveFolderShared,
   contextMenuDriveFolderNotSharedLink,
 } from './DriveItemContextMenu';
+import EditItemNameDialog from '../../EditItemNameDialog/EditItemNameDialog';
 import { ListShareLinksItem } from '@internxt/sdk/dist/drive/share/types';
 import envService from '../../../../core/services/env.service';
 
@@ -75,6 +76,7 @@ const createDriveListItem = (item: DriveItemData, isTrash?: boolean) => (
 
 const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
   const [isAllSelectedEnabled, setIsAllSelectedEnabled] = useState(false);
+  const [editNameItem, setEditNameItem] = useState<DriveItemData | null>(null);
   const isSelectedMultipleItemsAndNotTrash = props.selectedItems.length > 1 && !props.isTrash;
   const isSelectedSharedItem = props.selectedItems.length === 1 && (props.selectedItems?.[0].shares?.length || 0) > 0;
 
@@ -159,11 +161,10 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
   }
 
   const renameItem = useCallback(
-    (item: ContextMenuDriveItem) => {
-      dispatch(uiActions.setCurrentEditingNameDirty((item as DriveItemData).name));
-      dispatch(uiActions.setCurrentEditingNameDriveItem(item as DriveItemData));
+    (item) => {
+      setEditNameItem(item as DriveItemData);
     },
-    [dispatch, uiActions],
+    [setEditNameItem],
   );
 
   const moveItem = useCallback(
@@ -263,6 +264,17 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
   return (
     <div className="flex h-full flex-grow flex-col">
       <div className="h-full overflow-y-auto">
+        {editNameItem && (
+          <EditItemNameDialog
+            item={editNameItem}
+            onSuccess={() => {
+              dispatch(fetchSortedFolderContentThunk(currentFolderId));
+            }}
+            onClose={() => {
+              setEditNameItem(null);
+            }}
+          />
+        )}
         <List<DriveItemData, 'type' | 'name' | 'updatedAt' | 'size'>
           header={[
             {

--- a/src/app/drive/components/EditItemNameDialog/EditItemNameDialog.tsx
+++ b/src/app/drive/components/EditItemNameDialog/EditItemNameDialog.tsx
@@ -11,9 +11,10 @@ import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
 type EditItemNameDialogProps = {
   item: DriveItemData;
   onClose?: () => void;
+  onSuccess?: () => void;
 };
 
-const EditItemNameDialog: FC<EditItemNameDialogProps> = ({ item, onClose }) => {
+const EditItemNameDialog: FC<EditItemNameDialogProps> = ({ item, onClose, onSuccess }) => {
   const [newItemName, setNewItemName] = useState('');
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -44,6 +45,7 @@ const EditItemNameDialog: FC<EditItemNameDialogProps> = ({ item, onClose }) => {
         .then(() => {
           setIsLoading(false);
           handleOnClose();
+          onSuccess?.();
         })
         .catch((e) => {
           const errorMessage = e?.message?.includes('already exists') && translate('error.creatingFolder');


### PR DESCRIPTION
Files were renamed using inline inputs in the **drive** and **recents** sections. This breaks consistency with the shared files section, which uses a popup dialog to rename items.

- Added onSuccess prop to EditItemNameDialog component to be able to fetch items again after a successfull rename (to mimic the same behaviour it had before with the inline renaming). Shared section fetches items in a different way so it does not need onSuccess.
- Replaced renameItem function body with the needed status update to render it. 

https://github.com/internxt/drive-web/assets/143480783/c33e34ac-821e-4dcd-bb15-72fed02db097

