### PR TITLE
[PB-991]: feat/download a single folder with its own name

### DIFF
--- a/src/app/share/services/share.service.ts
+++ b/src/app/share/services/share.service.ts
@@ -614,6 +614,10 @@ export async function downloadSharedFiles({
   } else {
     const initPage = 0;
     const itemsPerPage = 15;
+    let folderName;
+    if (selectedItems.length === 1 && selectedItems[0].isFolder) {
+      folderName = selectedItems[0].name;
+    }
 
     const createFoldersIterator = (directoryUuid: string, resourcesToken?: string) => {
       return new DirectorySharedFolderIterator(
@@ -638,6 +642,7 @@ export async function downloadSharedFiles({
         fileIterator: createFilesIterator,
         folderIterator: createFoldersIterator,
         areSharedItems: true,
+        sharedFolderName: folderName,
       }),
     );
   }

--- a/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/downloadItemsThunk.ts
@@ -132,6 +132,7 @@ type DownloadItemsAsZipThunkType = {
   mnemonic?: string;
   existingTaskId?: string;
   areSharedItems?: boolean;
+  sharedFolderName?: string;
 };
 
 type FolderIterator = (directoryId: number) => Iterator<DriveFolderData>;
@@ -143,7 +144,7 @@ type SharedFileIterator = (directoryId: string, resourcesToken) => Iterator<Shar
 export const downloadItemsAsZipThunk = createAsyncThunk<void, DownloadItemsAsZipThunkType, { state: RootState }>(
   'storage/downloadItemsAsZip',
   async (
-    { items, credentials, mnemonic, existingTaskId, folderIterator, fileIterator, areSharedItems },
+    { items, credentials, mnemonic, existingTaskId, folderIterator, fileIterator, areSharedItems, sharedFolderName },
     { rejectWithValue },
   ) => {
     const errors: unknown[] = [];
@@ -151,7 +152,7 @@ export const downloadItemsAsZipThunk = createAsyncThunk<void, DownloadItemsAsZip
     const downloadProgress: number[] = [];
     const abortController = new AbortController();
     const formattedDate = date.format(new Date(), 'DD/MM/YYYY - HH:mm');
-    const folderName = `Internxt (${formattedDate})`;
+    const folderName = sharedFolderName ?? `Internxt (${formattedDate})`;
     const folder = new FlatFolderZip(folderName, {});
 
     const moreOptions = {


### PR DESCRIPTION
Download a single folder in Shared with its own name. 

If we download multiple items, we maintain the name as we have now ->  **Internxt + Date**.