### PR TITLE
[BR-128] fix: wait for namepath reset to set currentPath

### DIFF
--- a/src/app/drive/views/DriveView/DriveView.tsx
+++ b/src/app/drive/views/DriveView/DriveView.tsx
@@ -20,9 +20,8 @@ export interface DriveViewProps {
 
 class DriveView extends Component<DriveViewProps> {
   componentDidMount(): void {
-    const { namePath, dispatch } = this.props;
+    const { dispatch } = this.props;
     dispatch(storageThunks.resetNamePathThunk());
-    dispatch(storageActions.setCurrentPath(namePath[0]));
     this.fetchItems();
   }
 

--- a/src/app/store/slices/storage/storage.thunks/resetNamePathThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/resetNamePathThunk.ts
@@ -4,29 +4,32 @@ import { RootState } from '../../..';
 import { storageActions } from '..';
 import { StorageState } from '../storage.model';
 import storageSelectors from '../storage.selectors';
+import { FolderPath } from 'app/drive/types';
 
-export const resetNamePathThunk = createAsyncThunk<void, void, { state: RootState }>(
+export const resetNamePathThunk = createAsyncThunk<FolderPath[], void, { state: RootState }>(
   'storage/resetNamePath',
   async (payload: void, { getState, dispatch }) => {
     const { user } = getState().user;
     const rootFolderId: number = storageSelectors.rootFolderId(getState());
-
+    const rootFolderPath = {
+      id: rootFolderId,
+      name: 'Drive',
+    };
     dispatch(storageActions.resetNamePath());
 
     if (user) {
-      dispatch(
-        storageActions.pushNamePath({
-          id: rootFolderId,
-          name: 'Drive',
-        }),
-      );
+      dispatch(storageActions.pushNamePath(rootFolderPath));
+      return [rootFolderPath];
     }
+    return [];
   },
 );
 
 export const resetNamePathThunkExtraReducers = (builder: ActionReducerMapBuilder<StorageState>): void => {
   builder
     .addCase(resetNamePathThunk.pending, () => undefined)
-    .addCase(resetNamePathThunk.fulfilled, () => undefined)
+    .addCase(resetNamePathThunk.fulfilled, (state, { payload }) => {
+      state.currentPath = payload[0];
+    })
     .addCase(resetNamePathThunk.rejected, () => undefined);
 };

--- a/src/app/store/slices/storage/storage.thunks/resetNamePathThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/resetNamePathThunk.ts
@@ -29,7 +29,9 @@ export const resetNamePathThunkExtraReducers = (builder: ActionReducerMapBuilder
   builder
     .addCase(resetNamePathThunk.pending, () => undefined)
     .addCase(resetNamePathThunk.fulfilled, (state, { payload }) => {
-      state.currentPath = payload[0];
+      if (payload.length > 0) {
+        state.currentPath = payload[0];
+      }
     })
     .addCase(resetNamePathThunk.rejected, () => undefined);
 };


### PR DESCRIPTION
This bug seems random, but actually there is a way to reproduce it with 100% success.

1. Log in (it is essential that this is the first time logging  in)
2. Try to navigate throught folders. (currentPath is undefined, so the files fetch fails, you can check this with the redux developer tools)

Due to the async nature of thunks and the setCurrentPath reducer being called from the didComponentMount function, the new namePath was just and empty string. 
