### PR TITLE
[PB-3037]: fix/update react-pdf worker and destroy the worker after the thumbnail is generated

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,8 @@ import { workspaceThunks } from './app/store/slices/workspaces/workspacesStore';
 import SurveyDialog from './app/survey/components/SurveyDialog/SurveyDialog';
 import { manager } from './app/utils/dnd-utils';
 import useBeforeUnload from './hooks/useBeforeUnload';
-pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
+
+pdfjs.GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.js', import.meta.url).toString();
 
 interface AppProps {
   isAuthenticated: boolean;

--- a/src/app/drive/services/thumbnail.service.ts
+++ b/src/app/drive/services/thumbnail.service.ts
@@ -71,6 +71,7 @@ const getPDFThumbnail = async (file: File): Promise<ThumbnailGenerated['file']> 
   if (canvasContext) {
     const renderTask = page.render({ canvasContext, viewport });
     await renderTask.promise;
+    await loadingTask.destroy();
     return new Promise((resolve) => {
       // Convert the canvas to an image buffer.
       canvas.toBlob((blob: Blob | null) => {


### PR DESCRIPTION
The Worker for the react-pdf package has been updated (according to their docs). Also the workers that are generated when the pdf thumbnail is created, are destroyed afterwards so as not to accumulate them. This was creating problems with uploading large folders.