### PR TITLE
[PB-1210]: fix/context menu options aren't completely displayed

### DIFF
--- a/src/app/drive/components/DriveExplorer/components/DriveTopBarActions.tsx
+++ b/src/app/drive/components/DriveExplorer/components/DriveTopBarActions.tsx
@@ -287,7 +287,7 @@ const DriveTopBarActions = ({
               <Dropdown
                 classButton="flex items-center justify-center"
                 openDirection="right"
-                classMenuItems="z-20 right-0 mt-0 flex flex-col rounded-lg bg-white py-1.5 shadow-subtle-hard min-w-[180px]"
+                classMenuItems="z-20 right-0 mt-0 flex flex-col rounded-lg border-gray-10 border bg-white py-1.5 shadow-subtle-hard min-w-[180px]"
                 item={selectedItems[0]}
                 dropdownActionsContext={dropdownActions()}
               >

--- a/src/app/shared/components/List/ListItem.tsx
+++ b/src/app/shared/components/List/ListItem.tsx
@@ -205,14 +205,14 @@ export default function ListItem<T extends { id: string }>({
 
             function handleOpenPosition() {
               const element = menuButtonRef.current;
-              const contextMenu = menuItemsRef.current;
+              const contextMenu = menuItemsRef?.current?.offsetHeight || 300;
               if (!element) return;
               if (!contextMenu) return;
 
               const { bottom } = element.getBoundingClientRect();
               const windowHeight = window.innerHeight;
 
-              const isHalfway = bottom > contextMenu.offsetHeight / 2 + windowHeight / 2.3;
+              const isHalfway = bottom + contextMenu > windowHeight;
               setIsHalfwayDown(isHalfway);
             }
 

--- a/src/app/shared/components/List/ListItem.tsx
+++ b/src/app/shared/components/List/ListItem.tsx
@@ -201,11 +201,22 @@ export default function ListItem<T extends { id: string }>({
               const element = menuButtonRef.current;
               if (!element) return;
 
-              const { bottom } = element.getBoundingClientRect();
+              const { top, bottom } = element.getBoundingClientRect();
               const windowHeight = window.innerHeight;
 
-              const isHalfway = bottom > windowHeight / 1.5;
-              setIsHalfwayDown(isHalfway);
+              const rangoSuperior = windowHeight / 2 - 50; // Ajusta según tus necesidades
+              const rangoInferior = windowHeight / 2 + 100; // Ajusta según tus necesidades
+
+              // Comprueba si el elemento está en el rango del medio
+              const isEnElMedio = top <= rangoInferior && bottom >= rangoSuperior;
+
+              if (isEnElMedio) {
+                console.log('El elemento está en el medio');
+                setIsHalfwayDown(false);
+              } else {
+                const isHalfway = bottom > windowHeight / 2;
+                setIsHalfwayDown(isHalfway);
+              }
             }
 
             useEffect(() => {

--- a/src/app/shared/components/List/ListItem.tsx
+++ b/src/app/shared/components/List/ListItem.tsx
@@ -3,7 +3,6 @@ import { Menu } from '@headlessui/react';
 import { DotsThree } from '@phosphor-icons/react';
 import BaseCheckbox from 'app/shared/components/forms/BaseCheckbox/BaseCheckbox';
 import { useHotkeys } from 'react-hotkeys-hook';
-import { set } from 'lodash';
 
 export type ListItemMenu<T> = Array<
   | {
@@ -211,7 +210,7 @@ export default function ListItem<T extends { id: string }>({
               if (!element) return;
               if (!contextMenu) return;
 
-              const { top, bottom } = element.getBoundingClientRect();
+              const { bottom } = element.getBoundingClientRect();
               const windowHeight = window.innerHeight;
 
               const isHalfway = bottom > contextMenu.offsetHeight / 2 + windowHeight / 2.3;

--- a/src/app/shared/components/List/ListItem.tsx
+++ b/src/app/shared/components/List/ListItem.tsx
@@ -89,7 +89,7 @@ export default function ListItem<T extends { id: string }>({
       x = x - childWidth;
     }
 
-    if (event.clientY + childHeight > innerHeight) {
+    if (event.clientY + childHeight > innerHeight + 100) {
       y = y - childHeight;
     }
     setPosX(x);
@@ -204,14 +204,13 @@ export default function ListItem<T extends { id: string }>({
               const { top, bottom } = element.getBoundingClientRect();
               const windowHeight = window.innerHeight;
 
-              const rangoSuperior = windowHeight / 2 - 50; // Ajusta según tus necesidades
-              const rangoInferior = windowHeight / 2 + 100; // Ajusta según tus necesidades
+              const higherRank = windowHeight / 2 - 50; // Ajusta según tus necesidades
+              const lowerRank = windowHeight / 2 + 100; // Ajusta según tus necesidades
 
               // Comprueba si el elemento está en el rango del medio
-              const isEnElMedio = top <= rangoInferior && bottom >= rangoSuperior;
+              const isItemInHalfway = top <= lowerRank && bottom >= higherRank;
 
-              if (isEnElMedio) {
-                console.log('El elemento está en el medio');
+              if (isItemInHalfway) {
                 setIsHalfwayDown(false);
               } else {
                 const isHalfway = bottom > windowHeight / 2;

--- a/src/app/shared/components/List/ListItem.tsx
+++ b/src/app/shared/components/List/ListItem.tsx
@@ -204,7 +204,7 @@ export default function ListItem<T extends { id: string }>({
               const { bottom } = element.getBoundingClientRect();
               const windowHeight = window.innerHeight;
 
-              const isHalfway = bottom > windowHeight / 2;
+              const isHalfway = bottom > windowHeight / 1.5;
               setIsHalfwayDown(isHalfway);
             }
 

--- a/src/app/shared/components/List/ListItem.tsx
+++ b/src/app/shared/components/List/ListItem.tsx
@@ -3,6 +3,7 @@ import { Menu } from '@headlessui/react';
 import { DotsThree } from '@phosphor-icons/react';
 import BaseCheckbox from 'app/shared/components/forms/BaseCheckbox/BaseCheckbox';
 import { useHotkeys } from 'react-hotkeys-hook';
+import { set } from 'lodash';
 
 export type ListItemMenu<T> = Array<
   | {
@@ -36,6 +37,52 @@ interface ItemProps<T> {
 }
 
 const MENU_BUTTON_HEIGHT = 40;
+
+const MenuItemList = ({
+  menuItemsRef,
+  menu,
+}: {
+  menuItemsRef: React.MutableRefObject<HTMLDivElement | null>;
+  menu?: ListItemMenu<any>;
+}) => (
+  <div
+    className="z-20 mt-0 flex flex-col rounded-lg bg-white py-1.5 shadow-subtle-hard outline-none"
+    style={{
+      minWidth: '180px',
+      position: 'fixed',
+      top: -9999,
+      left: -9999,
+    }}
+    ref={menuItemsRef}
+  >
+    {menu?.map((option, i) => (
+      <div key={i}>
+        {option && option.separator ? (
+          <div className="my-0.5 flex w-full flex-row px-4">
+            <div className="h-px w-full bg-gray-10" />
+          </div>
+        ) : (
+          option && (
+            <div>
+              <div className={'flex cursor-pointer flex-row whitespace-nowrap px-4 py-1.5 text-base'}>
+                <div className="flex flex-row items-center space-x-2">
+                  {option.icon && <option.icon size={20} />}
+                  <span>{option.name}</span>
+                </div>
+                <span className="ml-5 flex grow items-center justify-end text-sm text-gray-40">
+                  {option.keyboardShortcutOptions?.keyboardShortcutIcon && (
+                    <option.keyboardShortcutOptions.keyboardShortcutIcon size={14} />
+                  )}
+                  {option.keyboardShortcutOptions?.keyboardShortcutText ?? ''}
+                </span>
+              </div>
+            </div>
+          )
+        )}
+      </div>
+    ))}
+  </div>
+);
 
 export default function ListItem<T extends { id: string }>({
   item,
@@ -89,7 +136,7 @@ export default function ListItem<T extends { id: string }>({
       x = x - childWidth;
     }
 
-    if (event.clientY + childHeight > innerHeight + 100) {
+    if (event.clientY + childHeight > innerHeight) {
       y = y - childHeight;
     }
     setPosX(x);
@@ -101,45 +148,6 @@ export default function ListItem<T extends { id: string }>({
   // This is used to get the size of the menu item list and adjust its position depending on where you are trying to open it.
   // As the size of the list is not fixed we need to create an item equal to the list to be rendered
   // at the same time as the view to get the size and make the necessary positional adjustments.
-  const MenuItemList = () => (
-    <div
-      className="z-20 mt-0 flex flex-col rounded-lg bg-white py-1.5 shadow-subtle-hard outline-none"
-      style={{
-        minWidth: '180px',
-        position: 'fixed',
-        top: -9999,
-        left: -9999,
-      }}
-      ref={menuItemsRef}
-    >
-      {menu?.map((option, i) => (
-        <div key={i}>
-          {option && option.separator ? (
-            <div className="my-0.5 flex w-full flex-row px-4">
-              <div className="h-px w-full bg-gray-10" />
-            </div>
-          ) : (
-            option && (
-              <div>
-                <div className={'flex cursor-pointer flex-row whitespace-nowrap px-4 py-1.5 text-base'}>
-                  <div className="flex flex-row items-center space-x-2">
-                    {option.icon && <option.icon size={20} />}
-                    <span>{option.name}</span>
-                  </div>
-                  <span className="ml-5 flex grow items-center justify-end text-sm text-gray-40">
-                    {option.keyboardShortcutOptions?.keyboardShortcutIcon && (
-                      <option.keyboardShortcutOptions.keyboardShortcutIcon size={14} />
-                    )}
-                    {option.keyboardShortcutOptions?.keyboardShortcutText ?? ''}
-                  </span>
-                </div>
-              </div>
-            )
-          )}
-        </div>
-      ))}
-    </div>
-  );
 
   return (
     <div
@@ -153,7 +161,7 @@ export default function ListItem<T extends { id: string }>({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
-      <MenuItemList />
+      <MenuItemList menu={menu} menuItemsRef={menuItemsRef} />
       <div
         className={`absolute left-5 top-0 flex h-full w-0 flex-row items-center justify-start p-0 opacity-0 focus-within:opacity-100 group-hover:opacity-100 ${
           selected && 'opacity-100'

--- a/src/app/shared/components/List/ListItem.tsx
+++ b/src/app/shared/components/List/ListItem.tsx
@@ -199,23 +199,15 @@ export default function ListItem<T extends { id: string }>({
 
             function handleOpenPosition() {
               const element = menuButtonRef.current;
+              const contextMenu = menuItemsRef.current;
               if (!element) return;
+              if (!contextMenu) return;
 
               const { top, bottom } = element.getBoundingClientRect();
               const windowHeight = window.innerHeight;
 
-              const higherRank = windowHeight / 2 - 50; // Ajusta según tus necesidades
-              const lowerRank = windowHeight / 2 + 100; // Ajusta según tus necesidades
-
-              // Comprueba si el elemento está en el rango del medio
-              const isItemInHalfway = top <= lowerRank && bottom >= higherRank;
-
-              if (isItemInHalfway) {
-                setIsHalfwayDown(false);
-              } else {
-                const isHalfway = bottom > windowHeight / 2;
-                setIsHalfwayDown(isHalfway);
-              }
+              const isHalfway = bottom > contextMenu.offsetHeight / 2 + windowHeight / 2.3;
+              setIsHalfwayDown(isHalfway);
             }
 
             useEffect(() => {
@@ -250,6 +242,7 @@ export default function ListItem<T extends { id: string }>({
                 </Menu.Button>
                 {open && (
                   <Menu.Items
+                    id="list-item-menu-items"
                     className="outline-none"
                     style={
                       openedFromRightClick
@@ -258,7 +251,7 @@ export default function ListItem<T extends { id: string }>({
                             position: 'absolute',
                             right: 0,
                             [isHalfwayDown ? 'bottom' : 'top']: MENU_BUTTON_HEIGHT,
-                            zIndex: 99,
+                            zIndex: 9999,
                           }
                     }
                   >

--- a/src/app/shared/components/List/ListItem.tsx
+++ b/src/app/shared/components/List/ListItem.tsx
@@ -201,19 +201,19 @@ export default function ListItem<T extends { id: string }>({
       >
         <Menu as="div" className={openedFromRightClick ? '' : 'relative'}>
           {({ open, close }) => {
-            const [isHalfwayDown, setIsHalfwayDown] = useState(false);
+            const [isContextMenuCutOff, setIsContextMenuCutOff] = useState(false);
 
             function handleOpenPosition() {
               const element = menuButtonRef.current;
-              const contextMenu = menuItemsRef?.current?.offsetHeight || 300;
+              const contextMenuHeight = menuItemsRef?.current?.offsetHeight || 300;
               if (!element) return;
-              if (!contextMenu) return;
+              if (!contextMenuHeight) return;
 
               const { bottom } = element.getBoundingClientRect();
               const windowHeight = window.innerHeight;
 
-              const isHalfway = bottom + contextMenu > windowHeight;
-              setIsHalfwayDown(isHalfway);
+              const isContextCutOff = bottom + contextMenuHeight > windowHeight;
+              setIsContextMenuCutOff(isContextCutOff);
             }
 
             useEffect(() => {
@@ -255,7 +255,7 @@ export default function ListItem<T extends { id: string }>({
                         : {
                             position: 'absolute',
                             right: 0,
-                            [isHalfwayDown ? 'bottom' : 'top']: MENU_BUTTON_HEIGHT,
+                            [isContextMenuCutOff ? 'bottom' : 'top']: MENU_BUTTON_HEIGHT,
                             zIndex: 9999,
                           }
                     }

--- a/src/app/shared/components/List/ListItem.tsx
+++ b/src/app/shared/components/List/ListItem.tsx
@@ -37,6 +37,9 @@ interface ItemProps<T> {
 
 const MENU_BUTTON_HEIGHT = 40;
 
+// This is used to get the size of the menu item list and adjust its position depending on where you are trying to open it.
+// As the size of the list is not fixed we need to create an item equal to the list to be rendered
+// at the same time as the view to get the size and make the necessary positional adjustments.
 const MenuItemList = ({
   menuItemsRef,
   menu,
@@ -144,10 +147,6 @@ export default function ListItem<T extends { id: string }>({
     menuButtonRef.current?.click();
   };
 
-  // This is used to get the size of the menu item list and adjust its position depending on where you are trying to open it.
-  // As the size of the list is not fixed we need to create an item equal to the list to be rendered
-  // at the same time as the view to get the size and make the necessary positional adjustments.
-
   return (
     <div
       onDoubleClick={onDoubleClick}
@@ -249,8 +248,7 @@ export default function ListItem<T extends { id: string }>({
                 </Menu.Button>
                 {open && (
                   <Menu.Items
-                    id="list-item-menu-items"
-                    className="outline-none"
+                    className="flex outline-none"
                     style={
                       openedFromRightClick
                         ? { position: 'absolute', left: posX, top: posY, zIndex: 99 }
@@ -263,7 +261,7 @@ export default function ListItem<T extends { id: string }>({
                     }
                   >
                     <div
-                      className="z-20 mt-0 flex flex-col rounded-lg bg-white py-1.5 shadow-subtle-hard"
+                      className="z-20 mt-0 flex flex-col rounded-lg border border-gray-10 bg-white py-1.5 shadow-subtle-hard"
                       style={{
                         minWidth: '180px',
                       }}


### PR DESCRIPTION
The context menu has been fixed. 

For now the context menu opens downwards until it does not fit, then we show it upwards. With this we try to prevent as much as possible that the context menu is cut off.