### PR TITLE
[PB-820]: fix/ignore .ds_store and other hidden files

### DIFF
--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -71,7 +71,6 @@ import WarningMessageWrapper from '../WarningMessage/WarningMessageWrapper';
 import './DriveExplorer.scss';
 import { DriveTopBarItems } from './DriveTopBarItems';
 import DriveTopBarActions from './components/DriveTopBarActions';
-import { removeHiddenItems } from 'app/utils/driveItemsUtils';
 
 const TRASH_PAGINATION_OFFSET = 50;
 export const UPLOAD_ITEMS_LIMIT = 3000;
@@ -376,10 +375,10 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
 
     if (files.length <= UPLOAD_ITEMS_LIMIT) {
       const unrepeatedUploadedFiles = handleRepeatedUploadingFiles(Array.from(files), items, dispatch) as File[];
-      const filteredItemsWithoutHiddenFiles = removeHiddenItems(unrepeatedUploadedFiles);
+
       dispatch(
         storageThunks.uploadItemsThunk({
-          files: Array.from(filteredItemsWithoutHiddenFiles),
+          files: Array.from(unrepeatedUploadedFiles),
           parentFolderId: currentFolderId,
         }),
       ).then(() => {
@@ -969,12 +968,11 @@ const uploadItems = async (props: DriveExplorerProps, rootList: IRoot[], files: 
         },
       });
       const unrepeatedUploadedFiles = handleRepeatedUploadingFiles(files, items, dispatch) as File[];
-      const filteredItems = removeHiddenItems(unrepeatedUploadedFiles);
 
       // files where dragged directly
       await dispatch(
         storageThunks.uploadItemsThunk({
-          files: filteredItems,
+          files: unrepeatedUploadedFiles,
           parentFolderId: currentFolderId,
           options: {
             onSuccess: onDragAndDropEnd,
@@ -996,10 +994,9 @@ const uploadItems = async (props: DriveExplorerProps, rootList: IRoot[], files: 
         },
       });
       const unrepeatedUploadedFolders = handleRepeatedUploadingFolders(rootList, items, dispatch) as IRoot[];
-      const filteredFolders = removeHiddenItems(unrepeatedUploadedFolders);
 
-      if (filteredFolders.length > 0) {
-        const folderDataToUpload = filteredFolders.map((root) => ({
+      if (unrepeatedUploadedFolders.length > 0) {
+        const folderDataToUpload = unrepeatedUploadedFolders.map((root) => ({
           root,
           currentFolderId,
           options: {

--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -375,7 +375,6 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
 
     if (files.length <= UPLOAD_ITEMS_LIMIT) {
       const unrepeatedUploadedFiles = handleRepeatedUploadingFiles(Array.from(files), items, dispatch) as File[];
-
       dispatch(
         storageThunks.uploadItemsThunk({
           files: Array.from(unrepeatedUploadedFiles),
@@ -968,7 +967,6 @@ const uploadItems = async (props: DriveExplorerProps, rootList: IRoot[], files: 
         },
       });
       const unrepeatedUploadedFiles = handleRepeatedUploadingFiles(files, items, dispatch) as File[];
-
       // files where dragged directly
       await dispatch(
         storageThunks.uploadItemsThunk({
@@ -1003,7 +1001,6 @@ const uploadItems = async (props: DriveExplorerProps, rootList: IRoot[], files: 
             onSuccess: onDragAndDropEnd,
           },
         }));
-
         dispatch(storageThunks.uploadMultipleFolderThunkNoCheck(folderDataToUpload)).then(() => {
           dispatch(fetchSortedFolderContentThunk(currentFolderId));
         });

--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
@@ -24,7 +24,7 @@ import { planThunks } from '../../plan';
 import { uiActions } from '../../ui';
 import workspacesSelectors from '../../workspaces/workspaces.selectors';
 import { StorageState } from '../storage.model';
-import { removeHiddenItems } from 'app/utils/driveItemsUtils';
+import { filterAndRemoveHiddenItemsBeforeUpload } from 'app/utils/driveItemsUtils';
 
 interface UploadItemsThunkOptions {
   relatedTaskId: string;
@@ -187,7 +187,7 @@ export const uploadItemsThunk = createAsyncThunk<void, UploadItemsPayload, { sta
       };
     }
 
-    const filteredFilesWithoutHiddenItems = removeHiddenItems(files);
+    const filteredFilesWithoutHiddenItems = filterAndRemoveHiddenItemsBeforeUpload(files);
 
     const continueWithUpload = isUploadAllowed({
       state: getState(),
@@ -215,8 +215,8 @@ export const uploadItemsThunk = createAsyncThunk<void, UploadItemsPayload, { sta
       taskId,
       relatedTaskId: options?.relatedTaskId,
       onFinishUploadFile: (driveItemData: DriveFileData, taskId: string) => {
-        const uploadRespository = DatabaseUploadRepository.getInstance();
-        uploadRespository.removeUploadState(taskId);
+        const uploadRepository = DatabaseUploadRepository.getInstance();
+        uploadRepository.removeUploadState(taskId);
 
         dispatch(
           storageActions.pushItems({
@@ -311,7 +311,7 @@ export const uploadSharedItemsThunk = createAsyncThunk<void, UploadSharedItemsPa
     const teamId = selectedWorkspace?.workspace.defaultTeamId;
     const options = { ...DEFAULT_OPTIONS, ...payloadOptions };
 
-    const filteredFilesWithoutHiddenItems = removeHiddenItems(files);
+    const filteredFilesWithoutHiddenItems = filterAndRemoveHiddenItemsBeforeUpload(files);
 
     const continueWithUpload = isUploadAllowed({
       state: state,

--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
@@ -24,6 +24,7 @@ import { planThunks } from '../../plan';
 import { uiActions } from '../../ui';
 import workspacesSelectors from '../../workspaces/workspaces.selectors';
 import { StorageState } from '../storage.model';
+import { removeHiddenItems } from 'app/utils/driveItemsUtils';
 
 interface UploadItemsThunkOptions {
   relatedTaskId: string;
@@ -186,16 +187,18 @@ export const uploadItemsThunk = createAsyncThunk<void, UploadItemsPayload, { sta
       };
     }
 
+    const filteredFilesWithoutHiddenItems = removeHiddenItems(files);
+
     const continueWithUpload = isUploadAllowed({
       state: getState(),
-      files,
+      files: filteredFilesWithoutHiddenItems,
       dispatch,
       isWorkspaceSelected: !!workspaceId,
     });
     if (!continueWithUpload) return;
 
     const { filesToUpload, zeroLengthFilesNumber } = await prepareFilesToUpload({
-      files,
+      files: filteredFilesWithoutHiddenItems,
       parentFolderId,
       disableDuplicatedNamesCheck: options.disableDuplicatedNamesCheck,
       fileType,

--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
@@ -311,11 +311,18 @@ export const uploadSharedItemsThunk = createAsyncThunk<void, UploadSharedItemsPa
     const teamId = selectedWorkspace?.workspace.defaultTeamId;
     const options = { ...DEFAULT_OPTIONS, ...payloadOptions };
 
-    const continueWithUpload = isUploadAllowed({ state: state, files, dispatch, isWorkspaceSelected: !!workspaceId });
+    const filteredFilesWithoutHiddenItems = removeHiddenItems(files);
+
+    const continueWithUpload = isUploadAllowed({
+      state: state,
+      files: filteredFilesWithoutHiddenItems,
+      dispatch,
+      isWorkspaceSelected: !!workspaceId,
+    });
     if (!continueWithUpload) return;
 
     let zeroLengthFilesNumber = 0;
-    for (const file of files) {
+    for (const file of filteredFilesWithoutHiddenItems) {
       if (file.size === 0) {
         zeroLengthFilesNumber = zeroLengthFilesNumber + 1;
         continue;
@@ -396,8 +403,8 @@ export const uploadSharedItemsThunk = createAsyncThunk<void, UploadSharedItemsPa
       relatedTaskId: options?.relatedTaskId,
       parentFolderId,
       onFinishUploadFile: (driveItemData: DriveFileData, taskId: string) => {
-        const uploadRespository = DatabaseUploadRepository.getInstance();
-        uploadRespository.removeUploadState(taskId);
+        const uploadRepository = DatabaseUploadRepository.getInstance();
+        uploadRepository.removeUploadState(taskId);
         dispatch(
           storageActions.pushItems({
             updateRecents: true,

--- a/src/app/utils/driveItemsUtils.ts
+++ b/src/app/utils/driveItemsUtils.ts
@@ -1,7 +1,9 @@
+import { IRoot } from 'app/store/slices/storage/storage.thunks/uploadFolderThunk';
 import { DriveItemData } from '../drive/types';
 import { AdvancedSharedItem } from '../share/types';
 
 type ItemData = AdvancedSharedItem | DriveItemData;
+type HiddenItemsData = IRoot | File;
 
 /**
  * Removes duplicate elements from a list based on a unique key.
@@ -23,4 +25,17 @@ const removeDuplicates = <T extends ItemData>(list: T[]) => {
   });
 };
 
-export { removeDuplicates };
+/**
+ * Remove hidden items in a folder or does not allow upload them (items starting with a .)
+ *
+ * @template T - Type of elements in the list, which must extend IRoot and File.
+ * @param {T[]} items The items array to check if there are hidden files
+ * @returns {T[]} - Filtered list without hidden items
+ */
+
+const removeHiddenItemsBeforeUpload = <T extends HiddenItemsData>(items: T[]) => {
+  const itemsFiltered = items.filter((file) => !file.name.startsWith('.'));
+  return itemsFiltered;
+};
+
+export { removeDuplicates, removeHiddenItemsBeforeUpload as removeHiddenItems };

--- a/src/app/utils/driveItemsUtils.ts
+++ b/src/app/utils/driveItemsUtils.ts
@@ -33,9 +33,9 @@ const removeDuplicates = <T extends ItemData>(list: T[]) => {
  * @returns {T[]} - Filtered list without hidden items
  */
 
-const removeHiddenItemsBeforeUpload = <T extends HiddenItemsData>(items: T[]) => {
+const filterAndRemoveHiddenItemsBeforeUpload = <T extends HiddenItemsData>(items: T[]) => {
   const itemsFiltered = items.filter((file) => !file.name.startsWith('.'));
   return itemsFiltered;
 };
 
-export { removeDuplicates, removeHiddenItemsBeforeUpload as removeHiddenItems };
+export { removeDuplicates, filterAndRemoveHiddenItemsBeforeUpload };


### PR DESCRIPTION
Ignore hidden files/folders before uploading (items starting with a dot). Files like .DS_store for example, will not be uploaded and will not appear in drive.