### PR TITLE
[BR-489]: fix/DE Web restore files from trash text surpasses box width

### DIFF
--- a/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
+++ b/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
@@ -184,7 +184,7 @@ const MoveItemsDialog = (props: MoveItemsDialogProps): JSX.Element => {
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose} maxWidth="max-w-[550px]" className="p-5">
       <div className="flex flex-col space-y-5">
         {/* Title */}
         <div className="flex text-2xl font-medium text-gray-100">

--- a/src/app/i18n/locales/de.json
+++ b/src/app/i18n/locales/de.json
@@ -1283,7 +1283,7 @@
     "move": "Verschieben",
     "moving": "Verschieben...",
     "navigating": "Navigieren...",
-    "restoreHere": "Hier wiederherstellen",
+    "restoreHere": "Wiederherstellen",
     "rename": "Umbenennen",
     "restore": "Wiederherstellen",
     "copyLink": "Kopiere Link",


### PR DESCRIPTION
Fixed the overflow of the restore items from trash button in the move/restore items dialog for the German language.