### PR TITLE
[PB-861] fix/inject react-tooltip css and decreased delay to 400ms

### DIFF
--- a/src/app/shared/components/Tooltip/Tooltip.tsx
+++ b/src/app/shared/components/Tooltip/Tooltip.tsx
@@ -6,13 +6,14 @@ interface TooltipProps {
   delayShow?: number;
 }
 
-export const DELAY_SHOW_MS = 2000;
+export const DELAY_SHOW_MS = 400;
 
 const TooltipElement: FC<TooltipProps> = ({ id, delayShow = 0 }) => (
   <Tooltip
     id={id}
     className="absolute top-1 w-auto whitespace-nowrap rounded-md bg-black-75 py-1.5 px-2.5 text-center text-xs text-white"
     delayShow={delayShow}
+    noArrow
   />
 );
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import { taskManagerThunks } from './app/store/slices/taskManager';
 import { sessionActions } from './app/store/slices/session';
 import { referralsThunks } from 'app/store/slices/referrals';
 
+import 'react-tooltip/dist/react-tooltip.css';
 import './index.scss';
 import { SdkFactory } from './app/core/factory/sdk';
 import localStorageService from './app/core/services/local-storage.service';


### PR DESCRIPTION
If a version before the 5.13.0 is used, you need to import the css file manually so react-tooltip works as expected. We are using the 5.8.3 version and this step was missing, making the tooltip look glitchy.

![image](https://github.com/internxt/drive-web/assets/143480783/f6bfe2a2-6154-47d2-9132-b4f04decf981)
source > https://react-tooltip.com/docs/getting-started

- Imported css file from react-tooltip library.
- Added noArrow prop. This arrow was not showing before because of the missing css file, this is needed to maintain the same style.
- Decreased delay to show the tooltip to 400ms.

https://github.com/internxt/drive-web/assets/143480783/937821d6-5b2a-4f09-98fc-d5e528e8b59f

