### PR TITLE
[_]: bugfix/item sharetype and role when navigating in shared view

### DIFF
--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -22,6 +22,7 @@ import copy from 'copy-to-clipboard';
 
 import crypto from 'crypto';
 import { aes } from '@internxt/lib';
+import { AdvancedSharedItem } from '../../../share/types';
 
 type AccessMode = 'public' | 'restricted';
 type UserRole = 'owner' | 'editor' | 'reader';
@@ -165,8 +166,11 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
   }, [itemToShare, roles]);
 
   const loadShareInfo = async () => {
-    // TODO -> Load access mode
-    const shareAccessMode: AccessMode = 'restricted';
+    // Change object type of itemToShare to AdvancedSharedItem
+    let shareAccessMode: AccessMode = 'public';
+    if ((itemToShare?.item as unknown as AdvancedSharedItem)?.sharingType) {
+      shareAccessMode = 'restricted';
+    }
     setAccessMode(shareAccessMode);
 
     // TODO -> Load invited users

--- a/src/app/share/types/index.ts
+++ b/src/app/share/types/index.ts
@@ -8,6 +8,7 @@ export type AdvancedSharedItem = SharedFolders &
     isRootLink: boolean;
     credentials: NetworkCredentials;
     sharingId?: string;
+    sharingType: 'public' | 'private';
   };
 
 export type PreviewFileItem = DriveFileData & {

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -256,17 +256,19 @@ export default function SharedView(): JSX.Element {
     if (currentFolderId && hasMoreFolders) {
       setIsLoading(true);
       try {
-        const response: ListSharedItemsResponse = await shareService.getSharedFolderContent(
+        const response: ListSharedItemsResponse & { role: string } = (await shareService.getSharedFolderContent(
           currentFolderId,
           'folders',
           currentResourcesToken,
           page,
           ITEMS_PER_PAGE,
           orderBy ? `${orderBy.field}:${orderBy.direction}` : undefined,
-        );
+        )) as ListSharedItemsResponse & { role: string };
 
         const token = response.token;
         setNextResourcesToken(token);
+
+        if (response.role) dispatch(sharedActions.setCurrentSharingRole(response.role.toLowerCase()));
 
         const folders = response.items.map((folder) => {
           const shareItem = folder as AdvancedSharedItem;
@@ -371,10 +373,6 @@ export default function SharedView(): JSX.Element {
   }, [currentShareId]);
 
   const onItemDoubleClicked = (shareItem: AdvancedSharedItem) => {
-    if (shareItem.sharingId) {
-      dispatch(sharedActions.setCurrentShareId(shareItem.sharingId));
-    }
-
     if (shareItem.isFolder) {
       dispatch(
         storageActions.pushSharedNamePath({


### PR DESCRIPTION
- Update user role while fetch items in Shared view
- Added `sharedType` field in Share dialog to select correctly share type (public or private)