### PR TITLE
[PB-2612] fix/change to plainName in backup breadcrumbs

### DIFF
--- a/src/app/shared/components/Breadcrumbs/Containers/BreadcrumbsBackupsView.tsx
+++ b/src/app/shared/components/Breadcrumbs/Containers/BreadcrumbsBackupsView.tsx
@@ -55,7 +55,7 @@ const BreadcrumbsBackupsView = ({
         };
         items.push({
           uuid: item.uuid,
-          label: item.name,
+          label: item.plainName || item.name,
           icon: null,
           isBackup: true,
           ...(i === backupsAsFoldersPath.length - 1 ? { active: false } : clickableOptions),


### PR DESCRIPTION
## Update
- Use plainName instead name

## PR related
- https://github.com/internxt/sdk/pull/238