### PR TITLE
[PB-3409] Remove crypto js 

### DIFF
--- a/src/app/crypto/services/utils.ts
+++ b/src/app/crypto/services/utils.ts
@@ -4,6 +4,66 @@ import { aes, items as itemUtils } from '@internxt/lib';
 import { AdvancedSharedItem } from '../../share/types';
 import { createSHA512, createHMAC, sha256, createSHA256, sha512, ripemd160 } from 'hash-wasm';
 import { Buffer } from 'buffer';
+
+/**
+ * Converts HEX string to Uint8Array the same way CryptoJS did it (for compatibility)
+ * @param {string} hex - The input string in HEX
+ * @returns {Uint8Array} The resulting Uint8Array identical to what CryptoJS previously did
+ */
+function hex2oldEncoding(hex: string): Uint8Array {
+  const words: number[] = [];
+  for (let i = 0; i < hex.length; i += 8) {
+    words.push(parseInt(hex.slice(i, i + 8), 16) | 0);
+  }
+  const sigBytes = hex.length / 2;
+  const uint8Array = new Uint8Array(sigBytes);
+
+  for (let i = 0; i < sigBytes; i++) {
+    uint8Array[i] = (words[i >>> 2] >>> ((3 - (i % 4)) * 8)) & 0xff;
+  }
+
+  return uint8Array;
+}
+
+/**
+ * Converts Uint8Array to Base64 the same way CryptoJS did it (for compatibility)
+ * @param {Uint8Array} uint8Array - The input Uint8Array array
+ * @returns {string} The resulting Base64 string identical to what CryptoJS previously did
+ */
+function uint8ArrayToBase64(uint8Array: Uint8Array) {
+  let result = '';
+  for (const byte of uint8Array) {
+    result += String.fromCharCode(byte);
+  }
+  return btoa(result);
+}
+
+/**
+ * Converts Base64 to HEX the same way CryptoJS did it (for compatibility)
+ * @param {string} base64String - The input Base64 string
+ * @returns {string} The resulting HEX string identical to what CryptoJS previously did
+ */
+function base64ToHex(base64String: string) {
+  const binaryString = atob(base64String);
+  const length = binaryString.length;
+  const bytes = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, '0')) // Convert to hex and pad with leading zero if necessary
+    .join(''); // Combine all hex values into a single string
+}
+
+function wordArrayToUtf8String(wordArray) {
+  const byteArray = new Uint8Array(wordArray.sigBytes);
+  for (let i = 0; i < wordArray.sigBytes; i++) {
+    byteArray[i] = (wordArray.words[i >>> 2] >>> (24 - (i % 4) * 8)) & 0xff;
+  }
+  const decoder = new TextDecoder('utf-8');
+  return decoder.decode(byteArray);
+}
+
 /**
  * Computes hmac-sha512
  * @param {string} encryptionKeyHex - The hmac key in HEX format
@@ -97,10 +157,17 @@ function decryptText(encryptedText: string): string {
 
 // AES Plain text encryption method with enc. key
 function encryptTextWithKey(textToEncrypt: string, keyToEncrypt: string): string {
-  const bytes = CryptoJS.AES.encrypt(textToEncrypt, keyToEncrypt).toString();
-  const text64 = CryptoJS.enc.Base64.parse(bytes);
-
-  return text64.toString(CryptoJS.enc.Hex);
+  const salt = CryptoJS.lib.WordArray.random(8);
+  const kdf = CryptoJS.algo.EvpKDF.create({ keySize: 12 });
+  const derived = kdf.compute(keyToEncrypt, salt);
+  const key = CryptoJS.lib.WordArray.create(derived.words.slice(0, 12), 8 * 4);
+  const iv = CryptoJS.lib.WordArray.create(derived.words.slice(8, 12), 4 * 4);
+  const bytes = CryptoJS.AES.encrypt(textToEncrypt, key, {
+    iv: iv,
+  });
+  const saltedPrefix = CryptoJS.enc.Utf8.parse('Salted__');
+  const result = saltedPrefix + salt.toString(CryptoJS.enc.Hex) + base64ToHex(bytes.toString());
+  return result;
 }
 
 // AES Plain text decryption method with enc. key
@@ -109,10 +176,10 @@ function decryptTextWithKey(encryptedText: string, keyToDecrypt: string): string
     throw new Error('No key defined. Check .env file');
   }
 
-  const reb = CryptoJS.enc.Hex.parse(encryptedText);
-  const bytes = CryptoJS.AES.decrypt(reb.toString(CryptoJS.enc.Base64), keyToDecrypt);
+  const reb = uint8ArrayToBase64(hex2oldEncoding(encryptedText));
+  const bytes = CryptoJS.AES.decrypt(reb, keyToDecrypt);
 
-  return bytes.toString(CryptoJS.enc.Utf8);
+  return wordArrayToUtf8String(bytes);
 }
 
 function excludeHiddenItems(items: DriveItemData[]): DriveItemData[] {
@@ -154,4 +221,8 @@ export {
   getSha256Hasher,
   getSha512FromHex,
   getRipemd160FromHex,
+  hex2oldEncoding,
+  uint8ArrayToBase64,
+  base64ToHex,
+  wordArrayToUtf8String,
 };

--- a/test/unit/services/utils.aes.test.ts
+++ b/test/unit/services/utils.aes.test.ts
@@ -7,16 +7,14 @@ import {
   encryptTextWithKey,
   decryptText,
   decryptTextWithKey,
-  hex2oldEncoding,
-  uint8ArrayToBase64,
-  base64ToHex,
-  wordArrayToUtf8String,
 } from '../../../src/app/crypto/services/utils';
 
 import { describe, expect, it, afterAll, beforeAll } from 'vitest';
 import CryptoJS from 'crypto-js';
+import { Buffer } from 'buffer';
 
 describe('Test encryption', () => {
+  globalThis.Buffer = Buffer;
   if (typeof globalThis.process === 'undefined') {
     globalThis.process = { env: {} } as any;
   }
@@ -27,69 +25,6 @@ describe('Test encryption', () => {
   });
   afterAll(() => {
     process.env.REACT_APP_CRYPTO_SECRET = originalEnv;
-  });
-
-  it('should convert hex to base64 as before', async () => {
-    const message = 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad';
-    const result = uint8ArrayToBase64(hex2oldEncoding(message));
-    const oldResult = CryptoJS.enc.Hex.parse(message).toString(CryptoJS.enc.Base64);
-    expect(result).toBe(oldResult);
-  });
-
-  it('should convert base64 to hex as before', async () => {
-    const message = 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad';
-    const key = '123456789QWERTY';
-    const bytes = CryptoJS.AES.encrypt(message, key).toString();
-    const result = base64ToHex(bytes);
-    const oldResult = CryptoJS.enc.Base64.parse(bytes).toString(CryptoJS.enc.Hex);
-    expect(result).toBe(oldResult);
-  });
-
-  it('should convert to Utf8 as before', async () => {
-    const message = 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad';
-    const key = '123456789QWERTY';
-    const ciphertext = oldEncryptTextWithKey(message, key);
-    const reb = uint8ArrayToBase64(hex2oldEncoding(ciphertext));
-    const bytes = CryptoJS.AES.decrypt(reb, key);
-    const result = wordArrayToUtf8String(bytes);
-    const oldResult = bytes.toString(CryptoJS.enc.Utf8);
-    expect(result).toBe(oldResult);
-  });
-
-  it('should derive the same key and salt as before', async () => {
-    const message = 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad';
-    const pwd = '123456789QWERTY';
-
-    const enc = CryptoJS.AES.encrypt(message, pwd);
-
-    const kdf = CryptoJS.algo.EvpKDF.create({ keySize: 12 });
-    const bytes = kdf.compute(pwd, enc.salt);
-    const key = CryptoJS.lib.WordArray.create(bytes.words.slice(0, 12), 8 * 4);
-    const iv = CryptoJS.lib.WordArray.create(bytes.words.slice(8, 12), 4 * 4);
-    const oldKey = enc.key;
-    const oldIv = enc.iv;
-
-    expect(key.words).toEqual(oldKey.words);
-    expect(key.sigBytes).toEqual(oldKey.sigBytes);
-    expect(iv.words).toEqual(oldIv.words);
-    expect(iv.sigBytes).toEqual(oldIv.sigBytes);
-    expect(key.toString(CryptoJS.enc.Hex)).toBe(oldKey.toString(CryptoJS.enc.Hex));
-    expect(iv.toString(CryptoJS.enc.Hex)).toBe(oldIv.toString(CryptoJS.enc.Hex));
-  });
-
-  it('should encrypt as before', async () => {
-    const message = 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad';
-    const pwd = '123456789QWERTY';
-    const enc = CryptoJS.AES.encrypt(message, pwd);
-    const kdf = CryptoJS.algo.EvpKDF.create({ keySize: 12 });
-    const bytes = kdf.compute(pwd, enc.salt);
-    const key = CryptoJS.lib.WordArray.create(bytes.words.slice(0, 12), 8 * 4);
-    const iv = CryptoJS.lib.WordArray.create(bytes.words.slice(8, 12), 4 * 4);
-    const enc2 = CryptoJS.AES.encrypt(message, key, {
-      iv: iv,
-    });
-
-    expect(enc.toString(CryptoJS.enc.Hex)).toBe(enc2.toString(CryptoJS.enc.Hex));
   });
 
   it('Should be able to encrypt and decrypt', async () => {

--- a/test/unit/services/utils.aes.test.ts
+++ b/test/unit/services/utils.aes.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  encryptText,
+  encryptTextWithKey,
+  decryptText,
+  decryptTextWithKey,
+  hex2oldEncoding,
+  uint8ArrayToBase64,
+  base64ToHex,
+  wordArrayToUtf8String,
+} from '../../../src/app/crypto/services/utils';
+
+import { describe, expect, it, afterAll, beforeAll } from 'vitest';
+import CryptoJS from 'crypto-js';
+
+describe('Test encryption', () => {
+  if (typeof globalThis.process === 'undefined') {
+    globalThis.process = { env: {} } as any;
+  }
+  const originalEnv = process.env.REACT_APP_CRYPTO_SECRET;
+
+  beforeAll(() => {
+    process.env.REACT_APP_CRYPTO_SECRET = '123456789QWERTY';
+  });
+  afterAll(() => {
+    process.env.REACT_APP_CRYPTO_SECRET = originalEnv;
+  });
+
+  it('should convert hex to base64 as before', async () => {
+    const message = 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad';
+    const result = uint8ArrayToBase64(hex2oldEncoding(message));
+    const oldResult = CryptoJS.enc.Hex.parse(message).toString(CryptoJS.enc.Base64);
+    expect(result).toBe(oldResult);
+  });
+
+  it('should convert base64 to hex as before', async () => {
+    const message = 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad';
+    const key = '123456789QWERTY';
+    const bytes = CryptoJS.AES.encrypt(message, key).toString();
+    const result = base64ToHex(bytes);
+    const oldResult = CryptoJS.enc.Base64.parse(bytes).toString(CryptoJS.enc.Hex);
+    expect(result).toBe(oldResult);
+  });
+
+  it('should convert to Utf8 as before', async () => {
+    const message = 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad';
+    const key = '123456789QWERTY';
+    const ciphertext = oldEncryptTextWithKey(message, key);
+    const reb = uint8ArrayToBase64(hex2oldEncoding(ciphertext));
+    const bytes = CryptoJS.AES.decrypt(reb, key);
+    const result = wordArrayToUtf8String(bytes);
+    const oldResult = bytes.toString(CryptoJS.enc.Utf8);
+    expect(result).toBe(oldResult);
+  });
+
+  it('should derive the same key and salt as before', async () => {
+    const message = 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad';
+    const pwd = '123456789QWERTY';
+
+    const enc = CryptoJS.AES.encrypt(message, pwd);
+
+    const kdf = CryptoJS.algo.EvpKDF.create({ keySize: 12 });
+    const bytes = kdf.compute(pwd, enc.salt);
+    const key = CryptoJS.lib.WordArray.create(bytes.words.slice(0, 12), 8 * 4);
+    const iv = CryptoJS.lib.WordArray.create(bytes.words.slice(8, 12), 4 * 4);
+    const oldKey = enc.key;
+    const oldIv = enc.iv;
+
+    expect(key.words).toEqual(oldKey.words);
+    expect(key.sigBytes).toEqual(oldKey.sigBytes);
+    expect(iv.words).toEqual(oldIv.words);
+    expect(iv.sigBytes).toEqual(oldIv.sigBytes);
+    expect(key.toString(CryptoJS.enc.Hex)).toBe(oldKey.toString(CryptoJS.enc.Hex));
+    expect(iv.toString(CryptoJS.enc.Hex)).toBe(oldIv.toString(CryptoJS.enc.Hex));
+  });
+
+  it('should encrypt as before', async () => {
+    const message = 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad';
+    const pwd = '123456789QWERTY';
+    const enc = CryptoJS.AES.encrypt(message, pwd);
+    const kdf = CryptoJS.algo.EvpKDF.create({ keySize: 12 });
+    const bytes = kdf.compute(pwd, enc.salt);
+    const key = CryptoJS.lib.WordArray.create(bytes.words.slice(0, 12), 8 * 4);
+    const iv = CryptoJS.lib.WordArray.create(bytes.words.slice(8, 12), 4 * 4);
+    const enc2 = CryptoJS.AES.encrypt(message, key, {
+      iv: iv,
+    });
+
+    expect(enc.toString(CryptoJS.enc.Hex)).toBe(enc2.toString(CryptoJS.enc.Hex));
+  });
+
+  it('Should be able to encrypt and decrypt', async () => {
+    const message = 'Test message';
+    expect(process.env.REACT_APP_CRYPTO_SECRET, '123456789QWERTY');
+    const ciphertext = encryptText(message);
+    const result = decryptText(ciphertext);
+    expect(result).toBe(message);
+  });
+
+  it('decryptTextWithKey should fail with an empty key', async () => {
+    const message = 'Test message';
+    const ciphertext = encryptText(message);
+    expect(() => decryptTextWithKey(ciphertext, '')).toThrowError('No key defined. Check .env file');
+  });
+
+  function oldEncryptTextWithKey(textToEncrypt: string, keyToEncrypt: string): string {
+    const bytes = CryptoJS.AES.encrypt(textToEncrypt, keyToEncrypt).toString();
+    const text64 = CryptoJS.enc.Base64.parse(bytes);
+    return text64.toString(CryptoJS.enc.Hex);
+  }
+
+  function oldDecryptTextWithKey(encryptedText: string, keyToDecrypt: string): string {
+    if (!keyToDecrypt) {
+      throw new Error('No key defined. Check .env file');
+    }
+    const reb = CryptoJS.enc.Hex.parse(encryptedText);
+    const bytes = CryptoJS.AES.decrypt(reb.toString(CryptoJS.enc.Base64), keyToDecrypt);
+    return bytes.toString(CryptoJS.enc.Utf8);
+  }
+
+  it('decryptTextWithKey should give the same result as before', async () => {
+    const message = 'Test message';
+    const key = '123456789QWERTY';
+    const ciphertext = encryptTextWithKey(message, key);
+    const result = decryptTextWithKey(ciphertext, key);
+    const oldResult = oldDecryptTextWithKey(ciphertext, key);
+    expect(result).toBe(oldResult);
+  });
+
+  it('decryptTextWithKey should decrypt old ciphertext', async () => {
+    const message = 'Test message';
+    const key = '123456789QWERTY';
+    const ciphertext = oldEncryptTextWithKey(message, key);
+    const result = decryptTextWithKey(ciphertext, key);
+    expect(result).toBe(message);
+  });
+
+  it('encryptTextWithKey should work with old decrypt', async () => {
+    const message = 'Test message';
+    const key = '123456789QWERTY';
+    const ciphertext = encryptTextWithKey(message, key);
+    const result = oldDecryptTextWithKey(ciphertext, key);
+    expect(result).toBe(message);
+  });
+});


### PR DESCRIPTION
## Description

Switch AES encryption/decryption from crypto-js to crypto and ensure that new functions can decrypt old ciphertexts

## Related Issues

Fixes [PB-3409](https://inxt.atlassian.net/browse/PB-3409)

## How Has This Been Tested?

Unit tests to check that old encryption can be decrypted by the new function and that old decrypt can handle new ciphertexts. 

## Additional Notes

Crypto-js is much older than I thought. It relies on MD5 and uses an old OpenSSL method for creating the key (https://docs.openssl.org/1.0.2/man3/EVP_BytesToKey/). By default, crypto-js performs only a single iteration of MD5 over the password, which is extremely weak unless the password is long and truly random. We need to migrate to something stronger. 

P.S. I've prepared a branch with stronger encryption (uses aes-256-gcm and argon2 for key derivation) that also supports old decryption as well for compatibility.  Once this PR or argon2 PR is merged, I'll create a PR for the encryption upgrade.


[PB-3409]: https://inxt.atlassian.net/browse/PB-3409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ