### PR TITLE
[_]: fix/details button action in drive

### DIFF
--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -10,10 +10,10 @@ import DriveExplorerList from './DriveExplorerList/DriveExplorerList';
 import DriveExplorerGrid from './DriveExplorerGrid/DriveExplorerGrid';
 import folderEmptyImage from 'assets/icons/light/folder-open.svg';
 import Empty from '../../../shared/components/Empty/Empty';
-import { transformDraggedItems } from 'app/core/services/drag-and-drop.service';
-import { StorageFilters } from 'app/store/slices/storage/storage.model';
-import { AppDispatch, RootState } from 'app/store';
-import { Workspace } from 'app/core/types';
+import { transformDraggedItems } from '../../../core/services/drag-and-drop.service';
+import { StorageFilters } from '../../../store/slices/storage/storage.model';
+import { AppDispatch, RootState } from '../../../store';
+import { Workspace } from '../../../core/types';
 
 import './DriveExplorer.scss';
 import storageThunks from '../../../store/slices/storage/storage.thunks';
@@ -32,19 +32,19 @@ import { DriveItemData, FileViewMode, FolderPath } from '../../types';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import iconService from '../../services/icon.service';
 import MoveItemsDialog from '../MoveItemsDialog/MoveItemsDialog';
-import { IRoot } from 'app/store/slices/storage/storage.thunks/uploadFolderThunk';
+import { IRoot } from '../../../store/slices/storage/storage.thunks/uploadFolderThunk';
 import {
   transformInputFilesToJSON,
   transformJsonFilesToItems,
-} from 'app/drive/services/folder.service/uploadFolderInput.service';
-import { useAppDispatch, useAppSelector } from 'app/store/hooks';
-import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
+} from '../../../drive/services/folder.service/uploadFolderInput.service';
+import { useAppDispatch, useAppSelector } from '../../../store/hooks';
+import notificationsService, { ToastType } from '../../../notifications/services/notifications.service';
 import {
   handleRepeatedUploadingFiles,
   handleRepeatedUploadingFolders,
 } from '../../../store/slices/storage/storage.thunks/renameItemsThunk';
 import NameCollisionContainer from '../NameCollisionDialog/NameCollisionContainer';
-import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
+import { useTranslationContext } from '../../../i18n/provider/TranslationProvider';
 import { Menu, Transition } from '@headlessui/react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { getTrashPaginated } from '../../../../use_cases/trash/get_trash';
@@ -60,13 +60,12 @@ import errorService from '../../../core/services/error.service';
 import { fetchPaginatedFolderContentThunk } from '../../../store/slices/storage/storage.thunks/fetchFolderContentThunk';
 import RealtimeService, { SOCKET_EVENTS } from '../../../core/services/socket.service';
 import ShareDialog from '../ShareDialog/ShareDialog';
-import { fetchSortedFolderContentThunk } from 'app/store/slices/storage/storage.thunks/fetchSortedFolderContentThunk';
+import { fetchSortedFolderContentThunk } from '../../../store/slices/storage/storage.thunks/fetchSortedFolderContentThunk';
 import WarningMessageWrapper from '../WarningMessage/WarningMessageWrapper';
 import EditItemNameDialog from '../EditItemNameDialog/EditItemNameDialog';
 import BannerWrapper from 'app/banners/BannerWrapper';
 import ItemDetailsDialog from '../ItemDetailsDialog/ItemDetailsDialog';
 import DriveTopBarActions from './components/DriveTopBarActions';
-import { PreviewFileItem } from 'app/share/types';
 import useDriveItemActions from './DriveExplorerItem/hooks/useDriveItemActions';
 
 const TRASH_PAGINATION_OFFSET = 50;

--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -291,7 +291,6 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
 
   const onDetailsButtonClicked = useCallback(
     (item: DriveItemData) => {
-      console.log('onDetailsButtonClicked', item);
       if (item.isFolder) {
         dispatch(storageThunks.goToFolderThunk({ name: item.name, id: item.id }));
       } else {

--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -1,4 +1,4 @@
-import { createRef, useState, RefObject, useEffect, useRef, LegacyRef } from 'react';
+import { createRef, useState, RefObject, useEffect, useRef, LegacyRef, useCallback } from 'react';
 import { connect } from 'react-redux';
 import { Trash, UploadSimple, FolderSimplePlus, FileArrowUp, Plus, CaretDown, ArrowFatUp } from '@phosphor-icons/react';
 import FolderSimpleArrowUp from 'assets/icons/FolderSimpleArrowUp.svg';
@@ -66,7 +66,6 @@ import EditItemNameDialog from '../EditItemNameDialog/EditItemNameDialog';
 import BannerWrapper from 'app/banners/BannerWrapper';
 import ItemDetailsDialog from '../ItemDetailsDialog/ItemDetailsDialog';
 import DriveTopBarActions from './components/DriveTopBarActions';
-import useDriveItemActions from './DriveExplorerItem/hooks/useDriveItemActions';
 
 const TRASH_PAGINATION_OFFSET = 50;
 const UPLOAD_ITEMS_LIMIT = 1000;
@@ -135,8 +134,6 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
 
   const isRecents = title === translate('views.recents.head');
   const isTrash = title === translate('trash.trash');
-
-  const { onNameClicked } = useDriveItemActions(selectedItems[0]);
 
   const [editNameItem, setEditNameItem] = useState<DriveItemData | null>(null);
 
@@ -291,6 +288,19 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
   const passToNextStep = () => {
     setCurrentTutorialStep(currentTutorialStep + 1);
   };
+
+  const onDetailsButtonClicked = useCallback(
+    (item: DriveItemData) => {
+      console.log('onDetailsButtonClicked', item);
+      if (item.isFolder) {
+        dispatch(storageThunks.goToFolderThunk({ name: item.name, id: item.id }));
+      } else {
+        dispatch(uiActions.setIsFileViewerOpen(true));
+        dispatch(uiActions.setFileViewerItem(item));
+      }
+    },
+    [dispatch],
+  );
 
   //TODO: MOVE PAGINATED TRASH LOGIC OUT OF VIEW
   const getMoreTrashFolders = async () => {
@@ -589,16 +599,7 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
       <EditFolderNameDialog />
       <UploadItemsFailsDialog />
       <MenuItemToGetSize />
-      <ItemDetailsDialog
-        onDetailsButtonClicked={(item, event) => {
-          if (item.isFolder) {
-            onNameClicked(event);
-          } else {
-            dispatch(uiActions.setIsFileViewerOpen(true));
-            dispatch(uiActions.setFileViewerItem(item as DriveItemData));
-          }
-        }}
-      />
+      <ItemDetailsDialog onDetailsButtonClicked={(item) => onDetailsButtonClicked(item as DriveItemData)} />
       {editNameItem && (
         <EditItemNameDialog
           item={editNameItem}

--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -66,6 +66,8 @@ import EditItemNameDialog from '../EditItemNameDialog/EditItemNameDialog';
 import BannerWrapper from 'app/banners/BannerWrapper';
 import ItemDetailsDialog from '../ItemDetailsDialog/ItemDetailsDialog';
 import DriveTopBarActions from './components/DriveTopBarActions';
+import { PreviewFileItem } from 'app/share/types';
+import useDriveItemActions from './DriveExplorerItem/hooks/useDriveItemActions';
 
 const TRASH_PAGINATION_OFFSET = 50;
 const UPLOAD_ITEMS_LIMIT = 1000;
@@ -134,6 +136,8 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
 
   const isRecents = title === translate('views.recents.head');
   const isTrash = title === translate('trash.trash');
+
+  const { onNameClicked } = useDriveItemActions(selectedItems[0]);
 
   const [editNameItem, setEditNameItem] = useState<DriveItemData | null>(null);
 
@@ -586,7 +590,16 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
       <EditFolderNameDialog />
       <UploadItemsFailsDialog />
       <MenuItemToGetSize />
-      <ItemDetailsDialog />
+      <ItemDetailsDialog
+        onButtonClicked={(item, event) => {
+          if (item.isFolder) {
+            onNameClicked(event);
+          } else {
+            dispatch(uiActions.setIsFileViewerOpen(true));
+            dispatch(uiActions.setFileViewerItem(item as DriveItemData));
+          }
+        }}
+      />
       {editNameItem && (
         <EditItemNameDialog
           item={editNameItem}

--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -590,7 +590,7 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
       <UploadItemsFailsDialog />
       <MenuItemToGetSize />
       <ItemDetailsDialog
-        onButtonClicked={(item, event) => {
+        onDetailsButtonClicked={(item, event) => {
           if (item.isFolder) {
             onNameClicked(event);
           } else {

--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -66,6 +66,7 @@ import EditItemNameDialog from '../EditItemNameDialog/EditItemNameDialog';
 import BannerWrapper from 'app/banners/BannerWrapper';
 import ItemDetailsDialog from '../ItemDetailsDialog/ItemDetailsDialog';
 import DriveTopBarActions from './components/DriveTopBarActions';
+import { AdvancedSharedItem } from '../../../share/types';
 
 const TRASH_PAGINATION_OFFSET = 50;
 const UPLOAD_ITEMS_LIMIT = 1000;
@@ -290,12 +291,12 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
   };
 
   const onDetailsButtonClicked = useCallback(
-    (item: DriveItemData) => {
+    (item: DriveItemData | AdvancedSharedItem) => {
       if (item.isFolder) {
         dispatch(storageThunks.goToFolderThunk({ name: item.name, id: item.id }));
       } else {
         dispatch(uiActions.setIsFileViewerOpen(true));
-        dispatch(uiActions.setFileViewerItem(item));
+        dispatch(uiActions.setFileViewerItem(item as DriveItemData));
       }
     },
     [dispatch],
@@ -598,7 +599,7 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
       <EditFolderNameDialog />
       <UploadItemsFailsDialog />
       <MenuItemToGetSize />
-      <ItemDetailsDialog onDetailsButtonClicked={(item) => onDetailsButtonClicked(item as DriveItemData)} />
+      <ItemDetailsDialog onDetailsButtonClicked={onDetailsButtonClicked} />
       {editNameItem && (
         <EditItemNameDialog
           item={editNameItem}

--- a/src/app/drive/components/ItemDetailsDialog/ItemDetailsDialog.tsx
+++ b/src/app/drive/components/ItemDetailsDialog/ItemDetailsDialog.tsx
@@ -68,7 +68,11 @@ const ItemsDetails = ({ item, translate }: { item: ItemDetailsProps; translate: 
  * - Location
  *  */
 
-const ItemDetailsDialog = ({ onSharedItemClicked }: { onSharedItemClicked?: (item: AdvancedSharedItem) => void }) => {
+const ItemDetailsDialog = ({
+  onButtonClicked,
+}: {
+  onButtonClicked: (item: AdvancedSharedItem | DriveItemData, event?) => void;
+}) => {
   const dispatch = useAppDispatch();
   const isOpen = useAppSelector((state: RootState) => state.ui.isItemDetailsDialogOpen);
   const item = useAppSelector((state: RootState) => state.ui.itemDetails);
@@ -78,7 +82,6 @@ const ItemDetailsDialog = ({ onSharedItemClicked }: { onSharedItemClicked?: (ite
   const IconComponent = iconService.getItemIcon(item?.type === 'folder', item?.type);
   const itemName = `${item?.plainName ?? item?.name}` + `${item?.type && !item.isFolder ? '.' + item?.type : ''}`;
   const user = localStorageService.getUser();
-  const { onNameClicked } = useDriveItemActions(item as DriveItemData);
   const isFolder = item?.isFolder;
 
   useEffect(() => {
@@ -111,15 +114,8 @@ const ItemDetailsDialog = ({ onSharedItemClicked }: { onSharedItemClicked?: (ite
     return date.format(dateString, 'D MMMM, YYYY [at] HH:mm');
   }
 
-  function handleButtonItemClick(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
-    if (item?.isShared && item.view === 'Shared') {
-      onSharedItemClicked?.(item as AdvancedSharedItem);
-    } else if (isFolder) {
-      onNameClicked(event);
-    } else {
-      dispatch(uiActions.setIsFileViewerOpen(true));
-      dispatch(uiActions.setFileViewerItem(item as DriveItemData));
-    }
+  function handleButtonItemClick(event) {
+    onButtonClicked(item as AdvancedSharedItem, event);
 
     onClose();
   }

--- a/src/app/drive/components/ItemDetailsDialog/ItemDetailsDialog.tsx
+++ b/src/app/drive/components/ItemDetailsDialog/ItemDetailsDialog.tsx
@@ -69,9 +69,9 @@ const ItemsDetails = ({ item, translate }: { item: ItemDetailsProps; translate: 
  *  */
 
 const ItemDetailsDialog = ({
-  onButtonClicked,
+  onDetailsButtonClicked,
 }: {
-  onButtonClicked: (item: AdvancedSharedItem | DriveItemData, event?) => void;
+  onDetailsButtonClicked: (item: AdvancedSharedItem | DriveItemData, event?) => void;
 }) => {
   const dispatch = useAppDispatch();
   const isOpen = useAppSelector((state: RootState) => state.ui.isItemDetailsDialogOpen);
@@ -115,7 +115,7 @@ const ItemDetailsDialog = ({
   }
 
   function handleButtonItemClick(event) {
-    onButtonClicked(item as AdvancedSharedItem, event);
+    onDetailsButtonClicked(item as AdvancedSharedItem, event);
 
     onClose();
   }

--- a/src/app/drive/components/ItemDetailsDialog/ItemDetailsDialog.tsx
+++ b/src/app/drive/components/ItemDetailsDialog/ItemDetailsDialog.tsx
@@ -112,7 +112,7 @@ const ItemDetailsDialog = ({ onSharedItemClicked }: { onSharedItemClicked?: (ite
   }
 
   function handleButtonItemClick(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
-    if (item?.isShared) {
+    if (item?.isShared && item.view === 'Shared') {
       onSharedItemClicked?.(item as AdvancedSharedItem);
     } else if (isFolder) {
       onNameClicked(event);

--- a/src/app/drive/components/ItemDetailsDialog/ItemDetailsDialog.tsx
+++ b/src/app/drive/components/ItemDetailsDialog/ItemDetailsDialog.tsx
@@ -11,7 +11,6 @@ import Button from '../../../shared/components/Button/Button';
 import { bytesToString } from '../../../drive/services/size.service';
 import date from '../../../core/services/date.service';
 import localStorageService from '../../../core/services/local-storage.service';
-import useDriveItemActions from '../DriveExplorer/DriveExplorerItem/hooks/useDriveItemActions';
 import { DriveItemData, DriveItemDetails, ItemDetailsProps } from '../../../drive/types';
 import newStorageService from 'app/drive/services/new-storage.service';
 import errorService from 'app/core/services/error.service';
@@ -71,7 +70,7 @@ const ItemsDetails = ({ item, translate }: { item: ItemDetailsProps; translate: 
 const ItemDetailsDialog = ({
   onDetailsButtonClicked,
 }: {
-  onDetailsButtonClicked: (item: AdvancedSharedItem | DriveItemData, event?) => void;
+  onDetailsButtonClicked: (item: AdvancedSharedItem | DriveItemData) => void;
 }) => {
   const dispatch = useAppDispatch();
   const isOpen = useAppSelector((state: RootState) => state.ui.isItemDetailsDialogOpen);
@@ -114,9 +113,8 @@ const ItemDetailsDialog = ({
     return date.format(dateString, 'D MMMM, YYYY [at] HH:mm');
   }
 
-  function handleButtonItemClick(event) {
-    onDetailsButtonClicked(item as AdvancedSharedItem, event);
-
+  function handleButtonItemClick() {
+    onDetailsButtonClicked(item as AdvancedSharedItem);
     onClose();
   }
 

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -413,7 +413,7 @@ function SharedView(props: SharedViewProps): JSX.Element {
       setHasMoreItems(true);
       setCurrentFolderId(sharedFolderId);
       setCurrentParentFolderId(shareItem.id);
-      setCurrentShareOwnerAvatar(shareItem.user.avatar || '');
+      setCurrentShareOwnerAvatar(shareItem.user?.avatar ?? '');
       setSelectedItems([]);
     } else {
       openPreview(shareItem);
@@ -1026,9 +1026,6 @@ function SharedView(props: SharedViewProps): JSX.Element {
           }}
           selectedItems={selectedItems}
           keyboardShortcuts={['unselectAll', 'selectAll', 'multiselect']}
-          //   disableKeyboardShortcuts={isUpdateLinkModalOpen}
-          // onOrderByChanged={onOrderByChanged}
-          // orderBy={orderBy}
           onSelectedItemsChanged={onSelectedItemsChanged}
         />
       </div>

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -814,6 +814,13 @@ function SharedView(props: SharedViewProps): JSX.Element {
     return items;
   };
 
+  const handleDetailsButtonClicked = useCallback(
+    (item: DriveItemData | AdvancedSharedItem) => {
+      onItemDoubleClicked(item as AdvancedSharedItem);
+    },
+    [nextResourcesToken],
+  );
+
   return (
     <div
       className="flex w-full shrink-0 flex-col"
@@ -1043,7 +1050,7 @@ function SharedView(props: SharedViewProps): JSX.Element {
         onClose={onCloseEditNameItems}
       />
       <NameCollisionContainer />
-      <ItemDetailsDialog onDetailsButtonClicked={(item) => onItemDoubleClicked(item as AdvancedSharedItem)} />
+      <ItemDetailsDialog onDetailsButtonClicked={handleDetailsButtonClicked} />
       {isShareDialogOpen && <ShareDialog />}
       {isShowInvitationsOpen && <ShowInvitationsDialog onClose={onShowInvitationsModalClose} />}
       <DeleteDialog

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -1046,7 +1046,7 @@ function SharedView(props: SharedViewProps): JSX.Element {
         onClose={onCloseEditNameItems}
       />
       <NameCollisionContainer />
-      <ItemDetailsDialog onSharedItemClicked={onItemDoubleClicked} />
+      <ItemDetailsDialog onButtonClicked={(item) => onItemDoubleClicked(item as AdvancedSharedItem)} />
       {isShareDialogOpen && <ShareDialog />}
       {isShowInvitationsOpen && <ShowInvitationsDialog onClose={onShowInvitationsModalClose} />}
       <DeleteDialog

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -1046,7 +1046,7 @@ function SharedView(props: SharedViewProps): JSX.Element {
         onClose={onCloseEditNameItems}
       />
       <NameCollisionContainer />
-      <ItemDetailsDialog onButtonClicked={(item) => onItemDoubleClicked(item as AdvancedSharedItem)} />
+      <ItemDetailsDialog onDetailsButtonClicked={(item) => onItemDoubleClicked(item as AdvancedSharedItem)} />
       {isShareDialogOpen && <ShareDialog />}
       {isShowInvitationsOpen && <ShowInvitationsDialog onClose={onShowInvitationsModalClose} />}
       <DeleteDialog


### PR DESCRIPTION
**PROBLEM:**
When the user opens the Details Dialog in Drive and the user clicks to the onButtonClicked (preview file/open folder), it doesn't work.

**FIX:**
Now, we send a callback through the component with the onButtonClicked logic. One callback for Drive and one for Shared.