### PR TITLE
[_]: fix/remove .folder extension from span title (Grid view)

### DIFF
--- a/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerGridItem/DriveExplorerGridItem.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerGridItem/DriveExplorerGridItem.tsx
@@ -67,7 +67,7 @@ const DriveExplorerGridItem = (props: DriveExplorerItemProps): JSX.Element => {
           data-test={`${item.isFolder ? 'folder' : 'file'}-name`}
           className={`${ṣpanDisplayClass} cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap px-1 text-base text-neutral-900 hover:underline`}
           onClick={onNameClicked}
-          title={items.getItemDisplayName(item)}
+          title={transformItemService.getItemPlainNameWithExtension(item) ?? items.getItemDisplayName(item)}
         >
           {transformItemService.getItemPlainNameWithExtension(item) ?? items.getItemDisplayName(item)}
         </span>


### PR DESCRIPTION
**PROBLEM:**
* When the user places the mouse over the name of a folder, the extension (.folder) is displayed.

**FIX:**
* Now, we always check if the item is a folder to hide the extension