### PR TITLE
[PB-965]: Bugfix/User avatar is showing "uu" instead of the user initials

### DIFF
--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -908,7 +908,11 @@ export default function SharedView(): JSX.Element {
                 <div className="mr-2">
                   <Avatar
                     diameter={28}
-                    fullName={`${shareItem.user?.name} ${shareItem.user?.lastname}`}
+                    fullName={
+                      shareItem.user?.name
+                        ? `${shareItem.user?.name} ${shareItem.user?.lastname}`
+                        : `${user?.name} ${user?.lastname}`
+                    }
                     src={shareItem.user?.avatar ? shareItem.user?.avatar : null}
                   />
                 </div>


### PR DESCRIPTION
- Show folder owners correct initials in avatar icon