### PR TITLE
[PB-3079] Feat/switch to argon2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "docx-preview": "^0.3.3",
     "fflate": "^0.8.2",
     "file-saver": "^2.0.5",
+    "hash-wasm": "^4.11.0",
     "heic2any": "^0.0.4",
     "history": "^4.10.1",
     "https-browserify": "^1.0.0",

--- a/src/app/auth/components/SignUp/useSignUp.ts
+++ b/src/app/auth/components/SignUp/useSignUp.ts
@@ -49,7 +49,7 @@ export function useSignUp(
 } {
   const updateInfo: UpdateInfoFunction = async (email: string, password: string) => {
     // Setup hash and salt
-    const hashObj = passToHash({ password });
+    const hashObj = await passToHash({ password });
     const encPass = encryptText(hashObj.hash);
     const encSalt = encryptText(hashObj.salt);
 
@@ -93,7 +93,7 @@ export function useSignUp(
   };
 
   const doRegister = async (email: string, password: string, captcha: string) => {
-    const hashObj = passToHash({ password });
+    const hashObj = await passToHash({ password });
     const encPass = encryptText(hashObj.hash);
     const encSalt = encryptText(hashObj.salt);
     const mnemonic = bip39.generateMnemonic(256);
@@ -158,7 +158,7 @@ export function useSignUp(
     password: string,
     captcha: string,
   ): Promise<RegisterDetails> => {
-    const hashObj = passToHash({ password });
+    const hashObj = await passToHash({ password });
     const encPass = encryptText(hashObj.hash);
     const encSalt = encryptText(hashObj.salt);
     const mnemonic = bip39.generateMnemonic(256);

--- a/src/app/crypto/services/utils.ts
+++ b/src/app/crypto/services/utils.ts
@@ -3,13 +3,77 @@ import { DriveItemData } from '../../drive/types';
 import { aes, items as itemUtils } from '@internxt/lib';
 import { getAesInitFromEnv } from '../services/keys.service';
 import { AdvancedSharedItem } from '../../share/types';
+import { argon2id, pbkdf2, createSHA256 } from 'hash-wasm';
 import crypto from 'crypto';
+
+const ARGON2ID_PARALLELISM = 4;
+const ARGON2ID_ITERATIONS = 2;
+const ARGON2ID_MEMORY = 65536;
+const ARGON2ID_TAG_LEN = 32;
+const ARGON2ID_SALT_LEN = 16;
+
+const PBKDF2_ITERATIONS = 10000;
+const PBKDF2_TAG_LEN = 32;
 
 interface PassObjectInterface {
   salt?: string | null;
   password: string;
 }
 
+/**
+ * Computes PBKDF2 and outputs the result in HEX format
+ * @param {string} password - The password
+ * @param {number} salt - The salt
+ * @param {number}[iterations=PBKDF2_ITERATIONS] - The number of iterations to perform
+ * @param {number} [hashLength=PBKDF2_TAG_LEN] - The desired output length
+ * @returns {Promise<string>} The result of PBKDF2 in HEX format
+ */
+function getPBKDF2(
+  password: string,
+  salt: string | Uint8Array,
+  iterations = PBKDF2_ITERATIONS,
+  hashLength = PBKDF2_TAG_LEN,
+): Promise<string> {
+  return pbkdf2({
+    password,
+    salt,
+    iterations,
+    hashLength,
+    hashFunction: createSHA256(),
+    outputType: 'hex',
+  });
+}
+
+/**
+ * Computes Argon2 and outputs the result in HEX format
+ * @param {string} password - The password
+ * @param {number} salt - The salt
+ * @param {number} [parallelism=ARGON2ID_PARALLELISM] - The parallelism degree
+ * @param {number}[iterations=ARGON2ID_ITERATIONS] - The number of iterations to perform
+ * @param {number}[memorySize=ARGON2ID_MEMORY] - The number of KB of memeory to use
+ * @param {number} [hashLength=ARGON2ID_TAG_LEN] - The desired output length
+ * @param {'hex'|'binary'|'encoded'} [outputType="encoded"] - The output type
+ * @returns {Promise<string>} The result of Argon2
+ */
+function getArgon2(
+  password: string,
+  salt: string,
+  parallelism: number = ARGON2ID_PARALLELISM,
+  iterations: number = ARGON2ID_ITERATIONS,
+  memorySize: number = ARGON2ID_MEMORY,
+  hashLength: number = ARGON2ID_TAG_LEN,
+  outputType: 'hex' | 'binary' | 'encoded' = 'encoded',
+): Promise<string> {
+  return argon2id({
+    password,
+    salt,
+    parallelism,
+    iterations,
+    memorySize,
+    hashLength,
+    outputType,
+  });
+}
 /**
  * Converts HEX string to Uint8Array the same way CryptoJS did it (for compatibility)
  * @param {string} hex - The input string in HEX
@@ -29,39 +93,29 @@ function hex2oldEncoding(hex: string): Uint8Array {
 
   return uint8Array;
 }
-function uint8ArrayToBase64(uint8Array) {
-  let binaryString = '';
-  for (const byte of uint8Array) {
-    binaryString += String.fromCharCode(byte);
+/**
+ * Password hash computation. If no salt or salt starts with 'argon2id$'  - uses Argon2, else - PBKDF2
+ * @param {PassObjectInterface} passObject - The input object containing password and salt (optional)
+ * @returns {Promise<{salt: string; hash: string }>} The resulting hash and salt
+ */
+async function passToHash(passObject: PassObjectInterface): Promise<{ salt: string; hash: string }> {
+  let salt;
+  let hash;
+
+  if (!passObject.salt) {
+    const argonSalt = crypto.randomBytes(ARGON2ID_SALT_LEN).toString('hex');
+    hash = await getArgon2(passObject.password, argonSalt);
+    salt = 'argon2id$' + argonSalt;
+  } else if (passObject.salt.startsWith('argon2id$')) {
+    const argonSalt = passObject.salt.replace('argon2id$', '');
+    hash = await getArgon2(passObject.password, argonSalt);
+    salt = passObject.salt;
+  } else {
+    salt = passObject.salt;
+    const encoded = hex2oldEncoding(salt);
+    hash = await getPBKDF2(passObject.password, encoded);
   }
-  return btoa(binaryString);
-}
-
-function base64ToHex(base64String) {
-  // Decode Base64 to a binary string
-  const binaryString = atob(base64String);
-
-  // Convert binary string to Uint8Array
-  const length = binaryString.length;
-  const bytes = new Uint8Array(length);
-  for (let i = 0; i < length; i++) {
-    bytes[i] = binaryString.charCodeAt(i);
-  }
-  return Array.from(bytes)
-    .map((byte) => byte.toString(16).padStart(2, '0')) // Convert to hex and pad with leading zero if necessary
-    .join(''); // Combine all hex values into a single string
-}
-
-// Method to hash password. If salt is passed, use it, in other case use crypto lib for generate salt
-function passToHash(passObject: PassObjectInterface): { salt: string; hash: string } {
-  const salt = passObject.salt ? CryptoJS.enc.Hex.parse(passObject.salt) : CryptoJS.lib.WordArray.random(128 / 8);
-  const hash = CryptoJS.PBKDF2(passObject.password, salt, { keySize: 256 / 32, iterations: 10000 });
-  const hashedObjetc = {
-    salt: salt.toString(),
-    hash: hash.toString(),
-  };
-
-  return hashedObjetc;
+  return { salt, hash };
 }
 
 // AES Plain text encryption method
@@ -77,8 +131,9 @@ function decryptText(encryptedText: string): string {
 // AES Plain text encryption method with enc. key
 function encryptTextWithKey(textToEncrypt: string, keyToEncrypt: string): string {
   const bytes = CryptoJS.AES.encrypt(textToEncrypt, keyToEncrypt).toString();
-  const result = base64ToHex(bytes);
-  return result;
+  const text64 = CryptoJS.enc.Base64.parse(bytes);
+
+  return text64.toString(CryptoJS.enc.Hex);
 }
 
 // AES Plain text decryption method with enc. key
@@ -87,8 +142,8 @@ function decryptTextWithKey(encryptedText: string, keyToDecrypt: string): string
     throw new Error('No key defined. Check .env file');
   }
 
-  const reb = uint8ArrayToBase64(hex2oldEncoding(encryptedText));
-  const bytes = CryptoJS.AES.decrypt(reb, keyToDecrypt);
+  const reb = CryptoJS.enc.Hex.parse(encryptedText);
+  const bytes = CryptoJS.AES.decrypt(reb.toString(CryptoJS.enc.Base64), keyToDecrypt);
 
   return bytes.toString(CryptoJS.enc.Utf8);
 }
@@ -137,7 +192,7 @@ export {
   excludeHiddenItems,
   renameFile,
   getItemPlainName,
+  getArgon2,
+  getPBKDF2,
   hex2oldEncoding,
-  uint8ArrayToBase64,
-  base64ToHex,
 };

--- a/test/unit/services/utils.passToHash.test.ts
+++ b/test/unit/services/utils.passToHash.test.ts
@@ -1,0 +1,265 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+    getPBKDF2,
+    getArgon2,
+    passToHash,
+    hex2oldEncoding,
+  } from '../../../src/app/crypto/services/utils';
+  
+  import { describe, expect, it } from 'vitest';
+  import CryptoJS from 'crypto-js';
+
+  describe('Test getPBKDF2 with RFC 7914 test vectors', () => {
+    it('getPBKDF2 should pass test 1 for PBKDF2-HMAC-SHA-256 from RFC 7914', async () => {
+      const password = 'passwd';
+      const salt = 'salt';
+      const iterations = 1;
+      const hashLength = 64;
+      const result = await getPBKDF2(password, salt, iterations, hashLength);
+      const testResult =
+        '55ac046e56e3089fec1691c22544b605f94185216dde0465e68b9d57c20dacbc49ca9cccf179b645991664b39d77ef317c71b845b1e30bd509112041d3a19783';
+      expect(result).toBe(testResult);
+    });
+  
+    it('getPBKDF2 should pass test 2 for PBKDF2-HMAC-SHA-256 from RFC 7914', async () => {
+      const password = 'Password';
+      const salt = 'NaCl';
+      const iterations = 80000;
+      const hashLength = 64;
+      const result = await getPBKDF2(password, salt, iterations, hashLength);
+      const testResult =
+        '4ddcd8f60b98be21830cee5ef22701f9641a4418d04c0414aeff08876b34ab56a1d425a1225833549adb841b51c9b3176a272bdebba1d078478f62b397f33c8d';
+      expect(result).toBe(testResult);
+    });
+  });
+  
+  describe('Test getArgon2 with test vectors from the reference implementation that won Password Hashing Competition ', () => {
+    it('getArgon2 should pass test 1', async () => {
+      const password = 'password';
+      const salt = 'somesalt';
+      const parallelism = 1;
+      const iterations = 2;
+      const memorySize = 65536;
+      const hashLength = 32;
+      const result = await getArgon2(password, salt, parallelism, iterations, memorySize, hashLength, 'hex');
+      const testResult = '09316115d5cf24ed5a15a31a3ba326e5cf32edc24702987c02b6566f61913cf7';
+      expect(result).toBe(testResult);
+    });
+  
+    it('getArgon2 should pass test 2', async () => {
+      const password = 'password';
+      const salt = 'somesalt';
+      const parallelism = 1;
+      const iterations = 2;
+      const memorySize = 262144;
+      const hashLength = 32;
+      const result = await getArgon2(password, salt, parallelism, iterations, memorySize, hashLength, 'hex');
+      const testResult = '78fe1ec91fb3aa5657d72e710854e4c3d9b9198c742f9616c2f085bed95b2e8c';
+      expect(result).toBe(testResult);
+    });
+  
+    it('getArgon2 should pass test 3', async () => {
+      const password = 'password';
+      const salt = 'somesalt';
+      const parallelism = 1;
+      const iterations = 2;
+      const memorySize = 256;
+      const hashLength = 32;
+      const result = await getArgon2(password, salt, parallelism, iterations, memorySize, hashLength, 'hex');
+      const testResult = '9dfeb910e80bad0311fee20f9c0e2b12c17987b4cac90c2ef54d5b3021c68bfe';
+      expect(result).toBe(testResult);
+    });
+  
+    it('getArgon2 should pass test 4', async () => {
+      const password = 'password';
+      const salt = 'somesalt';
+      const parallelism = 2;
+      const iterations = 2;
+      const memorySize = 256;
+      const hashLength = 32;
+      const result = await getArgon2(password, salt, parallelism, iterations, memorySize, hashLength, 'hex');
+      const testResult = '6d093c501fd5999645e0ea3bf620d7b8be7fd2db59c20d9fff9539da2bf57037';
+      expect(result).toBe(testResult);
+    });
+  
+    it('getArgon2 should pass test 5', async () => {
+      const password = 'password';
+      const salt = 'somesalt';
+      const parallelism = 1;
+      const iterations = 1;
+      const memorySize = 65536;
+      const hashLength = 32;
+      const result = await getArgon2(password, salt, parallelism, iterations, memorySize, hashLength, 'hex');
+      const testResult = 'f6a5adc1ba723dddef9b5ac1d464e180fcd9dffc9d1cbf76cca2fed795d9ca98';
+      expect(result).toBe(testResult);
+    });
+  
+    it('getArgon2 should pass test 6', async () => {
+      const password = 'password';
+      const salt = 'somesalt';
+      const parallelism = 1;
+      const iterations = 4;
+      const memorySize = 65536;
+      const hashLength = 32;
+      const result = await getArgon2(password, salt, parallelism, iterations, memorySize, hashLength, 'hex');
+      const testResult = '9025d48e68ef7395cca9079da4c4ec3affb3c8911fe4f86d1a2520856f63172c';
+      expect(result).toBe(testResult);
+    });
+  
+    it('getArgon2 should pass test 7', async () => {
+      const password = 'differentpassword';
+      const salt = 'somesalt';
+      const parallelism = 1;
+      const iterations = 2;
+      const memorySize = 65536;
+      const hashLength = 32;
+      const result = await getArgon2(password, salt, parallelism, iterations, memorySize, hashLength, 'hex');
+      const testResult = '0b84d652cf6b0c4beaef0dfe278ba6a80df6696281d7e0d2891b817d8c458fde';
+      expect(result).toBe(testResult);
+    });
+  
+    it('getArgon2 should pass test 8', async () => {
+      const password = 'password';
+      const salt = 'diffsalt';
+      const parallelism = 1;
+      const iterations = 2;
+      const memorySize = 65536;
+      const hashLength = 32;
+      const result = await getArgon2(password, salt, parallelism, iterations, memorySize, hashLength, 'hex');
+      const testResult = 'bdf32b05ccc42eb15d58fd19b1f856b113da1e9a5874fdcc544308565aa8141c';
+      expect(result).toBe(testResult);
+    });
+  });
+  
+  describe('Test against other crypto libraries', () => {
+
+    it('PBKDF2 should be identical to CryptoJS result for a test string', async () => {
+      const password = 'Test between hash-wasm and CryptoJS';
+      const salt = 'This is salt';
+      const result = await getPBKDF2(password, salt);
+      const cryptoJSresult = CryptoJS.PBKDF2(password, salt, { keySize: 256 / 32, iterations: 10000 }).toString(
+        CryptoJS.enc.Hex,
+      );
+      expect(result).toBe(cryptoJSresult);
+    });
+  
+    it('PBKDF2 should be identical to CryptoJS result for an empty string', async () => {
+      const password = '';
+      const salt = 'This is salt';
+      const result = await getPBKDF2(password, salt);
+      const cryptoJSresult = CryptoJS.PBKDF2(password, salt, { keySize: 256 / 32, iterations: 10000 }).toString(
+        CryptoJS.enc.Hex,
+      );
+      expect(result).toBe(cryptoJSresult);
+    });
+  });
+  
+  describe('Test passToHash', () => {
+    it('passToHash should be identical to getArgon2 for an empry salt', async () => {
+      const password = 'Test password';
+      const result = await passToHash({ password });
+      const salt: string = result.salt.split('$').pop() ?? '';
+      const argon2Result = await getArgon2(password, salt);
+      expect(result.hash).toBe(argon2Result);
+    });
+  
+    it('passToHash should be identical to getArgon2 in argon mode', async () => {
+      const password = 'Test password';
+      const salt = 'argon2id$6c7c6b9938cb8bd0baf1c2d2171b96a0';
+      const result = await passToHash({ password, salt });
+      const argon2Result = await getArgon2(password, '6c7c6b9938cb8bd0baf1c2d2171b96a0');
+      expect(result.hash).toBe(argon2Result);
+    });
+  
+    it('passToHash should be identical to getPBKDF2 in PBKDF2 mode', async () => {
+      const password = 'Test password';
+      const salt = '1238cb8bd0baf1c2d2171b96a0';
+      const result = await passToHash({ password, salt });
+      const encoded_salt = hex2oldEncoding(salt);
+      const pbkdf2Result = await getPBKDF2(password, encoded_salt);
+      expect(result.hash).toBe(pbkdf2Result);
+    });
+  
+    it('passToHash should return the same result for the given password and salt (argon mode)', async () => {
+      const password = 'Test password';
+      const salt = 'argon2id$6c7c6b9938cb8bd0baf1c2d2171b96a0';
+      const result1 = await passToHash({ password, salt });
+      const result2 = await passToHash({ password, salt });
+      expect(result1.hash).toBe(result2.hash);
+      expect(result1.salt).toBe(result2.salt);
+    });
+  
+    it('passToHash should return the same result for the same pwd and salt (PBKDF2)', async () => {
+      const password = 'Test password';
+      const salt = '6c7c6b9938cb8bd0baf1c2d2171b96a0';
+      const result1 = await passToHash({ password, salt });
+      const result2 = await passToHash({ password, salt });
+      expect(result1.hash).toBe(result2.hash);
+      expect(result1.salt).toBe(result2.salt);
+    });
+  
+    it('passToHash should return the same result when re-computed', async () => {
+      const password = 'Test password';
+      const salt = 'argon2id$6c7c6b9938cb8bd0baf1c2d2171b96a0';
+      const result1 = await passToHash({ password, salt });
+      const result2 = await passToHash({ password, salt: result1.salt });
+      expect(result1.hash).toBe(result2.hash);
+      expect(result1.salt).toBe(result2.salt);
+    });
+    
+  interface PassObjectInterface {
+    salt?: string | null;
+    password: string;
+  }
+
+  function oldPassToHash(passObject: PassObjectInterface): { salt: string; hash: string } {
+    const salt = passObject.salt ? CryptoJS.enc.Hex.parse(passObject.salt) : CryptoJS.lib.WordArray.random(128 / 8);
+    const hash = CryptoJS.PBKDF2(passObject.password, salt, { keySize: 256 / 32, iterations: 10000 });
+    const hashedObjetc = {
+      salt: salt.toString(),
+      hash: hash.toString(),
+    };
+
+    return hashedObjetc;
+  }
+
+  it('passToHash should return the same result for PBKDF2 as the old function', async () => {
+    const password = 'Test password';
+    const salt = '7121910994f21cd848c55e90835d7bd8';
+
+    const result = await passToHash({ password, salt });
+    const oldResult = oldPassToHash({ password, salt });
+    expect(result.salt).toBe(oldResult.salt);
+    expect(result.hash).toBe(oldResult.hash);
+  });
+
+  it('passToHash should return sucessfully verify old function hash', async () => {
+    const password = 'Test password';
+    const oldResult = oldPassToHash({ password });
+    const result = await passToHash({ password, salt: oldResult.salt });
+
+    expect(result.salt).toBe(oldResult.salt);
+    expect(result.hash).toBe(oldResult.hash);
+  });
+
+  it('passToHash should throw an error if salt is empty', async () => {
+    const password = 'Test password';
+    const salt = 'argon2id$';
+    await expect(passToHash({ password, salt })).rejects.toThrow('Salt must be specified');
+  });
+
+  it('passToHash should throw an error if password is empty', async () => {
+    const password = '';
+    const salt = 'argon2id$6c7c6b9938cb8bd0baf1c2d2171b96a0';
+    await expect(passToHash({ password, salt })).rejects.toThrow('Password must be specified');
+  });
+
+  it('passToHash should throw an error if salt is less than 8 bytes', async () => {
+    const password = 'Test password';
+    const salt = 'argon2id$6c';
+    await expect(passToHash({ password, salt })).rejects.toThrow('Salt should be at least 8 bytes long');
+  });
+});   


### PR DESCRIPTION
PR switches drive-web to Argon2

We now use hash = PBKDF2(pwd, salt). Unfortunately, the parameters are outdated, so we need to upgrade. The idea is to compute Argon2 for all new users and update the hash after login for old ones.

For that, passToHash works as follows:

    If no salt is given (new user), then it samples argon_salt, computes hash = Argon2 ( pwd, argon_salt) and sends (hash, 'argon2id$argoin_salt) to the database
    if salt starts with argon2id$, then it's already migrated user and we compute hash = Argon2( pwd, argon_salt)
    Else, then it's the user that hasn't migrated yet. We compute hash = PBKDF2(pwd, salt)

NOTE: Argon2 follows password [hash competition output format](https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md): the output will be $argon2id$v=19$m=65536,t=2,p=1$gZiV/M1gPc22ElAH/Jh1Hw$CWOrkoo7oJBQ/iyh7uJ0LO2aLEfrHwTWllSAxT0zRno or the same line but in HEX.