### PR TITLE
[PB-241]: fix/folder upload can't be cancelled

### DIFF
--- a/src/app/store/slices/storage/storage.thunks/uploadFolderThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadFolderThunk.ts
@@ -17,15 +17,7 @@ import { getUniqueFolderName } from '../folderUtils/getUniqueFolderName';
 import { StorageState } from '../storage.model';
 import { deleteItemsThunk } from './deleteItemsThunk';
 import { uploadItemsParallelThunk } from './uploadItemsThunk';
-
-// TODO: REMOVE IROOT from this file, it is in types.ts
-export interface IRoot {
-  name: string;
-  folderId: string | null;
-  childrenFiles: File[];
-  childrenFolders: IRoot[];
-  fullPathEdited: string;
-}
+import { IRoot } from '../types';
 
 interface UploadFolderThunkPayload {
   root: IRoot;

--- a/src/app/store/slices/storage/storage.thunks/uploadFolderThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadFolderThunk.ts
@@ -153,7 +153,10 @@ export const uploadFolderThunk = createAsyncThunk<void, UploadFolderThunkPayload
         //Added wait in order to allow enough time for the server to create the folder
         await wait(500);
 
-        rootFolderItem = createdFolder;
+        if (!rootFolderItem) {
+          rootFolderItem = createdFolder;
+        }
+
         if (!rootFolderData) {
           rootFolderData = createdFolder;
           tasksService.updateTask({
@@ -305,7 +308,10 @@ export const uploadMultipleFolderThunkNoCheck = createAsyncThunk<
         // Added wait in order to allow enough time for the server to create the folder
         await wait(500);
 
-        rootFolderItem = createdFolder;
+        if (!rootFolderItem) {
+          rootFolderItem = createdFolder;
+        }
+
         tasksService.updateTask({
           taskId,
           merge: {


### PR DESCRIPTION
## Description
The folder used for the “cancel upload” operation is the root folder, so when the user cancels the upload, the remaining tasks will be removed and the root folder will be deleted with all uploaded items, so it will also disappear from Drive.

## Related Issues
Fixes [PB-241](https://inxt.atlassian.net/browse/PB-241).

## Checklist
- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.

## How Has This Been Tested?
- Upload 1 folder without levels (subfolders) and cancel it.
- Upload 1 folder with levels (nested folders) and cancel it.
- Upload several folders without levels and cancel them.
- Upload several folders with levels and cancel them.


[PB-241]: https://inxt.atlassian.net/browse/PB-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Additional notes
When the user is uploading a folder and then, the user cancels the upload, this folder remains uploaded on Drive instead of being deleted. 

It appears that the folder being deleted is the last uploaded folder, rather than the root folder (the parent folder and all levels/files), so the folder remains on Drive with the content that was uploaded (removing the last uploaded folder).
