### PR TITLE
[PB-2115] feat: edit payment method for B2B and individual subscription

### DIFF
--- a/src/app/payment/services/payment.service.ts
+++ b/src/app/payment/services/payment.service.ts
@@ -102,6 +102,14 @@ const paymentService = {
     });
   },
 
+  async updateSubscriptionPaymentMethod(payload: {
+    paymentMethodId: string;
+    subscriptionType: string;
+  }): Promise<void | Error> {
+    const paymentsClient = await SdkFactory.getInstance().createPaymentsClient();
+    return paymentsClient.updateSubscriptionPaymentMethod(payload);
+  },
+
   async updateSubscriptionPrice(
     priceId: string,
     coupon?: string,


### PR DESCRIPTION
### This example must be adapted to be dynamic (business or individual).
#### Explanation
To implement this, a new endpoint was created that must receive the `paymentMethodId` and the `subscriptionType` (`business` or `individual`) on which the payment method must be updated.

It is important that when creating the payment method, a type field is created in the metadata to identify which subscription it was created for. Available options: `business` and `individual`. 

Once the payment method has been created, proceed to send it to the new endpoint.

Note: The SDK update must be taken into account for the consumption of the endpoint.
PR Sdk: https://github.com/internxt/sdk/pull/206

#### Endpoint 
URL: `/subscriptions/update-payment-method`
Method: POST
Body
```
    {
        paymentMethodId: { type: 'string' },
        subscriptionType: { type: 'string', enum: ['business', 'individual'] },
    }
```