### PR TITLE
[PB-2980]: fix/show item name in rename item dialog in Recents view

### DIFF
--- a/src/app/drive/components/EditItemNameDialog/EditItemNameDialog.tsx
+++ b/src/app/drive/components/EditItemNameDialog/EditItemNameDialog.tsx
@@ -22,9 +22,10 @@ const EditItemNameDialog: FC<EditItemNameDialogProps> = ({ item, isOpen, resourc
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [newItemName, setNewItemName] = useState('');
+  const itemName = item?.plainName ?? item?.plain_name ?? '';
 
   useEffect(() => {
-    setNewItemName(item?.plainName ?? item?.plain_name ?? '');
+    setNewItemName(itemName);
   }, [item]);
 
   const handleOnClose = (newName = ''): void => {

--- a/src/app/drive/components/EditItemNameDialog/EditItemNameDialog.tsx
+++ b/src/app/drive/components/EditItemNameDialog/EditItemNameDialog.tsx
@@ -24,7 +24,7 @@ const EditItemNameDialog: FC<EditItemNameDialogProps> = ({ item, isOpen, resourc
   const [newItemName, setNewItemName] = useState('');
 
   useEffect(() => {
-    setNewItemName(item?.plainName ?? '');
+    setNewItemName(item?.plainName ?? item?.plain_name ?? '');
   }, [item]);
 
   const handleOnClose = (newName = ''): void => {

--- a/src/app/drive/components/EditItemNameDialog/EditItemNameDialog.tsx
+++ b/src/app/drive/components/EditItemNameDialog/EditItemNameDialog.tsx
@@ -22,7 +22,7 @@ const EditItemNameDialog: FC<EditItemNameDialogProps> = ({ item, isOpen, resourc
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [newItemName, setNewItemName] = useState('');
-  const itemName = item?.plainName ?? item?.plain_name ?? '';
+  const itemName = item?.plainName ?? '';
 
   useEffect(() => {
     setNewItemName(itemName);

--- a/src/app/store/slices/storage/storage.thunks/fetchRecentsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/fetchRecentsThunk.ts
@@ -19,7 +19,7 @@ export const fetchRecentsThunk = createAsyncThunk<void, void, { state: RootState
 
     const recentsWithoutHiddenFiles = excludeHiddenItems(recents);
 
-    recentsWithoutHiddenFiles.map((item) => (item.plainName = item.plain_name));
+    recentsWithoutHiddenFiles.forEach((item) => (item.plainName = item.plain_name));
 
     dispatch(storageActions.clearSelectedItems());
     dispatch(storageActions.setRecents(recentsWithoutHiddenFiles));

--- a/src/app/store/slices/storage/storage.thunks/fetchRecentsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/fetchRecentsThunk.ts
@@ -19,6 +19,8 @@ export const fetchRecentsThunk = createAsyncThunk<void, void, { state: RootState
 
     const recentsWithoutHiddenFiles = excludeHiddenItems(recents);
 
+    recentsWithoutHiddenFiles.map((item) => (item.plainName = item.plain_name));
+
     dispatch(storageActions.clearSelectedItems());
     dispatch(storageActions.setRecents(recentsWithoutHiddenFiles));
   },

--- a/src/app/store/slices/storage/storage.thunks/fetchRecentsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/fetchRecentsThunk.ts
@@ -19,10 +19,13 @@ export const fetchRecentsThunk = createAsyncThunk<void, void, { state: RootState
 
     const recentsWithoutHiddenFiles = excludeHiddenItems(recents);
 
-    recentsWithoutHiddenFiles.forEach((item) => (item.plainName = item.plain_name));
+    const recentsWithPlainNameParam = recentsWithoutHiddenFiles.map((item) => ({
+      ...item,
+      plainName: item.plain_name,
+    }));
 
     dispatch(storageActions.clearSelectedItems());
-    dispatch(storageActions.setRecents(recentsWithoutHiddenFiles));
+    dispatch(storageActions.setRecents(recentsWithPlainNameParam));
   },
 );
 


### PR DESCRIPTION
Show the item name in the Rename Item dialog when opened from the Recents section.