### PR TITLE
[_]: fix/copy link in top bar drive actions

### DIFF
--- a/src/app/drive/components/DriveExplorer/components/DriveTopBarActions.tsx
+++ b/src/app/drive/components/DriveExplorer/components/DriveTopBarActions.tsx
@@ -189,7 +189,7 @@ const DriveTopBarActions = ({
         ? contextMenuDriveFolderNotSharedLink({
             shareLink: onOpenShareSettingsButtonClicked,
             showDetails: onShowDetailsButtonClicked,
-            getLink: onSelectedOneItemRename,
+            getLink: onSelectedOneItemShare,
             renameItem: onSelectedOneItemRename,
             moveItem: onMoveItemButtonClicked,
             downloadItem: onDownloadButtonClicked,
@@ -199,7 +199,7 @@ const DriveTopBarActions = ({
             shareLink: onOpenShareSettingsButtonClicked,
             openPreview: onOpenPreviewButtonClicked,
             showDetails: onShowDetailsButtonClicked,
-            getLink: onSelectedOneItemRename,
+            getLink: onSelectedOneItemShare,
             renameItem: onSelectedOneItemRename,
             moveItem: onMoveItemButtonClicked,
             downloadItem: onDownloadButtonClicked,


### PR DESCRIPTION
"Copy link" action has been fixed in Dropdown menu (Top Drive Actions).