### PR TITLE
[MKT-434]: fix/avoid activating/deactivating upsells from auth toggle button and fix saved discount

### DIFF
--- a/src/app/payment/components/checkout/ProductCardComponent.tsx
+++ b/src/app/payment/components/checkout/ProductCardComponent.tsx
@@ -61,6 +61,11 @@ export const ProductFeaturesComponent = ({
   const planAmount = getProductAmount(selectedPlan.decimalAmount, couponCodeData).toFixed(2);
   const upsellPlanAmount = upsellManager.amount && getProductAmount(upsellManager.amount, couponCodeData).toFixed(2);
 
+  const discountPercentage =
+    couponCodeData?.amountOff && couponCodeData?.amountOff < selectedPlan.amount
+      ? ((couponCodeData?.amountOff / selectedPlan.amount) * 100).toFixed(2)
+      : undefined;
+
   return (
     <div className="flex w-full flex-col space-y-4 overflow-y-auto">
       <div className="flex w-full flex-row items-center justify-between space-x-4">
@@ -91,7 +96,7 @@ export const ProductFeaturesComponent = ({
                 <SealPercent weight="fill" size={24} />
                 <p className="">
                   {translate('checkout.productCard.saving', {
-                    percent: couponCodeData?.percentOff,
+                    percent: couponCodeData?.percentOff ?? discountPercentage,
                   })}
                 </p>
               </div>

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutView.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutView.tsx
@@ -62,8 +62,11 @@ const CheckoutView = ({
   });
 
   function onAuthMethodToggled(authMethod: AuthMethodTypes) {
+    reset({
+      email: '',
+      password: '',
+    });
     checkoutViewManager.handleAuthMethodChange(authMethod);
-    reset();
   }
 
   return (


### PR DESCRIPTION
Fix wrong behavior of the auth toggle method that when clicking on the button, the upsell plan is activated or deactivated. 

Also fixed the problem where the percentage that the user saves was not shown when the discount is a fixed price.