### PR TITLE
[_]: feat/hiding or displaying options depending on the role

### DIFF
--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -370,7 +370,7 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
                     </div>
                   </Button>
                 )}
-                {(currentUserFolderRole === 'owner' || currentUserFolderRole === 'editor') && (
+                {currentUserFolderRole != 'viewer' && (
                   <Button variant="secondary" onClick={onInviteUser}>
                     <UserPlus size={24} />
                     <span>{translate('modals.shareModal.list.invite')}</span>

--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -509,10 +509,10 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
               </Popover>
             </div>
 
-            <Button variant="primary" onClick={onCopyLink}>
+            {/* <Button variant="primary" onClick={onCopyLink}>
               <Link size={24} />
               <span>{translate('modals.shareModal.general.copyLink')}</span>
-            </Button>
+            </Button> */}
           </div>
 
           {/* Stop sharing confirmation dialog */}

--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -79,10 +79,11 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
   const itemToShare = useAppSelector((state) => state.storage.itemToShare);
 
   const [selectedUserListIndex, setSelectedUserListIndex] = useState<number | null>(null);
-  const [accessMode, setAccessMode] = useState<AccessMode>('public');
+  const [accessMode, setAccessMode] = useState<AccessMode>('restricted');
   const [showStopSharingConfirmation, setShowStopSharingConfirmation] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [invitedUsers, setInvitedUsers] = useState<InvitedUserProps[]>([]);
+  const [isCurrentFolderOwner, setIsCurrentFolderOwner] = useState<boolean>(false);
 
   const [accessRequests, setAccessRequests] = useState<RequestProps[]>([]);
   const [userOptionsEmail, setUserOptionsEmail] = useState<InvitedUserProps>();
@@ -133,6 +134,11 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
     return () => clearTimeout(timer);
   }, [accessRequests]);
 
+  useEffect(() => {
+    const folderOwner = invitedUsers.find((user) => user.roleName === 'owner');
+    folderOwner?.email === props.user.email && setIsCurrentFolderOwner(folderOwner?.email === props.user.email);
+  }, [invitedUsers]);
+
   const getAndUpdateInvitedUsers = useCallback(async () => {
     if (!itemToShare?.item) return;
 
@@ -154,7 +160,7 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
 
   const loadShareInfo = async () => {
     // TODO -> Load access mode
-    const shareAccessMode: AccessMode = 'public';
+    const shareAccessMode: AccessMode = 'restricted';
     setAccessMode(shareAccessMode);
 
     // TODO -> Load invited users
@@ -405,11 +411,13 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
                   <>
                     <Popover.Button as="div" className="outline-none z-1">
                       <Button variant="secondary" disabled={isLoading}>
-                        {accessMode === 'public' ? <Globe size={24} /> : <Users size={24} />}
+                        {/* {accessMode === 'public' ? <Globe size={24} /> : <Users size={24} />} */}
+                        <Users size={24} />
                         <span>
-                          {accessMode === 'public'
+                          {translate('modals.shareModal.general.accessOptions.restricted.title')}
+                          {/* {accessMode === 'public'
                             ? translate('modals.shareModal.general.accessOptions.public.title')
-                            : translate('modals.shareModal.general.accessOptions.restricted.title')}
+                            : translate('modals.shareModal.general.accessOptions.restricted.title')} */}
                         </span>
                         {isLoading ? (
                           <div className="flex h-6 w-6 items-center justify-center">
@@ -430,7 +438,7 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
                       {({ close }) => (
                         <>
                           {/* Public */}
-                          <button
+                          {/* <button
                             className="flex h-16 w-full cursor-pointer items-center justify-start space-x-3 rounded-lg px-3 hover:bg-gray-5"
                             onClick={() => changeAccess('public')}
                           >
@@ -452,8 +460,7 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
                                 )
                               ) : null}
                             </div>
-                          </button>
-
+                          </button> */}
                           {/* Restricted */}
                           <button
                             className="flex h-16 w-full cursor-pointer items-center justify-start space-x-3 rounded-lg px-3 hover:bg-gray-5"
@@ -478,19 +485,20 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
                               ) : null}
                             </div>
                           </button>
-
                           {/* Stop sharing */}
-                          <button
-                            className="flex h-11 w-full cursor-pointer items-center justify-start rounded-lg pl-14 pr-3 hover:bg-gray-5"
-                            onClick={() => {
-                              setShowStopSharingConfirmation(true);
-                              close();
-                            }}
-                          >
-                            <p className="text-base font-medium">
-                              {translate('modals.shareModal.general.accessOptions.stopSharing')}
-                            </p>
-                          </button>
+                          {isCurrentFolderOwner && (
+                            <button
+                              className="flex h-11 w-full cursor-pointer items-center justify-start rounded-lg pl-14 pr-3 hover:bg-gray-5"
+                              onClick={() => {
+                                setShowStopSharingConfirmation(true);
+                                close();
+                              }}
+                            >
+                              <p className="text-base font-medium">
+                                {translate('modals.shareModal.general.accessOptions.stopSharing')}
+                              </p>
+                            </button>
+                          )}
                         </>
                       )}
                     </Popover.Panel>

--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -83,7 +83,7 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
   const [showStopSharingConfirmation, setShowStopSharingConfirmation] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [invitedUsers, setInvitedUsers] = useState<InvitedUserProps[]>([]);
-  const [isCurrentFolderOwner, setIsCurrentFolderOwner] = useState<boolean>(false);
+  const [currentUserFolderRole, setCurrentUserFolderRole] = useState<string | undefined>('');
 
   const [accessRequests, setAccessRequests] = useState<RequestProps[]>([]);
   const [userOptionsEmail, setUserOptionsEmail] = useState<InvitedUserProps>();
@@ -135,8 +135,8 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
   }, [accessRequests]);
 
   useEffect(() => {
-    const folderOwner = invitedUsers.find((user) => user.roleName === 'owner');
-    folderOwner?.email === props.user.email && setIsCurrentFolderOwner(folderOwner?.email === props.user.email);
+    const currentInvitedUser = invitedUsers.find((user) => user.email === props.user.email);
+    setCurrentUserFolderRole(currentInvitedUser?.roleName);
   }, [invitedUsers]);
 
   const getAndUpdateInvitedUsers = useCallback(async () => {
@@ -370,10 +370,12 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
                     </div>
                   </Button>
                 )}
-                <Button variant="secondary" onClick={onInviteUser}>
-                  <UserPlus size={24} />
-                  <span>{translate('modals.shareModal.list.invite')}</span>
-                </Button>
+                {(currentUserFolderRole === 'owner' || currentUserFolderRole === 'editor') && (
+                  <Button variant="secondary" onClick={onInviteUser}>
+                    <UserPlus size={24} />
+                    <span>{translate('modals.shareModal.list.invite')}</span>
+                  </Button>
+                )}
               </div>
             </div>
 
@@ -486,7 +488,7 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
                             </div>
                           </button>
                           {/* Stop sharing */}
-                          {isCurrentFolderOwner && (
+                          {currentUserFolderRole === 'owner' && (
                             <button
                               className="flex h-11 w-full cursor-pointer items-center justify-start rounded-lg pl-14 pr-3 hover:bg-gray-5"
                               onClick={() => {

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -109,10 +109,6 @@ export default function SharedView(): JSX.Element {
   }, []);
 
   useEffect(() => {
-    if (!isShowInvitationsOpen) fetchRootItems();
-  }, [isShowInvitationsOpen]);
-
-  useEffect(() => {
     if (!currentFolderId && !isShareDialogOpen) {
       fetchRootItems();
     } else if (currentFolderId && !isShareDialogOpen) {

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -79,8 +79,16 @@ export default function SharedView(): JSX.Element {
   }, []);
 
   useEffect(() => {
-    if (!isShowInvitationsOpen || !isShareDialogOpen) fetchRootItems();
-  }, [isShowInvitationsOpen, isShareDialogOpen]);
+    if (!isShowInvitationsOpen) fetchRootItems();
+  }, [isShowInvitationsOpen]);
+
+  useEffect(() => {
+    if (!currentFolderId && !isShareDialogOpen) {
+      fetchRootItems();
+    } else if (currentFolderId && !isShareDialogOpen) {
+      fetchFolders();
+    }
+  }, [isShareDialogOpen]);
 
   useEffect(() => {
     if (page === 0) {

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -79,8 +79,8 @@ export default function SharedView(): JSX.Element {
   }, []);
 
   useEffect(() => {
-    if (!isShowInvitationsOpen) fetchRootItems();
-  }, [isShowInvitationsOpen]);
+    if (!isShowInvitationsOpen || !isShareDialogOpen) fetchRootItems();
+  }, [isShowInvitationsOpen, isShareDialogOpen]);
 
   useEffect(() => {
     if (page === 0) {


### PR DESCRIPTION
- Reload list after manage users access
- Temporarily hide general access public option
- Hide general access options for users without permissions
- Hide invite button to viewers
- Temporarily Hide copy link button