### PR TITLE
[BR-127]: fix/download the correct version for drive-desktop

### DIFF
--- a/src/app/core/services/desktop.service.ts
+++ b/src/app/core/services/desktop.service.ts
@@ -1,20 +1,21 @@
 import axios from 'axios';
 import operatingSystemService from './operating-system.service';
 
-async function getDownloadAppUrl() {
-  const app = await fetch('https://internxt.com/api/download', {
-    method: 'GET',
-  });
+const INTERNXT_BASE_URL = 'https://internxt.com';
 
-  const platforms = await app.json();
+async function getDownloadAppUrl() {
+  const app = await axios({
+    method: 'GET',
+    url: `${INTERNXT_BASE_URL}/api/download`,
+  });
 
   switch (operatingSystemService.getOperatingSystem()) {
     case 'LinuxOS' || 'UNIXOS':
-      return platforms.platforms.Linux || 'https://internxt.com/downloads/drive.deb';
+      return app.data.platforms.Linux || 'https://internxt.com/downloads/drive.deb';
     case 'WindowsOS':
-      return platforms.platforms.Windows || 'https://internxt.com/downloads/drive.exe';
+      return app.data.platforms.Windows || 'https://internxt.com/downloads/drive.exe';
     case 'MacOS':
-      return platforms.platforms.MacOS || 'https://internxt.com/downloads/drive.dmg';
+      return app.data.platforms.MacOS || 'https://internxt.com/downloads/drive.dmg';
     default:
       break;
   }

--- a/src/app/core/services/desktop.service.ts
+++ b/src/app/core/services/desktop.service.ts
@@ -1,85 +1,23 @@
+import axios from 'axios';
 import operatingSystemService from './operating-system.service';
 
-interface AssetInfo {
-  browser_download_url: string;
-}
-
-interface LatestReleaseInfo {
-  id: number;
-  name: string;
-  published_at: Date;
-  assets: AssetInfo[];
-}
-
-export async function getLatestReleaseInfo(user: string, repo: string) {
-  const fetchUrl = `https://api.github.com/repos/${user}/${repo}/releases/latest`;
-  const res = await fetch(fetchUrl);
-
-  if (res.status !== 200) {
-    throw Error('Release not found');
-  }
-
-  const info: LatestReleaseInfo = await res.json();
-
-  let windows;
-  let linux;
-  let macos;
-
-  info.assets.forEach((asset) => {
-    const match: any = asset.browser_download_url.match(/\.(\w+)$/);
-
-    switch (match[1]) {
-      case 'exe':
-        windows = asset.browser_download_url;
-        break;
-      case 'dmg':
-        macos = asset.browser_download_url;
-        break;
-      case 'deb':
-        linux = asset.browser_download_url;
-        break;
-      default:
-        break;
-    }
+async function getDownloadAppUrl() {
+  const app = await fetch('https://internxt.com/api/download', {
+    method: 'GET',
   });
 
-  const url = {
-    version: info.name,
-    links: {
-      windows,
-      linux,
-      macos,
-    },
-    cached: false,
-  };
-
-  return url;
-}
-
-async function getDownloadAppUrl(): Promise<string> {
-  const release = await getLatestReleaseInfo('internxt', 'drive-desktop').catch(() => ({
-    cached: false,
-    links: { linux: null, windows: null, macos: null },
-  }));
-
-  let url: string;
+  const platforms = await app.json();
 
   switch (operatingSystemService.getOperatingSystem()) {
+    case 'LinuxOS' || 'UNIXOS':
+      return platforms.platforms.Linux || 'https://internxt.com/downloads/drive.deb';
     case 'WindowsOS':
-      url = release.links.windows || '';
-      break;
+      return platforms.platforms.Windows || 'https://internxt.com/downloads/drive.exe';
     case 'MacOS':
-      url = release.links.macos || '';
-      break;
-    case 'LinuxOS':
-      url = release.links.linux || '';
-      break;
+      return platforms.platforms.MacOS || 'https://internxt.com/downloads/drive.dmg';
     default:
-      url = '';
       break;
   }
-
-  return url;
 }
 
 const desktopService = {

--- a/src/app/core/services/desktop.service.ts
+++ b/src/app/core/services/desktop.service.ts
@@ -10,12 +10,13 @@ async function getDownloadAppUrl() {
   });
 
   switch (operatingSystemService.getOperatingSystem()) {
-    case 'LinuxOS' || 'UNIXOS':
-      return app.data.platforms.Linux || 'https://internxt.com/downloads/drive.deb';
+    case 'LinuxOS':
+    case 'UNIXOS':
+      return app.data.platforms.Linux || `${INTERNXT_BASE_URL}/downloads/drive.deb`;
     case 'WindowsOS':
-      return app.data.platforms.Windows || 'https://internxt.com/downloads/drive.exe';
+      return app.data.platforms.Windows || `${INTERNXT_BASE_URL}/downloads/drive.exe`;
     case 'MacOS':
-      return app.data.platforms.MacOS || 'https://internxt.com/downloads/drive.dmg';
+      return app.data.platforms.MacOS || `${INTERNXT_BASE_URL}/downloads/drive.dmg`;
     default:
       break;
   }


### PR DESCRIPTION
The user can download the latest version for his OS (win, deb or macOS).