### PR TITLE
[PB-473] bugfix:File/folder lists in drive-web are not consistent

### DIFF
--- a/src/app/backups/components/BackupsAsFoldersList/BackupsAsFoldersList.tsx
+++ b/src/app/backups/components/BackupsAsFoldersList/BackupsAsFoldersList.tsx
@@ -9,13 +9,15 @@ import { deleteItemsThunk } from '../../../store/slices/storage/storage.thunks/d
 import folderEmptyImage from 'assets/icons/light/folder-open.svg';
 import { downloadItemsThunk } from '../../../store/slices/storage/storage.thunks/downloadItemsThunk';
 import { uiActions } from '../../../store/slices/ui';
-import BackupsAsFoldersListItem from './BackupsAsFoldersListItem';
 import DriveListItemSkeleton from '../../../drive/components/DriveListItemSkeleton/DriveListItemSkeleton';
 import { deleteBackupDeviceAsFolder } from '../../../drive/services/folder.service';
 import { deleteFile } from '../../../drive/services/file.service';
 import List from '../../../shared/components/List';
 import { contextMenuSelectedBackupItems } from '../../../drive/components/DriveExplorer/DriveExplorerList/DriveItemContextMenu';
 import { useTranslationContext } from '../../../i18n/provider/TranslationProvider';
+import iconService from '../../../drive/services/icon.service';
+import dateService from '../../../core/services/date.service';
+import sizeService from '../../../drive/services/size.service';
 
 export default function BackupsAsFoldersList({
   className = '',
@@ -101,21 +103,21 @@ export default function BackupsAsFoldersList({
             header={[
               {
                 label: translate('drive.list.columns.name'),
-                width: 'flex flex-grow cursor-pointer items-center pl-6',
+                width: 'flex-1 min-w-activity truncate flex-shrink-0 cursor-pointer items-center',
                 name: 'name',
                 orderable: true,
                 defaultDirection: 'ASC',
               },
               {
                 label: translate('drive.list.columns.modified'),
-                width: 'hidden w-3/12 lg:flex pl-4',
+                width: 'w-date',
                 name: 'updatedAt',
                 orderable: true,
                 defaultDirection: 'ASC',
               },
               {
                 label: translate('drive.list.columns.size'),
-                width: 'flex w-2/12 cursor-pointer items-center',
+                width: 'flex cursor-pointer items-center w-size',
                 name: 'size',
                 orderable: true,
                 defaultDirection: 'ASC',
@@ -124,15 +126,26 @@ export default function BackupsAsFoldersList({
             items={currentItems}
             isLoading={isLoading}
             itemComposition={[
-              (item) => (
-                <BackupsAsFoldersListItem
-                  key={`${item.isFolder ? 'folder' : 'file'}-${item.id}`}
-                  item={item}
-                  onClick={onClick}
-                  dataTest="backup-list-folder"
-                />
-              ),
+              (item) => {
+                const displayName = item.type ? `${item.name}.${item.type}` : item.name;
+                const Icon = iconService.getItemIcon(item.isFolder, item.type);
+
+                return (
+                  <div className="flex flex-grow cursor-pointer items-center justify-center">
+                    <Icon className="mr-3 h-8 w-8" />
+                    <p className="flex-grow">{displayName}</p>
+                  </div>
+                );
+              },
+              (item) => {
+                return <div>{dateService.format(item.createdAt, 'DD MMMM YYYY. HH:mm')}</div>;
+              },
+              (item) => {
+                const size = 'size' in item ? sizeService.bytesToString(item.size) : '';
+                return <div>{size}</div>;
+              },
             ]}
+            onClick={onClick}
             skinSkeleton={Skeleton}
             emptyState={
               <Empty
@@ -154,7 +167,6 @@ export default function BackupsAsFoldersList({
               }));
               onItemSelected(selectedDevicesParsed);
             }}
-            disableItemCompositionStyles={true}
           />
         )}
       </div>

--- a/src/app/backups/components/BackupsAsFoldersList/BackupsAsFoldersList.tsx
+++ b/src/app/backups/components/BackupsAsFoldersList/BackupsAsFoldersList.tsx
@@ -103,7 +103,7 @@ export default function BackupsAsFoldersList({
             header={[
               {
                 label: translate('drive.list.columns.name'),
-                width: 'flex-1 min-w-activity truncate flex-shrink-0 cursor-pointer items-center',
+                width: 'flex-1 min-w-activity truncate cursor-pointer',
                 name: 'name',
                 orderable: true,
                 defaultDirection: 'ASC',
@@ -117,7 +117,7 @@ export default function BackupsAsFoldersList({
               },
               {
                 label: translate('drive.list.columns.size'),
-                width: 'flex cursor-pointer items-center w-size',
+                width: 'cursor-pointer items-center w-size',
                 name: 'size',
                 orderable: true,
                 defaultDirection: 'ASC',
@@ -131,9 +131,11 @@ export default function BackupsAsFoldersList({
                 const Icon = iconService.getItemIcon(item.isFolder, item.type);
 
                 return (
-                  <div className="flex flex-grow cursor-pointer items-center justify-center">
-                    <Icon className="mr-3 h-8 w-8" />
-                    <p className="flex-grow">{displayName}</p>
+                  <div className="flex min-w-activity flex-grow cursor-pointer items-center justify-start pr-3">
+                    <div className="mr-3 h-8 w-8">
+                      <Icon className="h-8 w-8" />
+                    </div>
+                    <p className="flex-grow truncate">{displayName}</p>
                   </div>
                 );
               },

--- a/src/app/backups/components/BackupsAsFoldersList/BackupsAsFoldersList.tsx
+++ b/src/app/backups/components/BackupsAsFoldersList/BackupsAsFoldersList.tsx
@@ -68,9 +68,12 @@ export default function BackupsAsFoldersList({
     dispatch(deleteItemsThunk(selectedItems));
   }
 
-  const onDoubleClick = (item: DriveItemData) => {
+  const onClick = (item: DriveItemData) => {
     if (item.isFolder) {
-      onFolderPush(item as DriveFolderData);
+      if (!isLoading) {
+        setIsloading(true);
+        onFolderPush(item as DriveFolderData);
+      }
     } else {
       dispatch(uiActions.setIsFileViewerOpen(true));
       dispatch(uiActions.setFileViewerItem(item));
@@ -91,71 +94,69 @@ export default function BackupsAsFoldersList({
   return (
     <div className={`${className} flex min-h-0 flex-grow flex-col`}>
       <div className="flex h-full w-full flex-col overflow-y-auto">
-        <List<DriveItemData, 'name' | 'updatedAt' | 'size'>
-          header={[
-            {
-              label: translate('drive.list.columns.name'),
-              width: 'flex flex-grow cursor-pointer items-center pl-6',
-              name: 'name',
-              orderable: true,
-              defaultDirection: 'ASC',
-            },
-            {
-              label: translate('drive.list.columns.modified'),
-              width: 'hidden w-3/12 lg:flex pl-4',
-              name: 'updatedAt',
-              orderable: true,
-              defaultDirection: 'ASC',
-            },
-            {
-              label: translate('drive.list.columns.size'),
-              width: 'flex w-2/12 cursor-pointer items-center',
-              name: 'size',
-              orderable: true,
-              defaultDirection: 'ASC',
-            },
-          ]}
-          items={currentItems}
-          isLoading={isLoading}
-          itemComposition={[
-            (item) => (
-              <BackupsAsFoldersListItem
-                key={`${item.isFolder ? 'folder' : 'file'}-${item.id}`}
-                item={item}
-                onClick={(item) => {
-                  const unselectedDevices = selectedItems.map((deviceSelected) => {
-                    return { device: deviceSelected, isSelected: false };
-                  });
-                  onItemSelected([...unselectedDevices, { device: item, isSelected: true }]);
-                }}
-                onDoubleClick={onDoubleClick}
-                dataTest="backup-list-folder"
+        {isLoading ? (
+          Skeleton
+        ) : (
+          <List<DriveItemData, 'name' | 'updatedAt' | 'size'>
+            header={[
+              {
+                label: translate('drive.list.columns.name'),
+                width: 'flex flex-grow cursor-pointer items-center pl-6',
+                name: 'name',
+                orderable: true,
+                defaultDirection: 'ASC',
+              },
+              {
+                label: translate('drive.list.columns.modified'),
+                width: 'hidden w-3/12 lg:flex pl-4',
+                name: 'updatedAt',
+                orderable: true,
+                defaultDirection: 'ASC',
+              },
+              {
+                label: translate('drive.list.columns.size'),
+                width: 'flex w-2/12 cursor-pointer items-center',
+                name: 'size',
+                orderable: true,
+                defaultDirection: 'ASC',
+              },
+            ]}
+            items={currentItems}
+            isLoading={isLoading}
+            itemComposition={[
+              (item) => (
+                <BackupsAsFoldersListItem
+                  key={`${item.isFolder ? 'folder' : 'file'}-${item.id}`}
+                  item={item}
+                  onClick={onClick}
+                  dataTest="backup-list-folder"
+                />
+              ),
+            ]}
+            skinSkeleton={Skeleton}
+            emptyState={
+              <Empty
+                icon={<img className="w-36" alt="" src={folderEmptyImage} />}
+                title="This folder is empty"
+                subtitle="Use Internxt Desktop to upload your data"
               />
-            ),
-          ]}
-          skinSkeleton={Skeleton}
-          emptyState={
-            <Empty
-              icon={<img className="w-36" alt="" src={folderEmptyImage} />}
-              title="This folder is empty"
-              subtitle="Use Internxt Desktop to upload your data"
-            />
-          }
-          menu={contextMenuSelectedBackupItems({
-            onDownloadSelectedItems,
-            onDeleteSelectedItems,
-          })}
-          selectedItems={selectedItems}
-          keyboardShortcuts={['unselectAll', 'selectAll', 'multiselect']}
-          onSelectedItemsChanged={(changes) => {
-            const selectedDevicesParsed = changes.map((change) => ({
-              device: change.props,
-              isSelected: change.value,
-            }));
-            onItemSelected(selectedDevicesParsed);
-          }}
-          disableItemCompositionStyles={true}
-        />
+            }
+            menu={contextMenuSelectedBackupItems({
+              onDownloadSelectedItems,
+              onDeleteSelectedItems,
+            })}
+            selectedItems={selectedItems}
+            keyboardShortcuts={['unselectAll', 'selectAll', 'multiselect']}
+            onSelectedItemsChanged={(changes) => {
+              const selectedDevicesParsed = changes.map((change) => ({
+                device: change.props,
+                isSelected: change.value,
+              }));
+              onItemSelected(selectedDevicesParsed);
+            }}
+            disableItemCompositionStyles={true}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/app/backups/components/BackupsAsFoldersList/BackupsAsFoldersList.tsx
+++ b/src/app/backups/components/BackupsAsFoldersList/BackupsAsFoldersList.tsx
@@ -41,6 +41,7 @@ export default function BackupsAsFoldersList({
 
   async function refreshFolderContent() {
     setIsloading(true);
+    setSelectedItems([]);
     const storageClient = SdkFactory.getInstance().createStorageClient();
     const [responsePromise] = storageClient.getFolderContent(folderId);
     const response = await responsePromise;
@@ -131,11 +132,15 @@ export default function BackupsAsFoldersList({
                 const Icon = iconService.getItemIcon(item.isFolder, item.type);
 
                 return (
-                  <div className="flex min-w-activity flex-grow cursor-pointer items-center justify-start pr-3">
+                  <div className="flex min-w-activity flex-grow items-center justify-start pr-3">
                     <div className="mr-3 h-8 w-8">
                       <Icon className="h-8 w-8" />
                     </div>
-                    <p className="flex-grow truncate">{displayName}</p>
+                    <div className="flex-grow cursor-default truncate">
+                      <span className="z-10 flex-shrink cursor-pointer truncate" onClick={() => onClick(item)}>
+                        {displayName}
+                      </span>
+                    </div>
                   </div>
                 );
               },
@@ -147,7 +152,14 @@ export default function BackupsAsFoldersList({
                 return <div>{size}</div>;
               },
             ]}
-            onClick={onClick}
+            onClick={(item) => {
+              const unselectedDevices = selectedItems.map((deviceSelected) => ({
+                device: deviceSelected,
+                isSelected: false,
+              }));
+              onItemSelected([...unselectedDevices, { device: item, isSelected: true }]);
+            }}
+            onDoubleClick={onClick}
             skinSkeleton={Skeleton}
             emptyState={
               <Empty

--- a/src/app/backups/components/BackupsAsFoldersList/BackupsAsFoldersListItem.tsx
+++ b/src/app/backups/components/BackupsAsFoldersList/BackupsAsFoldersListItem.tsx
@@ -25,14 +25,14 @@ export default function BackupsAsFoldersListItem({
       onDoubleClick={() => onDoubleClick?.(item)}
       data-test={dataTest}
     >
-      <div className="box-content flex w-0.5/12 items-center justify-center px-3">
+      <div className="box-content flex w-0.5/12 items-center justify-center pr-3">
         <Icon className={'h-8 w-8'} />
       </div>
       <p className="flex-1 truncate pr-3">{displayName}</p>
-      <div className="hidden w-3/12 items-center lg:flex">
+      <div className="w-3/12 min-w-date items-center lg:flex">
         {dateService.format(item.createdAt, 'DD MMMM YYYY. HH:mm')}
       </div>
-      <div className="flex w-2/12 items-center">{size}</div>
+      <div className="flex w-2/12 min-w-breadcrumb items-center">{size}</div>
     </div>
   );
 }

--- a/src/app/backups/components/BackupsAsFoldersList/BackupsAsFoldersListItem.tsx
+++ b/src/app/backups/components/BackupsAsFoldersList/BackupsAsFoldersListItem.tsx
@@ -11,7 +11,7 @@ export default function BackupsAsFoldersListItem({
 }: {
   item: DriveItemData;
   onClick: (target: typeof item) => void;
-  onDoubleClick: (target: typeof item) => void;
+  onDoubleClick?: (target: typeof item) => void;
   dataTest?: string;
 }): JSX.Element {
   const Icon = iconService.getItemIcon(item.isFolder, item.type);
@@ -20,9 +20,9 @@ export default function BackupsAsFoldersListItem({
 
   return (
     <div
-      className={'flex flex-grow items-center'}
+      className={'flex flex-grow cursor-pointer items-center'}
       onClick={() => onClick(item)}
-      onDoubleClick={() => onDoubleClick(item)}
+      onDoubleClick={() => onDoubleClick?.(item)}
       data-test={dataTest}
     >
       <div className="box-content flex w-0.5/12 items-center justify-center px-3">

--- a/src/app/backups/components/DeviceList/DeviceList.tsx
+++ b/src/app/backups/components/DeviceList/DeviceList.tsx
@@ -89,9 +89,15 @@ const DeviceList = (props: Props): JSX.Element => {
                 }
               } else Icon = UilDesktop;
               return (
-                <div className="flex flex-row items-center justify-center">
-                  <Icon className="mr-3 h-8 w-8" />
-                  <p className="flex-grow">{device.name}</p>
+                <div className="flex min-w-activity cursor-default flex-row items-center justify-center">
+                  <div className="mr-3 h-8 w-8">
+                    <Icon className="h-8 w-8" />
+                  </div>
+                  <div className="flex-grow cursor-default truncate pr-3">
+                    <span className="z-10 flex-shrink cursor-pointer truncate" onClick={() => onDeviceClicked(device)}>
+                      {device.name}
+                    </span>
+                  </div>
                 </div>
               );
             },
@@ -101,7 +107,14 @@ const DeviceList = (props: Props): JSX.Element => {
               return <div>{size}</div>;
             },
           ]}
-          onClick={onDeviceClicked}
+          onClick={(item) => {
+            const unselectedDevices = selectedItems.map((deviceSelected) => ({
+              device: deviceSelected,
+              isSelected: false,
+            }));
+            onDeviceSelected([...unselectedDevices, { device: item, isSelected: true }]);
+          }}
+          onDoubleClick={onDeviceClicked}
           skinSkeleton={getLoadingSkeleton()}
           emptyState={
             <Empty

--- a/src/app/backups/components/DeviceList/DeviceList.tsx
+++ b/src/app/backups/components/DeviceList/DeviceList.tsx
@@ -68,13 +68,7 @@ const DeviceList = (props: Props): JSX.Element => {
             (props) => (
               <DeviceListItem
                 device={props}
-                onClick={(device) => {
-                  const unselectedDevices = selectedItems.map((deviceSelected) => {
-                    return { device: deviceSelected, isSelected: false };
-                  });
-
-                  onDeviceSelected([...unselectedDevices, { device, isSelected: true }]);
-                }}
+                onClick={(device) => onDeviceClicked(device)}
                 onDoubleClick={(device) => onDeviceClicked(device)}
                 dataTest="device-list-item"
               />

--- a/src/app/backups/components/DeviceList/DeviceList.tsx
+++ b/src/app/backups/components/DeviceList/DeviceList.tsx
@@ -1,4 +1,3 @@
-import DeviceListItem from './DeviceListItem';
 import desktopService from '../../../core/services/desktop.service';
 import { Device } from '../../types';
 import DriveListItemSkeleton from '../../../drive/components/DriveListItemSkeleton/DriveListItemSkeleton';
@@ -10,6 +9,12 @@ import notificationsService, { ToastType } from 'app/notifications/services/noti
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
 import List from '../../../shared/components/List';
 import { contextMenuBackupItems } from '../../../drive/components/DriveExplorer/DriveExplorerList/DriveItemContextMenu';
+import UilApple from '@iconscout/react-unicons/icons/uil-apple';
+import UilLinux from '@iconscout/react-unicons/icons/uil-linux';
+import UilWindows from '@iconscout/react-unicons/icons/uil-windows';
+import UilDesktop from '@iconscout/react-unicons/icons/uil-desktop';
+import dateService from '../../../core/services/date.service';
+import sizeService from '../../../drive/services/size.service';
 
 interface Props {
   items: (Device | DriveFolderData)[];
@@ -42,21 +47,21 @@ const DeviceList = (props: Props): JSX.Element => {
           header={[
             {
               label: translate('drive.list.columns.name'),
-              width: 'flex flex-grow cursor-pointer items-center pl-6',
+              width: 'flex-1 min-w-activity truncate flex-shrink-0 cursor-pointer items-center',
               name: 'name',
               orderable: true,
               defaultDirection: 'ASC',
             },
             {
               label: translate('drive.list.columns.modified'),
-              width: 'hidden w-3/12 lg:flex pl-4',
+              width: 'w-date',
               name: 'updatedAt',
               orderable: true,
               defaultDirection: 'ASC',
             },
             {
               label: translate('drive.list.columns.size'),
-              width: 'flex w-2/12 cursor-pointer items-center',
+              width: 'flex cursor-pointer items-center w-size',
               name: 'size',
               orderable: true,
               defaultDirection: 'ASC',
@@ -65,15 +70,38 @@ const DeviceList = (props: Props): JSX.Element => {
           items={props.items as Device[] | (DriveFolderData & { size: number })[]}
           isLoading={isLoading}
           itemComposition={[
-            (props) => (
-              <DeviceListItem
-                device={props}
-                onClick={(device) => onDeviceClicked(device)}
-                onDoubleClick={(device) => onDeviceClicked(device)}
-                dataTest="device-list-item"
-              />
-            ),
+            (device) => {
+              let Icon;
+
+              if ('platform' in device) {
+                switch (device.platform) {
+                  case 'darwin':
+                    Icon = UilApple;
+                    break;
+                  case 'linux':
+                    Icon = UilLinux;
+                    break;
+                  case 'win32':
+                    Icon = UilWindows;
+                    break;
+                  default:
+                    Icon = UilDesktop;
+                }
+              } else Icon = UilDesktop;
+              return (
+                <div className="flex flex-row items-center justify-center">
+                  <Icon className="mr-3 h-8 w-8" />
+                  <p className="flex-grow">{device.name}</p>
+                </div>
+              );
+            },
+            (device) => <div>{dateService.format(device.updatedAt, 'DD MMMM YYYY. HH:mm')}</div>,
+            (device) => {
+              const size = 'size' in device ? sizeService.bytesToString(device.size) : '';
+              return <div>{size}</div>;
+            },
           ]}
+          onClick={onDeviceClicked}
           skinSkeleton={getLoadingSkeleton()}
           emptyState={
             <Empty
@@ -109,7 +137,7 @@ const DeviceList = (props: Props): JSX.Element => {
             const selectedDevicesParsed = changes.map((change) => ({ device: change.props, isSelected: change.value }));
             onDeviceSelected(selectedDevicesParsed);
           }}
-          disableItemCompositionStyles={true}
+          // disableItemCompositionStyles={true}
         />
       </div>
     </div>

--- a/src/app/backups/components/DeviceList/DeviceListItem.tsx
+++ b/src/app/backups/components/DeviceList/DeviceListItem.tsx
@@ -15,7 +15,7 @@ export default function DeviceListItem({
 }: {
   device: Device | (DriveFolderData & { size: number });
   onClick: (clickedDevice: typeof device) => void;
-  onDoubleClick: (clickedDevice: typeof device) => void;
+  onDoubleClick?: (clickedDevice: typeof device) => void;
   dataTest?: string;
 }): JSX.Element {
   let Icon;
@@ -40,9 +40,9 @@ export default function DeviceListItem({
 
   return (
     <div
-      className="flex flex-grow items-center py-3.5"
+      className="flex flex-grow cursor-pointer items-center py-3.5"
       onClick={() => onClick(device)}
-      onDoubleClick={() => onDoubleClick(device)}
+      onDoubleClick={() => onDoubleClick?.(device)}
       data-test={dataTest}
     >
       <div className="box-content flex w-0.5/12 items-center justify-center px-3">

--- a/src/app/backups/components/DeviceList/DeviceListItem.tsx
+++ b/src/app/backups/components/DeviceList/DeviceListItem.tsx
@@ -45,15 +45,15 @@ export default function DeviceListItem({
       onDoubleClick={() => onDoubleClick?.(device)}
       data-test={dataTest}
     >
-      <div className="box-content flex w-0.5/12 items-center justify-center px-3">
-        <Icon className="h-8 w-8" />
+      <div className="box-content flex flex-grow items-center justify-center">
+        <Icon className="mr-3 h-8 w-8" />
+        <p className="flex-grow">{device.name}</p>
       </div>
-      <p className="flex-grow pr-3">{device.name}</p>
-      <div className="hidden w-2/12 items-center xl:flex"></div>
-      <div className="hidden w-3/12 items-center lg:flex">
+      {/* <div className="hidden w-2/12 items-center xl:flex"></div> */}
+      <div className="w-3/12 min-w-date items-center lg:flex">
         {dateService.format(device.updatedAt, 'DD MMMM YYYY. HH:mm')}
       </div>
-      <div className="flex w-2/12 items-center">{size}</div>
+      <div className="flex w-2/12 min-w-breadcrumb items-center">{size}</div>
     </div>
   );
 }

--- a/src/app/backups/views/BackupsView/BackupsView.tsx
+++ b/src/app/backups/views/BackupsView/BackupsView.tsx
@@ -27,7 +27,6 @@ export default function BackupsView(): JSX.Element {
   const [backupsAsFoldersPath, setBackupsAsFoldersPath] = useState<DriveFolderData[]>([]);
 
   const onDeviceClicked = (target: Device | DriveFolderData) => {
-    console.log('ondeviceclicked');
     dispatch(backupsActions.setCurrentDevice(target));
     if ('mac' in target) {
       dispatch(backupsThunks.fetchDeviceBackupsThunk(target.mac));

--- a/src/app/backups/views/BackupsView/BackupsView.tsx
+++ b/src/app/backups/views/BackupsView/BackupsView.tsx
@@ -27,6 +27,7 @@ export default function BackupsView(): JSX.Element {
   const [backupsAsFoldersPath, setBackupsAsFoldersPath] = useState<DriveFolderData[]>([]);
 
   const onDeviceClicked = (target: Device | DriveFolderData) => {
+    setSelectedDevices([]);
     dispatch(backupsActions.setCurrentDevice(target));
     if ('mac' in target) {
       dispatch(backupsThunks.fetchDeviceBackupsThunk(target.mac));
@@ -34,6 +35,7 @@ export default function BackupsView(): JSX.Element {
   };
 
   const goBack = () => {
+    setSelectedDevices([]);
     dispatch(backupsActions.setCurrentDevice(null));
   };
 

--- a/src/app/backups/views/BackupsView/BackupsView.tsx
+++ b/src/app/backups/views/BackupsView/BackupsView.tsx
@@ -92,7 +92,8 @@ export default function BackupsView(): JSX.Element {
     {
       id: -1,
       label: `${translate('backups.your-devices')}`,
-      icon: <UilHdd className="mr-1 h-4 w-4" />,
+      icon: null,
+      isFirstPath: true,
       active: true,
       onClick: () => goBack(),
     },

--- a/src/app/backups/views/BackupsView/BackupsView.tsx
+++ b/src/app/backups/views/BackupsView/BackupsView.tsx
@@ -148,7 +148,7 @@ export default function BackupsView(): JSX.Element {
 
   return (
     <div
-      className="flex flex-grow flex-col"
+      className="flex w-full flex-shrink-0 flex-grow flex-col"
       onContextMenu={(e) => {
         e.preventDefault();
       }}

--- a/src/app/backups/views/BackupsView/BackupsView.tsx
+++ b/src/app/backups/views/BackupsView/BackupsView.tsx
@@ -24,8 +24,10 @@ export default function BackupsView(): JSX.Element {
 
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [selectedDevices, setSelectedDevices] = useState<(Device | DriveFolderData)[]>([]);
+  const [backupsAsFoldersPath, setBackupsAsFoldersPath] = useState<DriveFolderData[]>([]);
 
   const onDeviceClicked = (target: Device | DriveFolderData) => {
+    console.log('ondeviceclicked');
     dispatch(backupsActions.setCurrentDevice(target));
     if ('mac' in target) {
       dispatch(backupsThunks.fetchDeviceBackupsThunk(target.mac));
@@ -71,10 +73,11 @@ export default function BackupsView(): JSX.Element {
   };
 
   useEffect(() => {
+    dispatch(backupsActions.setCurrentDevice(null));
+    setBackupsAsFoldersPath([]);
     dispatch(backupsThunks.fetchDevicesThunk());
   }, []);
 
-  const [backupsAsFoldersPath, setBackupsAsFoldersPath] = useState<DriveFolderData[]>([]);
   useEffect(() => {
     if (currentDevice && !('mac' in currentDevice)) setBackupsAsFoldersPath([currentDevice]);
   }, [currentDevice]);

--- a/src/app/database/services/database.service/index.ts
+++ b/src/app/database/services/database.service/index.ts
@@ -10,6 +10,7 @@ export enum DatabaseProvider {
 
 export enum DatabaseCollection {
   Levels = 'levels',
+  MoveDialogLevels = 'move_levels',
   Photos = 'photos',
   LevelsBlobs = 'levels_blobs',
   LRU_cache = 'lru_cache',
@@ -44,6 +45,11 @@ export type AvatarBlobData = {
 
 export interface AppDatabase extends DBSchema {
   levels: {
+    key: number;
+    value: DriveItemData[];
+    indexes?: Record<string, IDBValidKey>;
+  };
+  move_levels: {
     key: number;
     value: DriveItemData[];
     indexes?: Record<string, IDBValidKey>;

--- a/src/app/database/services/database.service/indexed-db.service.ts
+++ b/src/app/database/services/database.service/indexed-db.service.ts
@@ -5,7 +5,6 @@ import { AppDatabase, DatabaseService } from '.';
 const open = (name: string, version?: number): Promise<idb.IDBPDatabase<AppDatabase>> => {
   return idb.openDB<AppDatabase>(name, version, {
     upgrade: (db, oldVersion) => {
-      console.log({ oldVersion });
       if (oldVersion === 0) db.createObjectStore('levels');
       if (oldVersion <= 1) db.createObjectStore('photos');
       if (oldVersion <= 2) {

--- a/src/app/database/services/database.service/indexed-db.service.ts
+++ b/src/app/database/services/database.service/indexed-db.service.ts
@@ -5,6 +5,7 @@ import { AppDatabase, DatabaseService } from '.';
 const open = (name: string, version?: number): Promise<idb.IDBPDatabase<AppDatabase>> => {
   return idb.openDB<AppDatabase>(name, version, {
     upgrade: (db, oldVersion) => {
+      console.log({ oldVersion });
       if (oldVersion === 0) db.createObjectStore('levels');
       if (oldVersion <= 1) db.createObjectStore('photos');
       if (oldVersion <= 2) {
@@ -14,6 +15,9 @@ const open = (name: string, version?: number): Promise<idb.IDBPDatabase<AppDatab
       }
       if (oldVersion <= 3) {
         db.createObjectStore('account_settings');
+      }
+      if (oldVersion <= 4) {
+        db.createObjectStore('move_levels');
       }
     },
     blocked: () => undefined,

--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -1010,6 +1010,7 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
                       text: translate('views.recents.empty.uploadFiles'),
                       onClick: onUploadFileButtonClicked,
                     }}
+                    contextMenuClick={handleContextMenuClick}
                   />
                 ))
             }

--- a/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerListItem/DriveExplorerListItem.scss
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerListItem/DriveExplorerListItem.scss
@@ -1,6 +1,6 @@
 @layer components {
   .file-list-item {
-    @apply relative flex flex-grow w-full flex-row items-center text-base;
+    @apply relative flex flex-grow flex-row items-center text-base;
 
     &.selected {
       @apply border-blue-20 border-opacity-65;
@@ -33,9 +33,9 @@
     }
   }
 
-  .file-list-item-name-span {
-    @apply flex-1 cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap px-1 text-gray-80;
-  }
+  // .file-list-item-name-span {
+  //   @apply flex-1 cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap px-1 text-gray-80;
+  // }
 
   .file-list-item-actions-button {
     @apply h-5 w-5 rounded-1/2 bg-neutral-20 p-0.5 font-bold text-primary;

--- a/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerListItem/DriveExplorerListItem.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerListItem/DriveExplorerListItem.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useEffect } from 'react';
-import { PencilSimple, Users } from '@phosphor-icons/react';
+import { PencilSimple } from '@phosphor-icons/react';
 import { items } from '@internxt/lib';
 import sizeService from '../../../../../drive/services/size.service';
 import dateService from '../../../../../core/services/date.service';
@@ -103,41 +103,43 @@ const DriveExplorerListItem = ({ item }: DriveExplorerItemProps): JSX.Element =>
       }
       data-test={`file-list-${item.isFolder ? 'folder' : 'file'}`}
     >
-      {/* ICON */}
-      <div className="box-content flex items-center pr-4">
-        <div className="flex h-10 w-10 justify-center drop-shadow-soft filter">
-          <ItemIconComponent
-            className="h-full"
-            data-test={`file-list-${
-              item.isFolder ? 'folder' : 'file'
-            }-${transformItemService.getItemPlainNameWithExtension(item)}`}
-          />
-          {isItemShared && (
-            <img
-              className="group-hover:border-slate-50 absolute -bottom-1 -right-2 ml-3 flex h-5 w-5 flex-col items-center justify-center place-self-end rounded-full border-2 border-white bg-primary p-0.5 text-white caret-white group-active:border-blue-100"
-              src={usersIcon}
-              width={13}
-              alt="shared users"
+      <div className="flex flex-grow items-center">
+        {/* ICON */}
+        <div className="box-content flex items-center pr-4">
+          <div className="flex h-10 w-10 justify-center drop-shadow-soft filter">
+            <ItemIconComponent
+              className="h-full"
+              data-test={`file-list-${
+                item.isFolder ? 'folder' : 'file'
+              }-${transformItemService.getItemPlainNameWithExtension(item)}`}
             />
-          )}
+            {isItemShared && (
+              <img
+                className="group-hover:border-slate-50 absolute -bottom-1 -right-2 ml-3 flex h-5 w-5 flex-col items-center justify-center place-self-end rounded-full border-2 border-white bg-primary p-0.5 text-white caret-white group-active:border-blue-100"
+                src={usersIcon}
+                width={13}
+                alt="shared users"
+              />
+            )}
+          </div>
         </div>
-      </div>
 
-      {/* NAME */}
-      <div className="flex w-1 flex-grow items-center pr-2">
-        <div className="flex max-w-full items-center">
-          <span
-            data-test={`${item.isFolder ? 'folder' : 'file'}-name`}
-            className={'file-list-item-name-span'}
-            title={transformItemService.getItemPlainNameWithExtension(item) ?? items.getItemDisplayName(item)}
-            onClick={
-              (item.isFolder && !item.deleted) || (!item.isFolder && item.status === 'EXISTS')
-                ? onNameClicked
-                : undefined
-            }
-          >
-            {transformItemService.getItemPlainNameWithExtension(item) ?? items.getItemDisplayName(item)}
-          </span>
+        {/* NAME */}
+        <div className="flex flex-grow items-center pr-2">
+          <div className="flex max-w-full items-center">
+            <span
+              data-test={`${item.isFolder ? 'folder' : 'file'}-name`}
+              className={'file-list-item-name-span'}
+              title={transformItemService.getItemPlainNameWithExtension(item) ?? items.getItemDisplayName(item)}
+              onClick={
+                (item.isFolder && !item.deleted) || (!item.isFolder && item.status === 'EXISTS')
+                  ? onNameClicked
+                  : undefined
+              }
+            >
+              {transformItemService.getItemPlainNameWithExtension(item) ?? items.getItemDisplayName(item)}
+            </span>
+          </div>
         </div>
       </div>
 
@@ -148,12 +150,12 @@ const DriveExplorerListItem = ({ item }: DriveExplorerItemProps): JSX.Element =>
       }
 
       {/* DATE */}
-      <div className="w-3/12 min-w-date items-center overflow-ellipsis whitespace-nowrap lg:flex">
+      <div className="w-date items-center overflow-ellipsis whitespace-nowrap">
         {dateService.format(item.updatedAt, 'DD MMMM YYYY. HH:mm')}
       </div>
 
       {/* SIZE */}
-      <div className="w-1/12 min-w-breadcrumb items-center overflow-ellipsis whitespace-nowrap">
+      <div className="w-size items-center overflow-ellipsis whitespace-nowrap">
         {sizeService.bytesToString(item.size, false) === '' ? (
           <span className="opacity-25">—</span>
         ) : (

--- a/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerListItem/DriveExplorerListItem.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerListItem/DriveExplorerListItem.tsx
@@ -104,7 +104,7 @@ const DriveExplorerListItem = ({ item }: DriveExplorerItemProps): JSX.Element =>
       data-test={`file-list-${item.isFolder ? 'folder' : 'file'}`}
     >
       {/* ICON */}
-      <div className="box-content flex w-1/12 items-center px-3">
+      <div className="box-content flex items-center pr-4">
         <div className="flex h-10 w-10 justify-center drop-shadow-soft filter">
           <ItemIconComponent
             className="h-full"
@@ -124,10 +124,22 @@ const DriveExplorerListItem = ({ item }: DriveExplorerItemProps): JSX.Element =>
       </div>
 
       {/* NAME */}
-      <div className="flex w-1 flex-grow items-center pr-2">{nameNodefactory()}</div>
-
-      {/* HOVER ACTIONS */}
-      <div className="hidden w-2/12 items-center pl-3 xl:flex"></div>
+      <div className="flex w-1 flex-grow items-center pr-2">
+        <div className="flex max-w-full items-center">
+          <span
+            data-test={`${item.isFolder ? 'folder' : 'file'}-name`}
+            className={'file-list-item-name-span'}
+            title={transformItemService.getItemPlainNameWithExtension(item) ?? items.getItemDisplayName(item)}
+            onClick={
+              (item.isFolder && !item.deleted) || (!item.isFolder && item.status === 'EXISTS')
+                ? onNameClicked
+                : undefined
+            }
+          >
+            {transformItemService.getItemPlainNameWithExtension(item) ?? items.getItemDisplayName(item)}
+          </span>
+        </div>
+      </div>
 
       {
         /* DROPPABLE ZONE */
@@ -136,12 +148,12 @@ const DriveExplorerListItem = ({ item }: DriveExplorerItemProps): JSX.Element =>
       }
 
       {/* DATE */}
-      <div className="hidden w-3/12 items-center overflow-ellipsis whitespace-nowrap lg:flex">
+      <div className="w-3/12 min-w-date items-center overflow-ellipsis whitespace-nowrap lg:flex">
         {dateService.format(item.updatedAt, 'DD MMMM YYYY. HH:mm')}
       </div>
 
       {/* SIZE */}
-      <div className="flex w-1/12 items-center overflow-ellipsis whitespace-nowrap">
+      <div className="w-1/12 min-w-breadcrumb items-center overflow-ellipsis whitespace-nowrap">
         {sizeService.bytesToString(item.size, false) === '' ? (
           <span className="opacity-25">—</span>
         ) : (

--- a/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerListItem/DriveExplorerListItem.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerListItem/DriveExplorerListItem.tsx
@@ -103,7 +103,7 @@ const DriveExplorerListItem = ({ item }: DriveExplorerItemProps): JSX.Element =>
       }
       data-test={`file-list-${item.isFolder ? 'folder' : 'file'}`}
     >
-      <div className="flex flex-grow items-center">
+      <div className="flex min-w-activity flex-grow items-center">
         {/* ICON */}
         <div className="box-content flex items-center pr-4">
           <div className="flex h-10 w-10 justify-center drop-shadow-soft filter">
@@ -150,12 +150,12 @@ const DriveExplorerListItem = ({ item }: DriveExplorerItemProps): JSX.Element =>
       }
 
       {/* DATE */}
-      <div className="w-date items-center overflow-ellipsis whitespace-nowrap">
+      <div className="w-date items-center whitespace-nowrap">
         {dateService.format(item.updatedAt, 'DD MMMM YYYY. HH:mm')}
       </div>
 
       {/* SIZE */}
-      <div className="w-size items-center overflow-ellipsis whitespace-nowrap">
+      <div className="w-size items-center whitespace-nowrap">
         {sizeService.bytesToString(item.size, false) === '' ? (
           <span className="opacity-25">—</span>
         ) : (

--- a/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerListItem/DriveExplorerListItem.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerItem/DriveExplorerListItem/DriveExplorerListItem.tsx
@@ -103,7 +103,7 @@ const DriveExplorerListItem = ({ item }: DriveExplorerItemProps): JSX.Element =>
       }
       data-test={`file-list-${item.isFolder ? 'folder' : 'file'}`}
     >
-      <div className="flex min-w-activity flex-grow items-center">
+      <div className="flex min-w-activity flex-grow items-center pr-3">
         {/* ICON */}
         <div className="box-content flex items-center pr-4">
           <div className="flex h-10 w-10 justify-center drop-shadow-soft filter">
@@ -125,21 +125,21 @@ const DriveExplorerListItem = ({ item }: DriveExplorerItemProps): JSX.Element =>
         </div>
 
         {/* NAME */}
-        <div className="flex flex-grow items-center pr-2">
-          <div className="flex max-w-full items-center">
-            <span
-              data-test={`${item.isFolder ? 'folder' : 'file'}-name`}
-              className={'file-list-item-name-span'}
-              title={transformItemService.getItemPlainNameWithExtension(item) ?? items.getItemDisplayName(item)}
-              onClick={
-                (item.isFolder && !item.deleted) || (!item.isFolder && item.status === 'EXISTS')
-                  ? onNameClicked
-                  : undefined
-              }
-            >
+        <div className="flex w-activity flex-grow cursor-pointer items-center truncate pr-2">
+          <span
+            data-test={`${item.isFolder ? 'folder' : 'file'}-name`}
+            className="truncate"
+            title={transformItemService.getItemPlainNameWithExtension(item) ?? items.getItemDisplayName(item)}
+            onClick={
+              (item.isFolder && !item.deleted) || (!item.isFolder && item.status === 'EXISTS')
+                ? onNameClicked
+                : undefined
+            }
+          >
+            <p className="truncate">
               {transformItemService.getItemPlainNameWithExtension(item) ?? items.getItemDisplayName(item)}
-            </span>
-          </div>
+            </p>
+          </span>
         </div>
       </div>
 
@@ -150,7 +150,7 @@ const DriveExplorerListItem = ({ item }: DriveExplorerItemProps): JSX.Element =>
       }
 
       {/* DATE */}
-      <div className="w-date items-center whitespace-nowrap">
+      <div className="block w-date items-center whitespace-nowrap">
         {dateService.format(item.updatedAt, 'DD MMMM YYYY. HH:mm')}
       </div>
 

--- a/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveExplorerList.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveExplorerList.tsx
@@ -275,7 +275,7 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
           header={[
             {
               label: translate('drive.list.columns.name'),
-              width: 'flex flex-grow items-center',
+              width: 'flex flex-grow items-center min-w-activity',
               name: 'name',
               orderable: isRecents || isTrash ? false : true,
               defaultDirection: 'ASC',

--- a/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveExplorerList.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveExplorerList.tsx
@@ -282,14 +282,14 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
             },
             {
               label: translate('drive.list.columns.modified'),
-              width: 'w-3/12 lg:flex pl-7 min-w-date',
+              width: 'w-date',
               name: 'updatedAt',
               orderable: isRecents || isTrash ? false : true,
               defaultDirection: 'ASC',
             },
             {
               label: translate('drive.list.columns.size'),
-              width: 'flex w-1/12 items-center min-w-breadcrumb',
+              width: 'w-size',
               name: 'size',
               orderable: false,
             },

--- a/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveExplorerList.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveExplorerList.tsx
@@ -274,28 +274,22 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
         <List<DriveItemData, 'type' | 'name' | 'updatedAt' | 'size'>
           header={[
             {
-              label: translate('drive.list.columns.type'),
-              width: 'flex w-1/12 items-center px-6',
-              name: 'type',
-              orderable: false,
-            },
-            {
               label: translate('drive.list.columns.name'),
-              width: 'flex flex-grow items-center pl-6',
+              width: 'flex flex-grow items-center',
               name: 'name',
               orderable: isRecents || isTrash ? false : true,
               defaultDirection: 'ASC',
             },
             {
               label: translate('drive.list.columns.modified'),
-              width: 'hidden w-3/12 lg:flex pl-4',
+              width: 'w-3/12 lg:flex pl-7 min-w-date',
               name: 'updatedAt',
               orderable: isRecents || isTrash ? false : true,
               defaultDirection: 'ASC',
             },
             {
               label: translate('drive.list.columns.size'),
-              width: 'flex w-1/12 items-center',
+              width: 'flex w-1/12 items-center min-w-breadcrumb',
               name: 'size',
               orderable: false,
             },
@@ -423,8 +417,7 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
             onRKeyPressed: () => {
               if (props.selectedItems.length === 1) {
                 const selectedItem = props.selectedItems[0];
-                dispatch(uiActions.setCurrentEditingNameDirty(selectedItem.name));
-                dispatch(uiActions.setCurrentEditingNameDriveItem(selectedItem));
+                renameItem(selectedItem);
               }
             },
           }}

--- a/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveExplorerList.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveExplorerList.tsx
@@ -258,7 +258,7 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
 
   return (
     <div className="flex h-full flex-grow flex-col">
-      <div className="h-full overflow-y-auto">
+      <div className="h-full w-full overflow-y-auto">
         {editNameItem && (
           <EditItemNameDialog
             item={editNameItem}
@@ -275,7 +275,7 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
           header={[
             {
               label: translate('drive.list.columns.name'),
-              width: 'flex flex-grow items-center min-w-activity',
+              width: 'flex flex-grow items-center min-w-driveNameHeader',
               name: 'name',
               orderable: isRecents || isTrash ? false : true,
               defaultDirection: 'ASC',

--- a/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
+++ b/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
@@ -85,7 +85,7 @@ const MoveItemsDialog = (props: MoveItemsDialogProps): JSX.Element => {
     dispatch(fetchDialogContentThunk(folderId))
       .unwrap()
       .then(() => {
-        databaseService.get(DatabaseCollection.Levels, folderId).then((items) => {
+        databaseService.get(DatabaseCollection.MoveDialogLevels, folderId).then((items) => {
           setCurrentFolderId(folderId);
           setCurrentFolderName(name);
           setDestinationId(folderId);

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -967,10 +967,10 @@ export default function SharedView(): JSX.Element {
               if (selectedItems.length === 1) {
                 const selectedItem = selectedItems[0];
                 const itemToRename = {
-                  ...(selectedItem as unknown as DriveItemData),
+                  ...selectedItem,
                   name: selectedItem.plainName ? selectedItem.plainName : '',
                 };
-                setEditNameItem(itemToRename);
+                renameItem(itemToRename);
               }
             },
           }}

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -832,13 +832,13 @@ export default function SharedView(): JSX.Element {
           header={[
             {
               label: translate('shared-links.list.name'),
-              width: 'flex-1 min-w-104 truncate flex-shrink-0 whitespace-nowrap', //flex-grow w-1
+              width: 'flex-1 min-w-activity truncate whitespace-nowrap',
               name: 'folder',
               orderable: false,
             },
             {
               label: translate('shared-links.list.owner'),
-              width: 'w-64', //w-1/12
+              width: 'w-64',
               name: 'ownerId',
               orderable: true,
               defaultDirection: 'ASC',
@@ -846,14 +846,14 @@ export default function SharedView(): JSX.Element {
 
             {
               label: translate('shared-links.list.size'),
-              width: 'w-40', //w-1.5/12
+              width: 'w-40',
               name: 'fileSize',
               orderable: true,
               defaultDirection: 'ASC',
             },
             {
               label: translate('shared-links.list.created'),
-              width: 'w-40', //w-2/12
+              width: 'w-40',
               name: 'createdAt',
               orderable: true,
               defaultDirection: 'ASC',

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -865,6 +865,7 @@ export default function SharedView(): JSX.Element {
             const unselectedDevices = selectedItems.map((deviceSelected) => ({ props: deviceSelected, value: false }));
             onSelectedItemsChanged([...unselectedDevices, { props: item, value: true }]);
           }}
+          onDoubleClick={onItemDoubleClicked}
           itemComposition={[
             (shareItem: AdvancedSharedItem) => {
               const Icon = iconService.getItemIcon(shareItem.isFolder, (shareItem as unknown as DriveFileData)?.type);

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -682,10 +682,12 @@ export default function SharedView(): JSX.Element {
     dispatch(uiActions.setIsFileViewerOpen(true));
   };
 
-  const isItemOwnedByCurrentUser = () => {
+  const isItemOwnedByCurrentUser = (userUUid?: string) => {
     const currentUser = localStorageService.getUser();
-    if (currentUser?.uuid && user?.uuid) {
-      return currentUser.uuid === user.uuid;
+
+    if (currentUser?.uuid && (user?.uuid || userUUid)) {
+      if (userUUid) return currentUser.uuid === userUUid;
+      else currentUser.uuid == user?.uuid;
     }
     return false;
   };
@@ -943,10 +945,10 @@ export default function SharedView(): JSX.Element {
                   copyLink,
                   deleteLink: () => setIsDeleteDialogModalOpen(true),
                   openShareAccessSettings,
-                  renameItem: isItemOwnedByCurrentUser() ? renameItem : undefined,
-                  moveItem: isItemOwnedByCurrentUser() ? moveItem : undefined,
+                  renameItem: isItemOwnedByCurrentUser(selectedItems[0]?.user?.uuid) ? renameItem : undefined,
+                  moveItem: isItemOwnedByCurrentUser(selectedItems[0]?.user?.uuid) ? moveItem : undefined,
                   downloadItem: downloadItem,
-                  moveToTrash: isItemOwnedByCurrentUser() ? moveToTrash : undefined,
+                  moveToTrash: isItemOwnedByCurrentUser(selectedItems[0]?.user?.uuid) ? moveToTrash : undefined,
                 })
               : contextMenuDriveItemSharedAFS({
                   openShareAccessSettings,
@@ -954,9 +956,9 @@ export default function SharedView(): JSX.Element {
                   copyLink,
                   deleteLink: () => setIsDeleteDialogModalOpen(true),
                   renameItem: !isCurrentUserViewer() ? renameItem : undefined,
-                  moveItem: isItemOwnedByCurrentUser() ? moveItem : undefined,
+                  moveItem: isItemOwnedByCurrentUser(selectedItems[0]?.user?.uuid) ? moveItem : undefined,
                   downloadItem: downloadItem,
-                  moveToTrash: isItemOwnedByCurrentUser() ? moveToTrash : undefined,
+                  moveToTrash: isItemOwnedByCurrentUser(selectedItems[0]?.user?.uuid) ? moveToTrash : undefined,
                 })
           }
           keyBoardShortcutActions={{

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -687,7 +687,7 @@ export default function SharedView(): JSX.Element {
 
     if (currentUser?.uuid && (user?.uuid || userUUid)) {
       if (userUUid) return currentUser.uuid === userUUid;
-      else currentUser.uuid == user?.uuid;
+      else return currentUser.uuid == user?.uuid;
     }
     return false;
   };

--- a/src/app/shared/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/app/shared/components/Breadcrumbs/Breadcrumbs.tsx
@@ -76,7 +76,7 @@ export default function Breadcrumbs(props: BreadcrumbsProps): JSX.Element {
         <Dropdown
           key="breadcrumbDropdownItems"
           openDirection="left"
-          classMenuItems="left-0 top-1 w-max max-h-80 overflow-y-auto rounded-md border border-black border-opacity-8 bg-white py-1.5 shadow-subtle-hard z-10"
+          classMenuItems="left-0 top-1 w-max max-h-80 overflow-y-auto rounded-md border border-black border-opacity-8 bg-white pr-1.5 shadow-subtle-hard z-10"
           menuItems={hiddenItemsList}
         >
           {({ open }) => {

--- a/src/app/shared/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/app/shared/components/Breadcrumbs/Breadcrumbs.tsx
@@ -34,7 +34,7 @@ export default function Breadcrumbs(props: BreadcrumbsProps): JSX.Element {
     const hiddenItemsList = [] as JSX.Element[];
     const breadcrumbSeparator = (key) => {
       return (
-        <div key={key} className="flex items-center text-gray-50">
+        <div key={key} className="text-dgray-50 flex items-center">
           <CaretRight weight="bold" className="h-4 w-4" />
         </div>
       );

--- a/src/app/shared/components/Breadcrumbs/BreadcrumbsItem/BreadcrumbsItem.tsx
+++ b/src/app/shared/components/Breadcrumbs/BreadcrumbsItem/BreadcrumbsItem.tsx
@@ -429,7 +429,7 @@ const BreadcrumbsItem = (props: BreadcrumbsItemProps): JSX.Element => {
         <div
           ref={drop}
           className={`flex ${props.isHiddenInList ? 'w-full' : 'max-w-fit'} ${
-            props.item.isFirstPath ? 'flex-shrink-0 p-1' : 'min-w-breadcrumb flex-1 py-1.5 px-3'
+            props.item.isFirstPath ? 'flex-shrink-0' : 'min-w-breadcrumb flex-1 py-1.5 px-3'
           } cursor-pointer flex-row items-center truncate font-medium ${isDraggingOverClassNames}
         ${
           !props.item.active || (props.item.isFirstPath && props.totalBreadcrumbsLength === 1)

--- a/src/app/shared/components/Breadcrumbs/BreadcrumbsItem/BreadcrumbsItem.tsx
+++ b/src/app/shared/components/Breadcrumbs/BreadcrumbsItem/BreadcrumbsItem.tsx
@@ -429,7 +429,7 @@ const BreadcrumbsItem = (props: BreadcrumbsItemProps): JSX.Element => {
         <div
           ref={drop}
           className={`flex ${props.isHiddenInList ? 'w-full' : 'max-w-fit'} ${
-            props.item.isFirstPath ? 'flex-shrink-0' : 'min-w-breadcrumb flex-1 py-1.5 px-3'
+            props.item.isFirstPath ? 'flex-shrink-0 pr-1' : 'min-w-breadcrumb flex-1 py-1.5 px-3'
           } cursor-pointer flex-row items-center truncate font-medium ${isDraggingOverClassNames}
         ${
           !props.item.active || (props.item.isFirstPath && props.totalBreadcrumbsLength === 1)

--- a/src/app/shared/components/Empty/Empty.tsx
+++ b/src/app/shared/components/Empty/Empty.tsx
@@ -1,5 +1,5 @@
 import { Upload } from '@phosphor-icons/react';
-import { ReactNode } from 'react';
+import { MouseEventHandler, ReactNode } from 'react';
 
 interface EmptyProps {
   icon: JSX.Element;
@@ -11,9 +11,10 @@ interface EmptyProps {
     style: 'plain' | 'elevated';
     onClick: () => void;
   };
+  contextMenuClick?: (event: any) => void;
 }
 
-export default function Empty({ icon, title, subtitle, action }: EmptyProps): JSX.Element {
+export default function Empty({ icon, title, subtitle, action, contextMenuClick }: EmptyProps): JSX.Element {
   let button: ReactNode = null;
 
   if (action) {
@@ -31,7 +32,7 @@ export default function Empty({ icon, title, subtitle, action }: EmptyProps): JS
   }
 
   return (
-    <div className="h-full w-full p-8">
+    <div className="h-full w-full p-8" onContextMenu={contextMenuClick}>
       <div className="flex h-full flex-col items-center justify-center pb-20">
         <div className="pointer-events-none mx-auto mb-10 w-max">{icon}</div>
         <div className="pointer-events-none text-center">

--- a/src/app/shared/components/Empty/Empty.tsx
+++ b/src/app/shared/components/Empty/Empty.tsx
@@ -1,5 +1,5 @@
 import { Upload } from '@phosphor-icons/react';
-import { MouseEventHandler, ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 interface EmptyProps {
   icon: JSX.Element;

--- a/src/app/shared/components/List/index.tsx
+++ b/src/app/shared/components/List/index.tsx
@@ -160,10 +160,9 @@ ListProps<T, F>): JSX.Element {
     }
   }
 
-  const handleKeyPress = (action) => {
-    return () => {
-      if (!disableKeyboardShortcuts) action();
-    };
+  const handleKeyPress = (action, e) => {
+    e.preventDefault();
+    if (!disableKeyboardShortcuts) action();
   };
 
   const handleRKeyPressed = () => {
@@ -174,20 +173,20 @@ ListProps<T, F>): JSX.Element {
     keyBoardShortcutActions?.onBackspaceKeyPressed?.();
   };
 
-  useHotkeys(
-    'ctrl+a, meta+a',
-    (e) => {
-      e.preventDefault();
-      handleKeyPress(selectAllItems)();
-    },
-    [items, selectedItems, disableKeyboardShortcuts],
-  );
+  useHotkeys('ctrl+a, meta+a', (e) => handleKeyPress(selectAllItems, e), [
+    items,
+    selectedItems,
+    disableKeyboardShortcuts,
+  ]);
 
-  useHotkeys('esc', handleKeyPress(unselectAllItems), [selectedItems, disableKeyboardShortcuts]);
-  useHotkeys('enter', handleKeyPress(executeClickOnSelectedItem), [selectedItems, disableKeyboardShortcuts]);
-  useHotkeys('r', handleKeyPress(handleRKeyPressed), [selectedItems, disableKeyboardShortcuts]);
-  useHotkeys('backspace', handleKeyPress(handleBackspaceKeyPressed), [selectedItems, disableKeyboardShortcuts]);
-  useHotkeys('delete', handleKeyPress(handleBackspaceKeyPressed), [selectedItems, disableKeyboardShortcuts]);
+  useHotkeys('esc', (e) => handleKeyPress(unselectAllItems, e), [selectedItems, disableKeyboardShortcuts]);
+  useHotkeys('enter', (e) => handleKeyPress(executeClickOnSelectedItem, e), [selectedItems, disableKeyboardShortcuts]);
+  useHotkeys('r', (e) => handleKeyPress(handleRKeyPressed, e), [selectedItems, disableKeyboardShortcuts]);
+  useHotkeys('backspace', (e) => handleKeyPress(handleBackspaceKeyPressed, e), [
+    selectedItems,
+    disableKeyboardShortcuts,
+  ]);
+  useHotkeys('delete', (e) => handleKeyPress(handleBackspaceKeyPressed, e), [selectedItems, disableKeyboardShortcuts]);
 
   function onItemClick(itemClicked: T, e: React.MouseEvent<HTMLDivElement>) {
     if (e.metaKey || e.ctrlKey) {

--- a/src/app/shared/components/List/index.tsx
+++ b/src/app/shared/components/List/index.tsx
@@ -206,7 +206,10 @@ ListProps<T, F>): JSX.Element {
   }
 
   return (
-    <div id="generic-list-component" className={`relative flex h-full flex-col overflow-y-hidden ${className}`}>
+    <div
+      id="generic-list-component"
+      className={`relative flex h-full flex-col overflow-x-hidden overflow-y-hidden ${className}`}
+    >
       {/* HEAD */}
       <div className="flex h-12 flex-shrink-0 flex-row px-5">
         {/* COLUMN */}
@@ -244,7 +247,7 @@ ListProps<T, F>): JSX.Element {
       </div>
 
       {/* BODY */}
-      <div id="scrollableList" className="flex h-full flex-col overflow-y-auto overflow-x-hidden" ref={ref}>
+      <div id="scrollableList" className="flex h-full flex-col overflow-x-auto overflow-y-auto" ref={ref}>
         {(!hasMoreItems ?? false) && items.length === 0 && !isLoading ? (
           emptyState
         ) : items.length > 0 ? (

--- a/src/app/shared/components/List/index.tsx
+++ b/src/app/shared/components/List/index.tsx
@@ -90,6 +90,8 @@ ListProps<T, F>): JSX.Element {
   const isItemSelected = (item: T) => {
     return selectedItems.some((i) => item.id === i.id);
   };
+  const container = document.getElementById('scrollableList');
+  const isVerticalScrollbarVisible = container && container.scrollHeight > container.clientHeight;
 
   const loader = new Array(25)
     .fill(0)
@@ -206,10 +208,10 @@ ListProps<T, F>): JSX.Element {
   return (
     <div
       id="generic-list-component"
-      className={`relative flex h-full flex-col overflow-x-auto overflow-y-auto ${className}`}
+      className={`relative flex h-full flex-col overflow-x-hidden overflow-y-hidden ${className}`}
     >
       {/* HEAD */}
-      <div className="sticky top-0 left-0 z-50 flex h-12 w-full flex-shrink-0 flex-row bg-white px-5">
+      <div className="flex h-12 flex-shrink-0 flex-row px-5">
         {/* COLUMN */}
         <div className="flex h-full min-w-full flex-row items-center border-b border-gray-10">
           {/* SELECTION CHECKBOX */}
@@ -239,12 +241,13 @@ ListProps<T, F>): JSX.Element {
                 ))}
             </div>
           ))}
+          {isVerticalScrollbarVisible && <div className="mr-15px" />}
           {menu && <div className="flex h-full w-12 flex-shrink-0" />}
         </div>
       </div>
 
       {/* BODY */}
-      <div id="scrollableList" className="flex h-full flex-col" ref={ref}>
+      <div id="scrollableList" className="flex h-full flex-col overflow-x-auto overflow-y-auto" ref={ref}>
         {(!hasMoreItems ?? false) && items.length === 0 && !isLoading ? (
           emptyState
         ) : items.length > 0 ? (
@@ -255,7 +258,7 @@ ListProps<T, F>): JSX.Element {
               hasMore={!!hasMoreItems}
               loader={loader}
               scrollThreshold={0.7}
-              scrollableTarget="generic-list-component"
+              scrollableTarget="scrollableList"
               className="h-full"
               style={{ overflow: 'visible' }}
             >

--- a/src/app/shared/components/List/index.tsx
+++ b/src/app/shared/components/List/index.tsx
@@ -90,8 +90,6 @@ ListProps<T, F>): JSX.Element {
   const isItemSelected = (item: T) => {
     return selectedItems.some((i) => item.id === i.id);
   };
-  const container = document.getElementById('scrollableList');
-  const isVerticalScrollbarVisible = container && container.scrollHeight > container.clientHeight;
 
   const loader = new Array(25)
     .fill(0)
@@ -208,10 +206,10 @@ ListProps<T, F>): JSX.Element {
   return (
     <div
       id="generic-list-component"
-      className={`relative flex h-full flex-col overflow-x-hidden overflow-y-hidden ${className}`}
+      className={`relative flex h-full flex-col overflow-x-auto overflow-y-auto ${className}`}
     >
       {/* HEAD */}
-      <div className="flex h-12 flex-shrink-0 flex-row px-5">
+      <div className="sticky top-0 left-0 z-50 flex h-12 w-full flex-shrink-0 flex-row bg-white px-5">
         {/* COLUMN */}
         <div className="flex h-full min-w-full flex-row items-center border-b border-gray-10">
           {/* SELECTION CHECKBOX */}
@@ -241,13 +239,12 @@ ListProps<T, F>): JSX.Element {
                 ))}
             </div>
           ))}
-          {isVerticalScrollbarVisible && <div className="mr-15px" />}
           {menu && <div className="flex h-full w-12 flex-shrink-0" />}
         </div>
       </div>
 
       {/* BODY */}
-      <div id="scrollableList" className="flex h-full flex-col overflow-x-auto overflow-y-auto" ref={ref}>
+      <div id="scrollableList" className="flex h-full flex-col" ref={ref}>
         {(!hasMoreItems ?? false) && items.length === 0 && !isLoading ? (
           emptyState
         ) : items.length > 0 ? (
@@ -258,7 +255,7 @@ ListProps<T, F>): JSX.Element {
               hasMore={!!hasMoreItems}
               loader={loader}
               scrollThreshold={0.7}
-              scrollableTarget="scrollableList"
+              scrollableTarget="generic-list-component"
               className="h-full"
               style={{ overflow: 'visible' }}
             >

--- a/src/app/shared/components/List/index.tsx
+++ b/src/app/shared/components/List/index.tsx
@@ -187,6 +187,7 @@ ListProps<T, F>): JSX.Element {
   useHotkeys('enter', handleKeyPress(executeClickOnSelectedItem), [selectedItems, disableKeyboardShortcuts]);
   useHotkeys('r', handleKeyPress(handleRKeyPressed), [selectedItems, disableKeyboardShortcuts]);
   useHotkeys('backspace', handleKeyPress(handleBackspaceKeyPressed), [selectedItems, disableKeyboardShortcuts]);
+  useHotkeys('delete', handleKeyPress(handleBackspaceKeyPressed), [selectedItems, disableKeyboardShortcuts]);
 
   function onItemClick(itemClicked: T, e: React.MouseEvent<HTMLDivElement>) {
     if (e.metaKey || e.ctrlKey) {
@@ -206,11 +207,11 @@ ListProps<T, F>): JSX.Element {
   return (
     <div id="generic-list-component" className={`relative flex h-full flex-col overflow-y-hidden ${className}`}>
       {/* HEAD */}
-      <div className="relative flex h-12 flex-shrink-0 flex-row px-5">
+      <div className="flex h-12 flex-shrink-0 flex-row px-5">
         {/* COLUMN */}
-        <div className="relative flex h-full min-w-full flex-row items-center border-b border-gray-10 pl-9">
+        <div className="flex h-full min-w-full flex-row items-center border-b border-gray-10">
           {/* SELECTION CHECKBOX */}
-          <div className="absolute left-0 top-0 flex h-full w-0 flex-row items-center justify-start p-0">
+          <div className="flex h-full flex-row items-center justify-between pr-4">
             <BaseCheckbox
               checked={selectedItems.length > 0}
               indeterminate={items.length > selectedItems.length && selectedItems.length > 0}
@@ -242,7 +243,7 @@ ListProps<T, F>): JSX.Element {
       </div>
 
       {/* BODY */}
-      <div id="scrollableList" className="flex h-full flex-col overflow-y-auto" ref={ref}>
+      <div id="scrollableList" className="flex h-full flex-col overflow-y-auto overflow-x-hidden" ref={ref}>
         {(!hasMoreItems ?? false) && items.length === 0 && !isLoading ? (
           emptyState
         ) : items.length > 0 ? (

--- a/src/app/shared/components/List/index.tsx
+++ b/src/app/shared/components/List/index.tsx
@@ -90,6 +90,8 @@ ListProps<T, F>): JSX.Element {
   const isItemSelected = (item: T) => {
     return selectedItems.some((i) => item.id === i.id);
   };
+  const container = document.getElementById('scrollableList');
+  const isVerticalScrollbarVisible = container && container.scrollHeight > container.clientHeight;
 
   const loader = new Array(25)
     .fill(0)
@@ -236,7 +238,7 @@ ListProps<T, F>): JSX.Element {
                 ))}
             </div>
           ))}
-
+          {isVerticalScrollbarVisible && <div className="mr-15px" />}
           {menu && <div className="flex h-full w-12 flex-shrink-0" />}
         </div>
       </div>

--- a/src/app/store/slices/storage/index.ts
+++ b/src/app/store/slices/storage/index.ts
@@ -15,6 +15,7 @@ const initialState: StorageState = {
   loadingFolders: {},
   isDeletingItems: false,
   levels: {},
+  moveDialogLevels: {},
   levelsFoldersLength: {},
   levelsFilesLength: {},
   hasMoreDriveFolders: true,
@@ -74,6 +75,9 @@ export const storageSlice = createSlice({
     },
     setItems: (state: StorageState, action: PayloadAction<{ folderId: number; items: DriveItemData[] }>) => {
       state.levels[action.payload.folderId] = action.payload.items;
+    },
+    setMoveDialogItems: (state: StorageState, action: PayloadAction<{ folderId: number; items: DriveItemData[] }>) => {
+      state.moveDialogLevels[action.payload.folderId] = action.payload.items;
     },
     addItems: (state: StorageState, action: PayloadAction<{ folderId: number; items: DriveItemData[] }>) => {
       const newFolderContent = (state.levels[action.payload.folderId] ?? []).concat(action.payload.items);

--- a/src/app/store/slices/storage/storage.model.ts
+++ b/src/app/store/slices/storage/storage.model.ts
@@ -12,6 +12,7 @@ export interface StorageState {
   loadingFolders: Record<number, boolean>;
   isDeletingItems: boolean;
   levels: Record<number, DriveItemData[]>;
+  moveDialogLevels: Record<number, DriveItemData[]>;
   levelsFoldersLength: Record<number, number>;
   levelsFilesLength: Record<number, number>;
   hasMoreDriveFolders: boolean;

--- a/src/app/store/slices/storage/storage.thunks/fetchDialogContentThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/fetchDialogContentThunk.ts
@@ -15,13 +15,14 @@ export const fetchDialogContentThunk = createAsyncThunk<void, number, { state: R
   async (folderId, { dispatch }) => {
     const storageClient = SdkFactory.getInstance().createStorageClient();
     const [responsePromise] = storageClient.getFolderContent(folderId);
-    const databaseContent = await databaseService.get<DatabaseCollection.Levels>(DatabaseCollection.Levels, folderId);
-
-    dispatch(storageActions.resetOrder());
+    const databaseContent = await databaseService.get<DatabaseCollection.MoveDialogLevels>(
+      DatabaseCollection.MoveDialogLevels,
+      folderId,
+    );
 
     if (databaseContent) {
       dispatch(
-        storageActions.setItems({
+        storageActions.setMoveDialogItems({
           folderId,
           items: databaseContent,
         }),
@@ -34,12 +35,12 @@ export const fetchDialogContentThunk = createAsyncThunk<void, number, { state: R
       const folders = response.children.map((folder) => ({ ...folder, isFolder: true }));
       const items = _.concat(folders as DriveItemData[], response.files as DriveItemData[]);
       dispatch(
-        storageActions.setItems({
+        storageActions.setMoveDialogItems({
           folderId,
           items,
         }),
       );
-      databaseService.put(DatabaseCollection.Levels, folderId, items);
+      databaseService.put(DatabaseCollection.MoveDialogLevels, folderId, items);
     });
   },
 );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -90,7 +90,7 @@ module.exports = {
         activity: '296px',
         date: '220px',
         breadcrumb: 'min(128px, 2ch)',
-        size: '130px',
+        size: '96px',
         contextmenu: '128px',
         '0.5/12': '4.166667%',
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -88,6 +88,7 @@ module.exports = {
         sidenav: '210px',
         'sidenav-collapsed': '64px',
         activity: '296px',
+
         contextmenu: '128px',
         '0.5/12': '4.166667%',
       },
@@ -98,6 +99,7 @@ module.exports = {
       minWidth: {
         104: '26rem',
         activity: '296px',
+        date: '200px',
         breadcrumb: 'min(128px, 2ch)',
       },
       padding: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -88,6 +88,7 @@ module.exports = {
         sidenav: '210px',
         'sidenav-collapsed': '64px',
         activity: '296px',
+        driveNameHeader: '364px',
         date: '220px',
         breadcrumb: 'min(128px, 2ch)',
         size: '96px',
@@ -102,6 +103,7 @@ module.exports = {
       minWidth: {
         104: '26rem',
         activity: '296px',
+        driveNameHeader: '364px',
         date: '200px',
         breadcrumb: 'min(128px, 2ch)',
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -97,6 +97,7 @@ module.exports = {
       margin: {
         '20px': '20px',
         '24px': '24px',
+        '15px': '15px',
       },
       minWidth: {
         104: '26rem',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -88,7 +88,9 @@ module.exports = {
         sidenav: '210px',
         'sidenav-collapsed': '64px',
         activity: '296px',
-
+        date: '220px',
+        breadcrumb: 'min(128px, 2ch)',
+        size: '130px',
         contextmenu: '128px',
         '0.5/12': '4.166667%',
       },


### PR DESCRIPTION
- Fixed some Drive, Shared and Backups lists incositences and behaviours

ℹ️  List of fixes by view:
**Drive**
- Remove Column Type
- Folder spacing and name
- R for rename has different action than right-click
- Delete must also use Supr button
- Move dialog refresh root list
- Fields should not be hidden when resizing
- Right-click on whitespace in empty folders should show the folder actions, as it happens in root

**Shared**
- Horizontal scroll, header and body are separate
- Right click not show correct options in root

**Backups**
- Clicking on the name doesn't open the folder like it does in Drive and Share
- When navigating to another tab it saves of the backups breadcrumb status, it shouldn't