### PR TITLE
[PB-1423]: fix/restore items from trash

### DIFF
--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -575,7 +575,8 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
       <MoveItemsDialog
         items={[...items]}
         onItemsMoved={() => {
-          !isTrash && dispatch(fetchSortedFolderContentThunk(currentFolderId));
+          dispatch(fetchSortedFolderContentThunk(currentFolderId));
+          onItemsMoved?.();
         }}
         isTrash={isTrash}
       />

--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -575,8 +575,7 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
       <MoveItemsDialog
         items={[...items]}
         onItemsMoved={() => {
-          dispatch(fetchSortedFolderContentThunk(currentFolderId));
-          onItemsMoved?.();
+          !isTrash && dispatch(fetchSortedFolderContentThunk(currentFolderId));
         }}
         isTrash={isTrash}
       />

--- a/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
+++ b/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
@@ -165,6 +165,8 @@ const MoveItemsDialog = (props: MoveItemsDialogProps): JSX.Element => {
         await restoreItemsFromTrash(itemsToMove, destinationFolderId, translate as TFunction, props.isTrash);
       }
 
+      props.onItemsMoved?.();
+
       setIsLoading(false);
       onClose();
       !props.isTrash && setDriveBreadcrumb();

--- a/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
+++ b/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
@@ -42,6 +42,8 @@ const MoveItemsDialog = (props: MoveItemsDialogProps): JSX.Element => {
   const dispatch = useAppDispatch();
   const isOpen = useAppSelector((state: RootState) => state.ui.isMoveItemsDialogOpen);
   const rootFolderID: number = useSelector((state: RootState) => storageSelectors.rootFolderId(state));
+  const itemParentId: number = itemsToMove[0]?.parentId ?? itemsToMove[0]?.folderId;
+  const isDriveAndCurrentFolder = !props.isTrash && itemParentId === currentFolderId;
 
   const onCreateFolderButtonClicked = () => {
     dispatch(uiActions.setIsCreateFolderDialogOpen(true));
@@ -163,11 +165,9 @@ const MoveItemsDialog = (props: MoveItemsDialogProps): JSX.Element => {
         await restoreItemsFromTrash(itemsToMove, destinationFolderId, translate as TFunction, props.isTrash);
       }
 
-      props.onItemsMoved?.();
-
       setIsLoading(false);
       onClose();
-      setDriveBreadcrumb();
+      !props.isTrash && setDriveBreadcrumb();
     } catch (err: unknown) {
       const castedError = errorService.castError(err);
       errorService.reportError(castedError);
@@ -246,7 +246,7 @@ const MoveItemsDialog = (props: MoveItemsDialogProps): JSX.Element => {
               {translate('actions.cancel')}
             </Button>
             <Button
-              disabled={isLoading}
+              disabled={isLoading || isDriveAndCurrentFolder}
               variant="primary"
               onClick={() =>
                 onAccept(destinationId ? destinationId : currentFolderId, currentFolderName, currentNamePaths)


### PR DESCRIPTION
When the user restores an item from the recycle garbage can, the recycle garbage can appears empty even if the user has more items in the recycle garbage can.

Now, only the restored items are deleted and the other items still appear.

Also, the move button has been disabled when the user tries to move the item to the same folder where it is located.