### PR TITLE
[PB-1278]: fix/remove duplicated edit name dialog

### DIFF
--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -24,7 +24,6 @@ import CreateFolderDialog from '../../../drive/components/CreateFolderDialog/Cre
 import DeleteItemsDialog from '../../../drive/components/DeleteItemsDialog/DeleteItemsDialog';
 import ClearTrashDialog from '../../../drive/components/ClearTrashDialog/ClearTrashDialog';
 import UploadItemsFailsDialog from '../UploadItemsFailsDialog/UploadItemsFailsDialog';
-import EditFolderNameDialog from '../EditFolderNameDialog/EditFolderNameDialog';
 import Button from '../../../shared/components/Button/Button';
 import storageSelectors from '../../../store/slices/storage/storage.selectors';
 import { planSelectors } from '../../../store/slices/plan';
@@ -135,6 +134,10 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
   const isRecents = title === translate('views.recents.head');
   const isTrash = title === translate('trash.trash');
 
+  const itemToRename = useAppSelector((state: RootState) => state.storage.itemToRename);
+  const isItemToRenameFromPreviewView = itemToRename !== null;
+  const isFileViewerOpen = useAppSelector((state: RootState) => state.ui.isFileViewerOpen);
+
   const [editNameItem, setEditNameItem] = useState<DriveItemData | null>(null);
 
   // UPLOAD ITEMS STATES
@@ -211,6 +214,12 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
     if (isEventCreated) setFolderListenerList([...folderListenerList, currentFolderId]);
     else setTimeout(handleOnEventCreation, 10000);
   };
+
+  useEffect(() => {
+    if (isItemToRenameFromPreviewView) {
+      setEditNameItem(itemToRename);
+    }
+  }, [itemToRename]);
 
   useEffect(() => {
     try {
@@ -583,7 +592,6 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
         isTrash={isTrash}
       />
       <ClearTrashDialog onItemsDeleted={onItemsDeleted} />
-      <EditFolderNameDialog />
       <UploadItemsFailsDialog />
       <MenuItemToGetSize />
       <ItemDetailsDialog />
@@ -592,6 +600,9 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
           item={editNameItem}
           isOpen={true}
           onSuccess={() => {
+            if (isFileViewerOpen) {
+              dispatch(uiActions.setCurrentEditingNameDirty(editNameItem.plainName ?? editNameItem.name));
+            }
             setTimeout(() => dispatch(fetchSortedFolderContentThunk(currentFolderId)), 500);
           }}
           onClose={() => {

--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -135,7 +135,6 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
   const isTrash = title === translate('trash.trash');
 
   const itemToRename = useAppSelector((state: RootState) => state.storage.itemToRename);
-  const isItemToRenameFromPreviewView = itemToRename !== null;
   const isFileViewerOpen = useAppSelector((state: RootState) => state.ui.isFileViewerOpen);
 
   const [editNameItem, setEditNameItem] = useState<DriveItemData | null>(null);

--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -216,7 +216,7 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
   };
 
   useEffect(() => {
-    if (isItemToRenameFromPreviewView) {
+    if (itemToRename) {
       setEditNameItem(itemToRename);
     }
   }, [itemToRename]);
@@ -600,12 +600,17 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
           item={editNameItem}
           isOpen={true}
           onSuccess={() => {
-            if (isFileViewerOpen) {
-              dispatch(uiActions.setCurrentEditingNameDirty(editNameItem.plainName ?? editNameItem.name));
-            }
             setTimeout(() => dispatch(fetchSortedFolderContentThunk(currentFolderId)), 500);
           }}
-          onClose={() => {
+          onClose={(newItem) => {
+            if (newItem) {
+              if (isFileViewerOpen) {
+                dispatch(uiActions.setCurrentEditingNameDirty(newItem.plainName ?? newItem.name));
+              } else if (itemToRename && editNameItem.isFolder) {
+                dispatch(uiActions.setCurrentEditingBreadcrumbNameDirty(newItem.plainName ?? newItem.name));
+              }
+            }
+            dispatch(storageActions.setItemToRename(null));
             setEditNameItem(null);
           }}
         />

--- a/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveItemContextMenu.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorerList/DriveItemContextMenu.tsx
@@ -297,11 +297,11 @@ const contextMenuTrashItems = ({
   restoreItem,
   deletePermanently,
 }: {
-  openPreview: (item: DriveItemData) => void;
+  openPreview?: (item: DriveItemData) => void;
   restoreItem: (item: DriveItemData) => void;
   deletePermanently: (item: DriveItemData) => void;
 }): ListItemMenu<DriveItemData> => [
-  getOpenPreviewMenuItem(openPreview),
+  openPreview && getOpenPreviewMenuItem(openPreview),
   getRestoreMenuItem(restoreItem),
   { name: '', action: () => false, separator: true },
   getDeletePermanentlyMenuItem(deletePermanently),

--- a/src/app/drive/components/EditItemNameDialog/EditItemNameDialog.tsx
+++ b/src/app/drive/components/EditItemNameDialog/EditItemNameDialog.tsx
@@ -7,7 +7,6 @@ import Modal from 'app/shared/components/Modal';
 import { DriveItemData } from '../../types';
 import { DriveFolderMetadataPayload } from 'app/drive/types/index';
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
-import { uiActions } from 'app/store/slices/ui';
 
 type EditItemNameDialogProps = {
   item: DriveItemData | undefined;

--- a/src/app/drive/components/EditItemNameDialog/EditItemNameDialog.tsx
+++ b/src/app/drive/components/EditItemNameDialog/EditItemNameDialog.tsx
@@ -7,6 +7,7 @@ import Modal from 'app/shared/components/Modal';
 import { DriveItemData } from '../../types';
 import { DriveFolderMetadataPayload } from 'app/drive/types/index';
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
+import { uiActions } from 'app/store/slices/ui';
 
 type EditItemNameDialogProps = {
   item: DriveItemData | undefined;

--- a/src/app/drive/components/FileViewer/FileViewer.tsx
+++ b/src/app/drive/components/FileViewer/FileViewer.tsx
@@ -17,6 +17,8 @@ import { RootState } from 'app/store';
 import { uiActions } from 'app/store/slices/ui';
 import { setItemsToMove, storageActions } from '../../../store/slices/storage';
 import { isLargeFile } from 'app/core/services/media.service';
+import { ListItemMenu } from 'app/shared/components/List/ListItem';
+import { TopBarActionsMenu } from './FileViewerWrapper';
 
 interface FileViewerProps {
   file: DriveFileData;
@@ -27,11 +29,10 @@ interface FileViewerProps {
   progress?: number;
   isShareView?: boolean;
   blob?: Blob | null;
-  setBlob?: (blob: Blob | null) => void;
-  changeFile?;
-  totalFolderIndex?;
-  fileIndex?;
-  dropdownItems?;
+  changeFile?: (direction: 'next' | 'prev') => void;
+  totalFolderIndex?: number;
+  fileIndex?: number;
+  dropdownItems?: TopBarActionsMenu;
 }
 
 export interface FormatFileViewerProps {
@@ -89,6 +90,9 @@ const FileViewer = ({
   const isEditNameDialogOpen = useAppSelector((state: RootState) => state.ui.isEditFolderNameDialog);
   const isShareItemSettingsDialogOpen = useAppSelector((state) => state.ui.isShareItemDialogOpenInPreviewView);
 
+  const isFirstItem = fileIndex === 0 || isShareView;
+  const isLastItem = (totalFolderIndex && fileIndex === totalFolderIndex - 1) || isShareView;
+
   // To prevent close FileViewer if any of those modal are open
   useEffect(() => {
     function handleKeyDown(event) {
@@ -141,16 +145,16 @@ const FileViewer = ({
   //UseHotKeys for switch between files with the keyboard (left and right arrows)
   useHotkeys(
     'right',
-    () => changeFile('next'),
+    () => changeFile?.('next'),
     {
-      enabled: fileIndex !== totalFolderIndex - 1,
+      enabled: () => fileIndex !== totalFolderIndex! - 1,
     },
     [fileIndex, totalFolderIndex],
   );
 
   useHotkeys(
     'left',
-    () => changeFile('prev'),
+    () => changeFile?.('prev'),
     {
       enabled: fileIndex !== 0,
     },
@@ -196,11 +200,11 @@ const FileViewer = ({
 
           {/* Content */}
           {file && <ShareItemDialog share={file?.shares?.[0]} isPreviewView item={file as DriveItemData} />}
-          {fileIndex === 0 || isShareView ? null : (
+          {isFirstItem ? null : (
             <button
               title={translate('actions.previous')}
               className="absolute left-4 top-1/2 z-30 rounded-full bg-black p-4 text-white outline-none"
-              onClick={() => changeFile('prev')}
+              onClick={() => changeFile?.('prev')}
             >
               <CaretLeft size={24} />
             </button>
@@ -265,11 +269,11 @@ const FileViewer = ({
               <DownloadFile onDownload={onDownload} translate={translate} />
             </div>
           )}
-          {fileIndex === totalFolderIndex - 1 || isShareView ? null : (
+          {isLastItem ? null : (
             <button
               title={translate('actions.next')}
               className="absolute right-4 top-1/2 z-30 rounded-full bg-black p-4 text-white outline-none"
-              onClick={() => changeFile('next')}
+              onClick={() => changeFile?.('next')}
             >
               <CaretRight size={24} />
             </button>
@@ -308,7 +312,7 @@ const FileViewer = ({
               file={file as DriveItemData}
               isAuthenticated={isAuthenticated}
               isShareView={isShareView}
-              dropdownItems={dropdownItems}
+              dropdownItems={dropdownItems as ListItemMenu<DriveItemData>}
             />
           </div>
         </div>

--- a/src/app/drive/components/FileViewer/FileViewer.tsx
+++ b/src/app/drive/components/FileViewer/FileViewer.tsx
@@ -222,29 +222,27 @@ const FileViewer = ({
                     />
                   </Suspense>
                 ) : (
-                  <>
-                    <div
-                      tabIndex={0}
-                      className={`${
-                        progress === 1 ? 'hidden' : 'flex'
-                      } pointer-events-none z-10 select-none flex-col items-center justify-center rounded-xl
+                  <div
+                    tabIndex={0}
+                    className={`${
+                      progress === 1 ? 'hidden' : 'flex'
+                    } pointer-events-none z-10 select-none flex-col items-center justify-center rounded-xl
                       font-medium outline-none`}
-                    >
-                      <div className="flex h-20 w-20 items-center">
-                        <ItemIconComponent width={80} height={80} />
-                      </div>
-                      <span className="w-96 truncate pt-4 text-center text-lg" title={filename}>
-                        {filename}
-                      </span>
-                      <span className="text-white/50">{translate('drive.loadingFile')}</span>
-                      <div className="mt-8 h-1.5 w-56 rounded-full bg-white/25">
-                        <div
-                          className="h-1.5 rounded-full bg-white"
-                          style={{ width: `${progress !== undefined && Number(progress) ? progress * 100 : 0}%` }}
-                        />
-                      </div>
+                  >
+                    <div className="flex h-20 w-20 items-center">
+                      <ItemIconComponent width={80} height={80} />
                     </div>
-                  </>
+                    <span className="w-96 truncate pt-4 text-center text-lg" title={filename}>
+                      {filename}
+                    </span>
+                    <span className="text-white/50">{translate('drive.loadingFile')}</span>
+                    <div className="mt-8 h-1.5 w-56 rounded-full bg-white/25">
+                      <div
+                        className="h-1.5 rounded-full bg-white"
+                        style={{ width: `${progress !== undefined && Number(progress) ? progress * 100 : 0}%` }}
+                      />
+                    </div>
+                  </div>
                 )}
               </div>
             </div>

--- a/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
+++ b/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
@@ -80,7 +80,7 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
     onRenameItemButtonClicked,
     onRestoreItemButtonClicked,
     onDeletePermanentlyButtonClicked,
-  } = useDriveItemActions(file);
+  } = useDriveItemActions(currentFile);
 
   const isCurrentUserViewer = useCallback(() => {
     return currentUserRole === UserRoles.Reader;

--- a/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
+++ b/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
@@ -66,7 +66,7 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
   const recentsActions = pathId === 'recents';
   const sharedActions = pathId === 'shared';
   const trashActions = pathId === 'trash';
-  const isSharedItem = file.sharings && file.sharings?.length > 0;
+  const isSharedItem = sharedActions;
   const isOwner = file.credentials?.user === user?.email;
 
   const {
@@ -80,7 +80,7 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
     onRestoreItemButtonClicked,
     onDeletePermanentlyButtonClicked,
     isCurrentUserViewer,
-  } = useDriveItemActions(file);
+  } = useDriveItemActions(currentFile);
 
   const driveActionsMenu = (): ListItemMenu<DriveItemData> => {
     if (isSharedItem) {
@@ -134,7 +134,6 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
 
   const trashActionsMenu = (): ListItemMenu<DriveItemData> => {
     return contextMenuTrashItems({
-      openPreview: () => ({}),
       restoreItem: onRestoreItemButtonClicked,
       deletePermanently: onDeletePermanentlyButtonClicked,
     });
@@ -151,7 +150,11 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
   useEffect(() => {
     setBlob(null);
     if (dirtyName) {
-      setCurrentFile?.(currentItemsFolder?.find((item) => item.name === dirtyName) as DriveFileData);
+      // setCurrentFile?.(currentItemsFolder?.find((item) => item.name === dirtyName) as DriveFileData);
+      setCurrentFile?.({
+        ...currentFile,
+        plainName: dirtyName,
+      });
     }
     dispatch(uiActions.setCurrentEditingNameDirty(''));
   }, [dirtyName, currentFile]);
@@ -346,6 +349,7 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
       changeFile={changeFile}
       setBlob={setBlob}
       dropdownItems={topDropdownBarActionsMenu()}
+      isShareView={isSharedItem}
     />
   ) : (
     <div className="hidden" />

--- a/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
+++ b/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
@@ -64,10 +64,11 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
 
   const path = getAppConfig().views.find((view) => view.path === location.pathname);
   const pathId = path?.id as pathProps;
-  const recentsActions = pathId === 'recents';
-  const sharedActions = pathId === 'shared';
-  const trashActions = pathId === 'trash';
-  const isSharedItem = sharedActions;
+  const recentsView = pathId === 'recents';
+  const sharedView = pathId === 'shared';
+  const trashView = pathId === 'trash';
+
+  const isSharedItem = file.sharings && file.sharings?.length > 0;
   const isOwner = file.credentials?.user === user?.email;
 
   const {
@@ -144,9 +145,9 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
   };
 
   const topDropdownBarActionsMenu = (): TopBarActionsMenu => {
-    if (sharedActions) return sharedActionsMenu();
-    if (recentsActions) return recentsActionsMenu();
-    if (trashActions) return trashActionsMenu();
+    if (sharedView) return sharedActionsMenu();
+    if (recentsView) return recentsActionsMenu();
+    if (trashView) return trashActionsMenu();
 
     return driveActionsMenu();
   };
@@ -154,7 +155,6 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
   useEffect(() => {
     setBlob(null);
     if (dirtyName) {
-      // setCurrentFile?.(currentItemsFolder?.find((item) => item.name === dirtyName) as DriveFileData);
       setCurrentFile?.({
         ...currentFile,
         plainName: dirtyName,
@@ -280,8 +280,8 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
           const isCacheExpired = !fileSource?.updatedAt
             ? true
             : dateService.isDateOneBefore({
-                dateOne: fileSource?.updatedAt as string,
-                dateTwo: currentFile?.updatedAt as string,
+                dateOne: fileSource?.updatedAt,
+                dateTwo: currentFile?.updatedAt,
               });
           if (isCacheExpired) {
             fileContent = await downloadFile(currentFile, abortController);
@@ -351,9 +351,8 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
       fileIndex={fileIndex}
       totalFolderIndex={totalFolderIndex}
       changeFile={changeFile}
-      setBlob={setBlob}
       dropdownItems={topDropdownBarActionsMenu()}
-      isShareView={isSharedItem}
+      isShareView={sharedView}
     />
   ) : (
     <div className="hidden" />

--- a/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
+++ b/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
@@ -64,9 +64,9 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
 
   const path = getAppConfig().views.find((view) => view.path === location.pathname);
   const pathId = path?.id as pathProps;
-  const recentsView = pathId === 'recents';
-  const sharedView = pathId === 'shared';
-  const trashView = pathId === 'trash';
+  const isRecentsView = pathId === 'recents';
+  const isSharedView = pathId === 'shared';
+  const isTrashView = pathId === 'trash';
 
   const isSharedItem = file.sharings && file.sharings?.length > 0;
   const isOwner = file.credentials?.user === user?.email;
@@ -145,9 +145,9 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
   };
 
   const topDropdownBarActionsMenu = (): TopBarActionsMenu => {
-    if (sharedView) return sharedActionsMenu();
-    if (recentsView) return recentsActionsMenu();
-    if (trashView) return trashActionsMenu();
+    if (isSharedView) return sharedActionsMenu();
+    if (isRecentsView) return recentsActionsMenu();
+    if (isTrashView) return trashActionsMenu();
 
     return driveActionsMenu();
   };
@@ -352,7 +352,7 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
       totalFolderIndex={totalFolderIndex}
       changeFile={changeFile}
       dropdownItems={topDropdownBarActionsMenu()}
-      isShareView={sharedView}
+      isShareView={isSharedView}
     />
   ) : (
     <div className="hidden" />

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -42,7 +42,6 @@ import { AppView } from '../../../core/types';
 import WarningMessageWrapper from '../../../drive/components/WarningMessage/WarningMessageWrapper';
 import ItemDetailsDialog from '../../../drive/components/ItemDetailsDialog/ItemDetailsDialog';
 import { connect } from 'react-redux';
-import EditFolderNameDialog from 'app/drive/components/EditFolderNameDialog/EditFolderNameDialog';
 
 export const ITEMS_PER_PAGE = 15;
 

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -87,6 +87,11 @@ function SharedView(props: Readonly<SharedViewProps>): JSX.Element {
   const urlParams = new URLSearchParams(window.location.search);
   const folderUUID = urlParams.get('folderuuid');
 
+  const itemToRename = useAppSelector((state: RootState) => state.storage.itemToRename);
+
+  const isItemToRenameFromPreviewView = itemToRename !== null;
+  const isFileViewerOpen = useAppSelector((state: RootState) => state.ui.isFileViewerOpen);
+
   const [hasMoreItems, setHasMoreItems] = useState<boolean>(true);
   const [hasMoreFolders, setHasMoreFolders] = useState<boolean>(true);
   const [hasMoreRootFolders, setHasMoreRootFolders] = useState<boolean>(true);
@@ -112,6 +117,14 @@ function SharedView(props: Readonly<SharedViewProps>): JSX.Element {
   const [ownerBucket, setOwnerBucket] = useState<null | string>(null);
   const [ownerEncryptionKey, setOwnerEncryptionKey] = useState<null | string>(null);
   const pendingInvitations = useAppSelector((state: RootState) => state.shared.pendingInvitations);
+
+  // Set the item to rename from preview view
+  useEffect(() => {
+    if (isItemToRenameFromPreviewView) {
+      setEditNameItem(itemToRename);
+      setIsEditNameDialogOpen(true);
+    }
+  }, [itemToRename]);
 
   useEffect(() => {
     dispatch(sharedThunks.getPendingInvitations());
@@ -674,13 +687,16 @@ function SharedView(props: Readonly<SharedViewProps>): JSX.Element {
     dispatch(uiActions.setIsMoveItemsDialogOpen(true));
   };
 
-  const renameItem = (shareItem: AdvancedSharedItem) => {
+  const renameItem = (shareItem: AdvancedSharedItem | DriveItemData) => {
     setEditNameItem(shareItem as unknown as DriveItemData);
     setIsEditNameDialogOpen(true);
   };
 
   const onCloseEditNameItems = (newItem?: DriveItemData) => {
     if (newItem) {
+      if (isFileViewerOpen) {
+        dispatch(uiActions.setCurrentEditingNameDirty(newItem.plainName ?? newItem.name));
+      }
       const editNameItemUuid = newItem.uuid || '';
       setShareItems(
         shareItems.map((shareItem) => {
@@ -697,12 +713,13 @@ function SharedView(props: Readonly<SharedViewProps>): JSX.Element {
         }),
       );
     }
+
     setIsEditNameDialogOpen(false);
     setEditNameItem(undefined);
   };
 
   const openPreview = async (shareItem: AdvancedSharedItem) => {
-    const previewItem = shareItem as unknown as PreviewFileItem;
+    const previewItem = { ...(shareItem as unknown as PreviewFileItem) };
     previewItem.credentials = { user: shareItem.credentials.networkUser, pass: shareItem.credentials.networkPass };
 
     const mnemonic = await decryptMnemonic(shareItem.encryptionKey ? shareItem.encryptionKey : encryptionKey);
@@ -1037,7 +1054,6 @@ function SharedView(props: Readonly<SharedViewProps>): JSX.Element {
         }))}
         isTrash={false}
       />
-      <EditFolderNameDialog />
       <EditItemNameDialog
         item={editNameItem}
         resourceToken={nextResourcesToken}

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -87,8 +87,6 @@ function SharedView(props: Readonly<SharedViewProps>): JSX.Element {
   const folderUUID = urlParams.get('folderuuid');
 
   const itemToRename = useAppSelector((state: RootState) => state.storage.itemToRename);
-
-  const isItemToRenameFromPreviewView = itemToRename !== null;
   const isFileViewerOpen = useAppSelector((state: RootState) => state.ui.isFileViewerOpen);
 
   const [hasMoreItems, setHasMoreItems] = useState<boolean>(true);
@@ -119,7 +117,7 @@ function SharedView(props: Readonly<SharedViewProps>): JSX.Element {
 
   // Set the item to rename from preview view
   useEffect(() => {
-    if (isItemToRenameFromPreviewView) {
+    if (itemToRename) {
       setEditNameItem(itemToRename);
       setIsEditNameDialogOpen(true);
     }

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -712,7 +712,7 @@ function SharedView(props: Readonly<SharedViewProps>): JSX.Element {
         }),
       );
     }
-
+    dispatch(storageActions.setItemToRename(null));
     setIsEditNameDialogOpen(false);
     setEditNameItem(undefined);
   };

--- a/src/app/shared/components/Breadcrumbs/BreadcrumbsItem/BreadcrumbsItem.tsx
+++ b/src/app/shared/components/Breadcrumbs/BreadcrumbsItem/BreadcrumbsItem.tsx
@@ -32,7 +32,6 @@ import {
 import { SdkFactory } from '../../../../core/factory/sdk';
 import { downloadItemsThunk } from 'app/store/slices/storage/storage.thunks/downloadItemsThunk';
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
-import { useEffect } from 'react';
 
 interface BreadcrumbsItemProps {
   item: BreadcrumbItemData;

--- a/src/app/shared/components/Breadcrumbs/BreadcrumbsItem/BreadcrumbsItem.tsx
+++ b/src/app/shared/components/Breadcrumbs/BreadcrumbsItem/BreadcrumbsItem.tsx
@@ -32,6 +32,7 @@ import {
 import { SdkFactory } from '../../../../core/factory/sdk';
 import { downloadItemsThunk } from 'app/store/slices/storage/storage.thunks/downloadItemsThunk';
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
+import { useEffect } from 'react';
 
 interface BreadcrumbsItemProps {
   item: BreadcrumbItemData;
@@ -160,7 +161,6 @@ const BreadcrumbsItem = (props: BreadcrumbsItemProps): JSX.Element => {
   };
 
   const currentFolder = findCurrentFolder(currentBreadcrumb);
-  const isBreadcrumbItemShared = currentFolder[0]?.sharings && currentFolder[0]?.sharings?.length !== 0;
 
   const onCreateFolderButtonClicked = () => {
     dispatch(uiActions.setIsCreateFolderDialogOpen(true));
@@ -186,11 +186,6 @@ const BreadcrumbsItem = (props: BreadcrumbsItemProps): JSX.Element => {
     dispatch(uiActions.setIsItemDetailsDialogOpen(true));
   };
 
-  const onCreateLinkButtonClicked = () => {
-    const item = currentFolder[0];
-    dispatch(sharedThunks.getSharedLinkThunk({ item }));
-  };
-
   const onCopyLinkButtonClicked = () => {
     const item = currentFolder[0];
     dispatch(sharedThunks.getSharedLinkThunk({ item }));
@@ -202,7 +197,7 @@ const BreadcrumbsItem = (props: BreadcrumbsItemProps): JSX.Element => {
   };
 
   const onEditButtonClicked = () => {
-    dispatch(uiActions.setIsEditFolderNameDialog(true));
+    dispatch(storageActions.setItemToRename(currentFolder[0]));
   };
 
   const onDeleteBackupButtonClicked = () => {


### PR DESCRIPTION
One of the item renaming dialogs has been removed and now, we use only one dialog for all views.