### PR TITLE
[PB-3441]: fix/add validation for maximum assignable space

### DIFF
--- a/src/app/newSettings/Sections/Workspace/Members/components/ModifyStorageModal.tsx
+++ b/src/app/newSettings/Sections/Workspace/Members/components/ModifyStorageModal.tsx
@@ -53,7 +53,8 @@ export const ModifyStorageModal = (): JSX.Element => {
 
   const handleSliderChange = (newUserStorage: number) => {
     const roundedSpace = Math.round(newUserStorage);
-    setNewStorage(roundedSpace);
+    const validatedSpace = Math.min(roundedSpace, maxStorageForWorkspaceMember);
+    setNewStorage(validatedSpace);
   };
 
   const onClose = () => {


### PR DESCRIPTION
## Description

When updating the space assigned to a member of a workspace, in the case of assigning it the maximum available space, an error occurs, what happens is that an attempt is made to assign a higher value than the available one.
I have added a validation so that the request is not made with a value greater than the available one.

## Related Issues

--

## Related Pull Requests

--

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.

## How Has This Been Tested?

For the moment I have tested it locally and I have also passed the url environment that is generated with the PR for QA to test it.

## Additional Notes

--
