### PR TITLE
[PB-1013]: Fix/enable download of files from sharings Root list

### DIFF
--- a/src/app/share/types/index.ts
+++ b/src/app/share/types/index.ts
@@ -6,10 +6,15 @@ export type AdvancedSharedItem = SharedFolders &
   SharedFiles & {
     isFolder: boolean;
     isRootLink: boolean;
-    credentials: NetworkCredentials;
+    credentials: SharedNetworkCredentials;
     sharingId?: string;
     sharingType: 'public' | 'private';
   };
+
+export type SharedNetworkCredentials = {
+  networkUser: string;
+  networkPass: string;
+};
 
 export type PreviewFileItem = DriveFileData & {
   credentials?: NetworkCredentials;

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -185,7 +185,6 @@ export default function SharedView(): JSX.Element {
         shareItem.isFolder = true;
         shareItem.isRootLink = true;
         shareItem.name = getItemPlainName(shareItem as unknown as DriveItemData);
-        shareItem.credentials = { user: response.credentials.networkUser, pass: response.credentials.networkPass };
         return shareItem;
       });
 
@@ -225,10 +224,6 @@ export default function SharedView(): JSX.Element {
         shareItem.isFolder = false;
         shareItem.isRootLink = true;
         shareItem.name = getItemPlainName(shareItem as unknown as DriveItemData);
-        shareItem.credentials = {
-          user: response.credentials.networkUser,
-          pass: response.credentials.networkPass,
-        };
         return shareItem;
       });
 
@@ -269,7 +264,10 @@ export default function SharedView(): JSX.Element {
           shareItem.isFolder = true;
           shareItem.isRootLink = false;
           shareItem.name = getItemPlainName(shareItem as unknown as DriveItemData);
-          shareItem.credentials = { user: response.credentials.networkUser, pass: response.credentials.networkPass };
+          shareItem.credentials = {
+            networkUser: response.credentials.networkUser,
+            networkPass: response.credentials.networkPass,
+          };
           return shareItem;
         });
 
@@ -325,7 +323,10 @@ export default function SharedView(): JSX.Element {
           shareItem.isFolder = false;
           shareItem.isRootLink = false;
           shareItem.name = getItemPlainName(shareItem as unknown as DriveItemData);
-          shareItem.credentials = { user: response.credentials.networkUser, pass: response.credentials.networkPass };
+          shareItem.credentials = {
+            networkUser: response.credentials.networkUser,
+            networkPass: response.credentials.networkPass,
+          };
           return shareItem;
         });
 
@@ -600,19 +601,10 @@ export default function SharedView(): JSX.Element {
   const downloadItem = async (shareItem: AdvancedSharedItem) => {
     try {
       if (shareItem.isRootLink) {
-        const { credentials } = await shareService.getSharedFolderContent(
-          // folderUUID
-          shareItem.uuid,
-          'files',
-          '',
-          0,
-          ITEMS_PER_PAGE,
-          orderBy ? `${orderBy.field}:${orderBy.direction}` : undefined,
-        );
         await shareService.downloadSharedFiles({
           creds: {
-            user: credentials.networkUser,
-            pass: credentials.networkPass,
+            user: shareItem.credentials.networkUser,
+            pass: shareItem.credentials.networkPass,
           },
           dispatch,
           selectedItems,
@@ -628,7 +620,10 @@ export default function SharedView(): JSX.Element {
           orderBy ? `${orderBy.field}:${orderBy.direction}` : undefined,
         );
         await shareService.downloadSharedFiles({
-          creds: shareItem.credentials,
+          creds: {
+            user: shareItem.credentials.networkUser,
+            pass: shareItem.credentials.networkPass,
+          },
           dispatch,
           selectedItems,
           encryptionKey: encryptionKey,
@@ -679,6 +674,7 @@ export default function SharedView(): JSX.Element {
 
   const openPreview = async (shareItem: AdvancedSharedItem) => {
     const previewItem = shareItem as unknown as PreviewFileItem;
+    previewItem.credentials = { user: shareItem.credentials.networkUser, pass: shareItem.credentials.networkPass };
 
     const mnemonic = await decryptMnemonic(shareItem.encryptionKey ? shareItem.encryptionKey : encryptionKey);
 


### PR DESCRIPTION
1. Get owner credentials from response to download files and folders instead of extra request.

needs:

https://github.com/internxt/drive-server-wip/pull/214