### PR TITLE
[_] Fix/hide options according to role

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@iconscout/react-unicons": "^1.1.6",
     "@internxt/inxt-js": "=1.2.21",
     "@internxt/lib": "^1.2.0",
-    "@internxt/sdk": "1.4.46",
+    "@internxt/sdk": "1.4.48",
     "@phosphor-icons/react": "^2.0.10",
     "@popperjs/core": "^2.11.6",
     "@reduxjs/toolkit": "^1.6.0",

--- a/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveItemContextMenu.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveItemContextMenu.tsx
@@ -438,7 +438,7 @@ const contextMenuDriveItemSharedAFS = ({
       ]
     : [
         manageLinkAccessMenuItem(openShareAccessSettings), // TODO: UNCOMMENT TO CHECK ADVANCED SHARING
-        getGetLinkMenuItem(copyLink), // TODO: UNCOMMENT TO CHECK ADVANCED SHARING]),
+        //  getGetLinkMenuItem(copyLink), // TODO: UNCOMMENT TO CHECK ADVANCED SHARING]),
       ]),
   { name: '', action: () => false, separator: true },
   ...(isProduction ? [] : [getOpenPreviewMenuItem(openPreview)]),
@@ -468,7 +468,8 @@ const contextMenuDriveFolderSharedAFS = ({
 }): ListItemMenu<AdvancedSharedItem> => [
   ...(isProduction
     ? [...getSharedLinkMenuItems({ copyLink, openLinkSettings: openShareAccessSettings, deleteLink })]
-    : [manageLinkAccessMenuItem(openShareAccessSettings), getGetLinkMenuItem(copyLink)]),
+    : // TODO: UNCOMMENT getGetLinkMenuItem to enable get-link AFS
+      [manageLinkAccessMenuItem(openShareAccessSettings) /* getGetLinkMenuItem(copyLink) */]),
   { name: '', action: () => false, separator: true },
   renameItem && getRenameMenuItem(renameItem),
   moveItem && getMoveItemMenuItem(moveItem),

--- a/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
+++ b/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
@@ -157,7 +157,8 @@ const MoveItemsDialog = (props: MoveItemsDialogProps): JSX.Element => {
         if (!destinationFolderId) {
           destinationFolderId = currentFolderId;
         }
-        await restoreItemsFromTrash(itemsToMove, destinationFolderId, translate as TFunction);
+        // TODO:  change function name or separate logic to prevent confusions between moving and restoring
+        await restoreItemsFromTrash(itemsToMove, destinationFolderId, translate as TFunction, props.isTrash);
       }
 
       props.onItemsMoved && props.onItemsMoved();

--- a/src/app/i18n/locales/en.json
+++ b/src/app/i18n/locales/en.json
@@ -1104,6 +1104,7 @@
     "linkUpdated": "Link updated",
     "itemsMovedToTrash": "{{item}} moved to trash",
     "restoreItems": "{{itemsToRecover}} restored successfully",
+    "moveItems": "{{itemsToMove}} moved successfully",
     "itemDeleted": "{{item}} deleted",
     "itemsDeleted": "Files deleted",
     "emailNotEmpty": "Email must not be empty",

--- a/src/app/i18n/locales/es.json
+++ b/src/app/i18n/locales/es.json
@@ -1071,6 +1071,7 @@
     "linkUpdated": "Enlace actualizado",
     "itemsMovedToTrash": "{{item}} movid{{s}} a la papelera",
     "restoreItems": "{{itemsToRecover}} restaurad{{s}} con éxito",
+    "moveItems": "{{itemsToMove}} movid{{s}} con éxito",
     "itemDeleted": "{{item}} eliminado",
     "itemsDeleted": "Archivos eliminados",
     "emailNotEmpty": "El correo no debe estar vacío",

--- a/src/app/share/services/share.service.ts
+++ b/src/app/share/services/share.service.ts
@@ -252,6 +252,13 @@ export function acceptSharedFolderInvite({
   });
 }
 
+export function getUserRoleOfSharedRolder(sharingId: string): Promise<Role> {
+  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  return shareClient.getUserRole(sharingId).catch((error) => {
+    throw errorService.castError(error);
+  });
+}
+
 export function updateUserRoleOfSharedFolder({
   newRoleId,
   sharingId,
@@ -531,6 +538,7 @@ const shareService = {
   downloadSharedFiles,
   getUsersOfSharedFolder,
   updateUserRoleOfSharedFolder,
+  getUserRoleOfSharedRolder,
 };
 
 export default shareService;

--- a/src/app/share/types/index.ts
+++ b/src/app/share/types/index.ts
@@ -23,3 +23,9 @@ export type SharedNamePath = {
   token: string | null;
   uuid: string;
 };
+
+export enum UserRoles {
+  Editor = 'editor',
+  Reader = 'reader',
+  Owner = 'owner',
+}

--- a/src/app/share/types/index.ts
+++ b/src/app/share/types/index.ts
@@ -7,6 +7,7 @@ export type AdvancedSharedItem = SharedFolders &
     isFolder: boolean;
     isRootLink: boolean;
     credentials: NetworkCredentials;
+    sharingId?: string;
   };
 
 export type PreviewFileItem = DriveFileData & {

--- a/src/app/store/slices/sharedLinks/index.ts
+++ b/src/app/store/slices/sharedLinks/index.ts
@@ -43,6 +43,8 @@ export interface ShareLinksState {
     perPage: number;
     //totalItems: number;
   };
+  currentShareId: string | null;
+  currentSharingRole: Role['name'] | null;
 }
 
 const initialState: ShareLinksState = {
@@ -58,6 +60,8 @@ const initialState: ShareLinksState = {
     perPage: 50,
     //totalItems: 0,
   },
+  currentShareId: null,
+  currentSharingRole: null,
 };
 
 export const fetchSharedLinksThunk = createAsyncThunk<ListShareLinksResponse, void, { state: RootState }>(
@@ -322,6 +326,20 @@ const getPendingInvitations = createAsyncThunk<string | void, void, { state: Roo
   },
 );
 
+// Get role of the user in a sharing folder
+const getCurrentSharingRole = createAsyncThunk<string | void, void, { state: RootState }>(
+  'shareds/getUserSharingRole',
+  async (_, { dispatch }): Promise<string | void> => {
+    try {
+      const pendingInvitations = await getSharedFolderInvitationsAsInvitedUser({});
+
+      dispatch(sharedActions.setPendingInvitations(pendingInvitations.invites));
+    } catch (err: unknown) {
+      errorService.reportError(err, { extra: { thunk: 'getPendingInvitations' } });
+    }
+  },
+);
+
 export const sharedSlice = createSlice({
   name: 'shared',
   initialState,
@@ -331,6 +349,12 @@ export const sharedSlice = createSlice({
     },
     setPendingInvitations: (state: ShareLinksState, action: PayloadAction<any>) => {
       state.pendingInvitations = action.payload;
+    },
+    setCurrentShareId: (state: ShareLinksState, action: PayloadAction<any>) => {
+      state.currentShareId = action.payload;
+    },
+    setCurrentSharingRole: (state: ShareLinksState, action: PayloadAction<any>) => {
+      state.currentSharingRole = action.payload;
     },
   },
   extraReducers: (builder) => {

--- a/src/app/store/slices/sharedLinks/index.ts
+++ b/src/app/store/slices/sharedLinks/index.ts
@@ -29,6 +29,7 @@ import { t } from 'i18next';
 import userService from '../../../auth/services/user.service';
 import { encryptMessageWithPublicKey } from '../../../crypto/services/pgp.service';
 import { Role } from './types';
+import { UserRoles } from 'app/share/types';
 
 export interface ShareLinksState {
   isLoadingGeneratingLink: boolean;
@@ -44,7 +45,7 @@ export interface ShareLinksState {
     //totalItems: number;
   };
   currentShareId: string | null;
-  currentSharingRole: Role['name'] | null;
+  currentSharingRole: UserRoles | null;
 }
 
 const initialState: ShareLinksState = {
@@ -315,20 +316,6 @@ const getSharedFolderRoles = createAsyncThunk<string | void, void, { state: Root
 // Get pending invitations
 const getPendingInvitations = createAsyncThunk<string | void, void, { state: RootState }>(
   'shareds/getPendingInvitations',
-  async (_, { dispatch }): Promise<string | void> => {
-    try {
-      const pendingInvitations = await getSharedFolderInvitationsAsInvitedUser({});
-
-      dispatch(sharedActions.setPendingInvitations(pendingInvitations.invites));
-    } catch (err: unknown) {
-      errorService.reportError(err, { extra: { thunk: 'getPendingInvitations' } });
-    }
-  },
-);
-
-// Get role of the user in a sharing folder
-const getCurrentSharingRole = createAsyncThunk<string | void, void, { state: RootState }>(
-  'shareds/getUserSharingRole',
   async (_, { dispatch }): Promise<string | void> => {
     try {
       const pendingInvitations = await getSharedFolderInvitationsAsInvitedUser({});

--- a/src/use_cases/trash/recover-items-from-trash.ts
+++ b/src/use_cases/trash/recover-items-from-trash.ts
@@ -87,6 +87,7 @@ async function afterMoving(
   destinationId: number,
   failedItems: DriveItemData[],
   t: TFunction,
+  isTrash = false,
 ): Promise<void> {
   itemsToRecover = itemsToRecover.filter((el) => !failedItems.includes(el));
 
@@ -102,8 +103,10 @@ async function afterMoving(
     store.dispatch(storageActions.popItemsToDelete(itemsToRecover));
     store.dispatch(storageActions.clearSelectedItems());
 
-    const toastText = t('notificationMessages.restoreItems', {
-      itemsToRecover:
+    const translationKey = isTrash ? 'notificationMessages.restoreItems' : 'notificationMessages.moveItems';
+
+    const toastText = t(translationKey, {
+      [isTrash ? 'itemsToRecover' : 'itemsToMove']:
         itemsToRecover.length > 1
           ? t('general.files')
           : itemsToRecover[0].isFolder
@@ -128,6 +131,7 @@ const recoverItemsFromTrash = async (
   itemsToRecover: DriveItemData[],
   destinationId: number,
   t: TFunction,
+  isTrash = true,
 ): Promise<void> => {
   const failedItems: DriveItemData[] = [];
   for (const item of itemsToRecover) {
@@ -137,7 +141,7 @@ const recoverItemsFromTrash = async (
       await moveFile(item, item.fileId, destinationId, item.bucket, failedItems);
     }
   }
-  return afterMoving(itemsToRecover, destinationId, failedItems, t);
+  return afterMoving(itemsToRecover, destinationId, failedItems, t, isTrash);
 };
 
 export default recoverItemsFromTrash;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1638,10 +1638,10 @@
   resolved "https://npm.pkg.github.com/download/@internxt/prettier-config/1.0.2/9a19de23e3330a81c0e2bace1a6a0325fc8633197cf677e44ea75e54df315b5e"
   integrity sha512-t4HiqvCbC7XgQepwWlIaFJe3iwW7HCf6xOSU9nKTV0tiGqOPz7xMtIgLEloQrDA34Cx4PkOYBXrvFPV6RxSFAA==
 
-"@internxt/sdk@1.4.46":
-  version "1.4.46"
-  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.4.46/8c70683caaab78baf46767dc25746c4a81337b7d#8c70683caaab78baf46767dc25746c4a81337b7d"
-  integrity sha512-AuR6jUJp141xVurZ/ijzkKVmmD8+3fSacyZLY6T0ArGerBgebwP6jB1M/5QUklkKgNh7vrloX5BgCjEwfAirjg==
+"@internxt/sdk@1.4.48":
+  version "1.4.48"
+  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.4.48/a4ea383d3f86d115c3721f408f0fd4ae90f9e244#a4ea383d3f86d115c3721f408f0fd4ae90f9e244"
+  integrity sha512-Urrtc1Y7Wbr3hbLy61vuWnGpBxTT2J+dcT5/35MKmcKK5jbyPDomqMNq3/tJxEUhNlwX1GzdqmjNb/4UdkGdRg==
   dependencies:
     axios "^0.24.0"
     query-string "^7.1.0"


### PR DESCRIPTION
- [x]  The ‘viewer’ should not be able to see the upload files button 
- [x]  Any role should not be able to see the Get Link button on any item inside a shared folder, for now. 
- [x]  The moved items notification says ‘File restored successfully’, it should say ‘File moved successfully’ 
- [x]  The ‘viewer’ should not be able to see the rename option 