### PR TITLE
[PB-1372]: fix/user can't rename an item by pressing "R" in preview mode.

### DIFF
--- a/src/app/drive/components/FileViewer/FileViewer.tsx
+++ b/src/app/drive/components/FileViewer/FileViewer.tsx
@@ -39,6 +39,7 @@ interface FileViewerProps {
   totalFolderIndex?: number;
   fileIndex?: number;
   dropdownItems?: TopBarActionsMenu;
+  renameItemFromKeyboard?: () => void;
 }
 
 export interface FormatFileViewerProps {
@@ -84,6 +85,7 @@ const FileViewer = ({
   totalFolderIndex,
   fileIndex,
   dropdownItems,
+  renameItemFromKeyboard,
 }: FileViewerProps): JSX.Element => {
   const { translate } = useTranslationContext();
   const [isPreviewAvailable, setIsPreviewAvailable] = useState<boolean>(true);
@@ -172,6 +174,10 @@ const FileViewer = ({
     },
     [fileIndex],
   );
+
+  useHotkeys('r', () => {
+    renameItemFromKeyboard?.();
+  });
 
   const dispatch = useAppDispatch();
 

--- a/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
+++ b/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
@@ -145,10 +145,8 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
   };
 
   const renameItemFromKeyboard = () => {
-    if (isSharedView) {
-      if (!isCurrentUserViewer()) {
-        onRenameItemButtonClicked();
-      }
+    if (isSharedView && !isCurrentUserViewer()) {
+      onRenameItemButtonClicked();
     }
   };
 

--- a/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
+++ b/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
@@ -38,6 +38,7 @@ import {
 import { ListItemMenu } from 'app/shared/components/List/ListItem';
 import { getAppConfig } from 'app/core/services/config.service';
 import useDriveItemActions from '../DriveExplorer/DriveExplorerItem/hooks/useDriveItemActions';
+import { useHotkeys } from 'react-hotkeys-hook';
 
 export type TopBarActionsMenu = ListItemMenu<DriveItemData> | ListItemMenu<AdvancedSharedItem> | undefined;
 
@@ -142,6 +143,14 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
       restoreItem: onRestoreItemButtonClicked,
       deletePermanently: onDeletePermanentlyButtonClicked,
     });
+  };
+
+  const renameItemFromKeyboard = () => {
+    if (isSharedView) {
+      if (!isCurrentUserViewer()) {
+        onRenameItemButtonClicked();
+      }
+    }
   };
 
   const topDropdownBarActionsMenu = (): TopBarActionsMenu => {
@@ -353,6 +362,7 @@ const FileViewerWrapper = ({ file, onClose, showPreview }: FileViewerWrapperProp
       changeFile={changeFile}
       dropdownItems={topDropdownBarActionsMenu()}
       isShareView={isSharedView}
+      renameItemFromKeyboard={renameItemFromKeyboard}
     />
   ) : (
     <div className="hidden" />

--- a/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
+++ b/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
@@ -38,7 +38,6 @@ import {
 import { ListItemMenu } from 'app/shared/components/List/ListItem';
 import { getAppConfig } from 'app/core/services/config.service';
 import useDriveItemActions from '../DriveExplorer/DriveExplorerItem/hooks/useDriveItemActions';
-import { useHotkeys } from 'react-hotkeys-hook';
 
 export type TopBarActionsMenu = ListItemMenu<DriveItemData> | ListItemMenu<AdvancedSharedItem> | undefined;
 

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -1102,7 +1102,7 @@ function SharedView(props: SharedViewProps): JSX.Element {
           keyBoardShortcutActions={{
             onBackspaceKeyPressed: moveSelectedItemsToTrash,
             onRKeyPressed: () => {
-              if (selectedItems.length === 1) {
+              if (selectedItems.length === 1 && !isCurrentUserViewer() && isNotRootFolder) {
                 const selectedItem = selectedItems[0];
                 const itemToRename = {
                   ...selectedItem,


### PR DESCRIPTION
User can't rename an item by pressing "R" in preview mode.