### PR TITLE
[_]: feat/dynamic-upload-concurrency-depending-on-ram-chrome

### DIFF
--- a/src/app/network/UploadManager.ts
+++ b/src/app/network/UploadManager.ts
@@ -103,18 +103,10 @@ class UploadManager {
       if (this.abortController?.signal.aborted ?? fileData.abortController?.signal.aborted) return;
 
       if (window.performance && (window.performance as any).memory) {
-        const memory = (window.performance as unknown as { 
-          memory: {
-            totalJSHeapSize: number, 
-            usedJSHeapSize: number, 
-            jsHeapSizeLimit: number 
-          }
-        }).memory;
+        const memory = window.performance.memory;
 
-        if (memory.jsHeapSizeLimit !== null && memory.usedJSHeapSize !== null) {
+        if (memory && memory.jsHeapSizeLimit !== null && memory.usedJSHeapSize !== null) {
           const memoryUsagePercentage = memory.usedJSHeapSize / memory.jsHeapSizeLimit;
-          console.log({...memory, memoryUsagePercentage});
-
           const shouldIncreaseConcurrency = memoryUsagePercentage < 0.7 && this.currentGroupBeingUploaded !== FileSizeType.Big;
 
           if (shouldIncreaseConcurrency) {

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -39,6 +39,13 @@ interface Window {
     ready: (cb: () => void) => void;
     execute: (siteKey: string, { action: string }) => Promise<string>;
   };
+  performance: {
+    memory?: {
+      jsHeapSizeLimit: number;
+      totalJSHeapSize: number;
+      usedJSHeapSize: number;
+    };
+  }
 }
 
 interface Navigator {


### PR DESCRIPTION
**Context**
We have received complaints about crashes on the upload of thousands of files, because with the time, it exhaustes some devices resources using Chrome. After some research, the RAM could be the cause of this issue as we use concurrency to use all the available bandwidth on the upload to make it as fast as possible. 

**Changes**
- The UploadManager modifies the upload queue concurrency on Chrome depending on the RAM usage