### PR TITLE
add hybrid encryption funcions

### DIFF
--- a/src/app/crypto/services/pgp.service.ts
+++ b/src/app/crypto/services/pgp.service.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'buffer';
 import { Data, MaybeStream, WebStream } from 'openpgp';
 import kemBuilder from '@dashlane/pqc-kem-kyber512-browser';
+import { extendSecret } from './utils';
 
 export async function getOpenpgp(): Promise<typeof import('openpgp')> {
   return import('openpgp');
@@ -30,6 +31,115 @@ export async function generateNewKeys(): Promise<{
     privateKyberKeyBase64: Buffer.from(privateKyberKey).toString('base64'),
   };
 }
+
+/**
+ * XORs two strings of the identical length
+ * @param {string} a - The first string
+ * @param {string} b - The second string
+ * @returns {string} The result of XOR of strings a and b.
+ */
+export function XORhex(a: string, b: string): string {
+  let res = '',
+    i = a.length,
+    j = b.length;
+  if (i != j) {
+    throw new Error('Can XOR only strings with identical length');
+  }
+  while (i-- > 0 && j-- > 0) res = (parseInt(a.charAt(i), 16) ^ parseInt(b.charAt(j), 16)).toString(16) + res;
+  return res;
+}
+
+/**
+ * Encrypts message using hybrid method (ecc and kyber) if kyber key is given, else uses ecc only
+ * @param {string} message - The message to encrypt
+ * @param {string} publicKeyInBase64 - The ecc public key in Base64
+ * @param {string=}[publicKyberKeyBase64] - The kyber public key in Base64
+ * @returns {Promise<string>} The encrypted message.
+ */
+export const hybridEncryptMessageWithPublicKey = async ({
+  message,
+  publicKeyInBase64,
+  publicKyberKeyBase64,
+}: {
+  message: string;
+  publicKeyInBase64: string;
+  publicKyberKeyBase64?: string;
+}): Promise<string> => {
+  let result = '';
+  let plaintext = message;
+  if (publicKyberKeyBase64) {
+    const kem = await kemBuilder();
+
+    const publicKyberKey = Buffer.from(publicKyberKeyBase64, 'base64');
+    const { ciphertext, sharedSecret: secret } = await kem.encapsulate(new Uint8Array(publicKyberKey));
+    const kyberCiphertextStr = Buffer.from(ciphertext).toString('base64');
+
+    const bits = message.length * 8;
+    const secretHex = await extendSecret(secret, bits);
+    const messageHex = Buffer.from(message).toString('hex');
+
+    plaintext = XORhex(messageHex, secretHex);
+    const prefixBase64 = '4879627269644d6f6465';
+    result = prefixBase64.concat('$', kyberCiphertextStr, '$');
+  }
+
+  const encryptedMessage = await encryptMessageWithPublicKey({ message: plaintext, publicKeyInBase64 });
+  const eccCiphertextStr = btoa(encryptedMessage as string);
+
+  result = result.concat(eccCiphertextStr);
+
+  return result;
+};
+
+/**
+ * Decrypts ciphertext using hybrid method (ecc and kyber) if kyber key is given, else uses ecc only
+ * @param {string} encryptedMessageInBase64 - The encrypted message
+ * @param {string} privateKeyInBase64 - The ecc private key in Base64
+ * @param {string=}[privateKyberKeyInBase64] - The kyber private key in Base64
+ * @returns {Promise<string>} The encrypted message.
+ */
+export const hybridDecryptMessageWithPrivateKey = async ({
+  encryptedMessageInBase64,
+  privateKeyInBase64,
+  privateKyberKeyInBase64,
+}: {
+  encryptedMessageInBase64: string;
+  privateKeyInBase64: string;
+  privateKyberKeyInBase64?: string;
+}): Promise<string> => {
+  let eccCiphertextStr = encryptedMessageInBase64;
+  let kyberSecret = new Uint8Array();
+  const ciphertexts = encryptedMessageInBase64.split('$');
+  const prefix = ciphertexts[0];
+
+  if (prefix == '4879627269644d6f6465') {
+    if (!privateKyberKeyInBase64) {
+      return Promise.reject(new Error('Attempted to decrypt hybrid ciphertex without Kyber key'));
+    }
+    const kem = await kemBuilder();
+
+    const kyberCiphertextBase64 = ciphertexts[1];
+    eccCiphertextStr = ciphertexts[2];
+
+    const privateKyberKey = Buffer.from(privateKyberKeyInBase64, 'base64');
+    const kyberCiphertext = Buffer.from(kyberCiphertextBase64, 'base64');
+    const decapsulate = await kem.decapsulate(new Uint8Array(kyberCiphertext), new Uint8Array(privateKyberKey));
+    kyberSecret = decapsulate.sharedSecret;
+  }
+  const decryptedMessage = await decryptMessageWithPrivateKey({
+    encryptedMessage: atob(eccCiphertextStr),
+    privateKeyInBase64,
+  });
+  let result = decryptedMessage as string;
+  if (privateKyberKeyInBase64) {
+    const bits = result.length * 4;
+    const secretHex = await extendSecret(kyberSecret, bits);
+    const xored = XORhex(result, secretHex);
+    result = Buffer.from(xored, 'hex').toString('utf8');
+  }
+
+  return result;
+};
 
 export const encryptMessageWithPublicKey = async ({
   message,

--- a/src/app/crypto/services/utils.ts
+++ b/src/app/crypto/services/utils.ts
@@ -2,7 +2,7 @@ import CryptoJS from 'crypto-js';
 import { DriveItemData } from '../../drive/types';
 import { aes, items as itemUtils } from '@internxt/lib';
 import { AdvancedSharedItem } from '../../share/types';
-import { createSHA512, createHMAC, sha256, createSHA256, sha512, ripemd160 } from 'hash-wasm';
+import { createSHA512, createHMAC, sha256, createSHA256, sha512, ripemd160, blake3 } from 'hash-wasm';
 import { Buffer } from 'buffer';
 /**
  * Computes hmac-sha512
@@ -34,6 +34,16 @@ async function getHmacSha512(encryptionKey: Buffer, dataArray: string[] | Buffer
 interface PassObjectInterface {
   salt?: string | null;
   password: string;
+}
+
+/**
+ * Extends the given secret to the required number of bits
+ * @param {string} secret - The original secret
+ * @param {number} length - The desired bitlength
+ * @returns {Promise<string>} The extended secret of the desired bitlength
+ */
+function extendSecret(secret: Uint8Array, length: number): Promise<string> {
+  return blake3(secret, length);
 }
 
 /**
@@ -154,4 +164,5 @@ export {
   getSha256Hasher,
   getSha512FromHex,
   getRipemd160FromHex,
+  extendSecret,
 };

--- a/test/unit/services/pgp.service.test.ts
+++ b/test/unit/services/pgp.service.test.ts
@@ -7,6 +7,9 @@ import {
   decryptMessageWithPrivateKey,
   encryptMessageWithPublicKey,
   generateNewKeys,
+  XORhex,
+  hybridEncryptMessageWithPublicKey,
+  hybridDecryptMessageWithPrivateKey,
 } from '../../../src/app/crypto/services/pgp.service';
 
 describe('Encryption and Decryption', () => {
@@ -18,6 +21,151 @@ describe('Encryption and Decryption', () => {
     expect(keys).toHaveProperty('revocationCertificate');
     expect(keys).toHaveProperty('publicKyberKeyBase64');
     expect(keys).toHaveProperty('privateKyberKeyBase64');
+  });
+
+  it('should encrypt a message using hybrid encryption', async () => {
+    const keys = await generateNewKeys();
+    const publicKeyInBase64 = keys.publicKeyArmored;
+    const message =
+      'truck arch rather sell tilt return warm nurse rack vacuum rubber tribe unfold scissors copper sock panel ozone harsh ahead danger soda legal state';
+    const publicKyberKeyBase64 = keys.publicKyberKeyBase64;
+
+    const encryptedMessage = await hybridEncryptMessageWithPublicKey({
+      message,
+      publicKeyInBase64,
+      publicKyberKeyBase64,
+    });
+
+    expect(encryptedMessage).toBeDefined();
+  });
+
+  it('XOR should throw an error when strings are of different length', async () => {
+    const messageHex = '74686973206973207468652074657374206d657373616765';
+    const secretHex =
+      '74686973206973207468652074657374206d65737361676574686973206973207468652074657374206d657373616765';
+
+    expect(() => {
+      XORhex(messageHex, secretHex);
+    }).toThrowError('Can XOR only strings with identical length');
+  });
+
+  it('XOR should work for the given fixed example', async () => {
+    const firstHex = '74686973206973207468652074657374206d657373616765';
+    const secondHex = '7468697320697320746865207365636f6e64206d65737361';
+    const resultHex = '0000000000000000000000000700101b4e09451e16121404';
+
+    const xoredMessage = await XORhex(firstHex, secondHex);
+
+    expect(xoredMessage).toEqual(resultHex);
+  });
+
+  it('XOR of two identical strings should result in zero string', async () => {
+    const strHex = '74686973206973207468652074657374206d657373616765';
+    const resultHex = '000000000000000000000000000000000000000000000000';
+
+    const xoredMessage = await XORhex(strHex, strHex);
+
+    expect(xoredMessage).toEqual(resultHex);
+  });
+
+  it('XOR of str1, str2 and str1 should result in str2', async () => {
+    const str1 = '74686973206973207468652074657374206d657373616765';
+    const str2 = '7468697320697320746865207365636f6e64206d65737361';
+
+    const str3 = await XORhex(str1, str2);
+    const should_be_str2 = await XORhex(str3, str1);
+
+    expect(should_be_str2).toEqual(str2);
+  });
+
+  it('should generate keys, encrypt and decrypt a message using hybrid encryption', async () => {
+    const keys = await generateNewKeys();
+
+    const originalMessage =
+      'until bonus summer risk chunk oyster census ability frown win pull steel measure employ rigid improve riot remind system earn inch broken chalk clip';
+
+    const encryptedMessageInBase64 = await hybridEncryptMessageWithPublicKey({
+      message: originalMessage,
+      publicKeyInBase64: keys.publicKeyArmored,
+      publicKyberKeyBase64: keys.publicKyberKeyBase64,
+    });
+
+    const decryptedMessage = await hybridDecryptMessageWithPrivateKey({
+      encryptedMessageInBase64,
+      privateKeyInBase64: Buffer.from(keys.privateKeyArmored).toString('base64'),
+      privateKyberKeyInBase64: keys.privateKyberKeyBase64,
+    });
+
+    expect(keys).toHaveProperty('privateKeyArmored');
+    expect(keys).toHaveProperty('publicKeyArmored');
+    expect(encryptedMessageInBase64).not.toEqual(originalMessage);
+    expect(decryptedMessage).toEqual(originalMessage);
+  });
+
+  it('should throw an error if hybrid ciphertext but no kyber key', async () => {
+    const keys = await generateNewKeys();
+
+    const originalMessage =
+      'until bonus summer risk chunk oyster census ability frown win pull steel measure employ rigid improve riot remind system earn inch broken chalk clip';
+
+    const encryptedMessageInBase64 = await hybridEncryptMessageWithPublicKey({
+      message: originalMessage,
+      publicKeyInBase64: keys.publicKeyArmored,
+      publicKyberKeyBase64: keys.publicKyberKeyBase64,
+    });
+
+    await expect(
+      hybridDecryptMessageWithPrivateKey({
+        encryptedMessageInBase64,
+        privateKeyInBase64: Buffer.from(keys.privateKeyArmored).toString('base64'),
+      }),
+    ).rejects.toThrowError('Attempted to decrypt hybrid ciphertex without Kyber key');
+  });
+
+  it('hybrid decryption should decrypt old ciphertexts', async () => {
+    const keys = await generateNewKeys();
+
+    const originalMessage =
+      'until bonus summer risk chunk oyster census ability frown win pull steel measure employ rigid improve riot remind system earn inch broken chalk clip';
+
+    const encryptedMessage = await encryptMessageWithPublicKey({
+      message: originalMessage,
+      publicKeyInBase64: keys.publicKeyArmored,
+    });
+
+    const encryptedMessageStr = btoa(encryptedMessage as string);
+
+    const decryptedMessage = await hybridDecryptMessageWithPrivateKey({
+      encryptedMessageInBase64: encryptedMessageStr,
+      privateKeyInBase64: Buffer.from(keys.privateKeyArmored).toString('base64'),
+    });
+
+    expect(decryptedMessage).toEqual(originalMessage);
+  });
+
+  it('hybrid decryption should decrypt without kyber keys as before', async () => {
+    const keys = await generateNewKeys();
+
+    const originalMessage =
+      'until bonus summer risk chunk oyster census ability frown win pull steel measure employ rigid improve riot remind system earn inch broken chalk clip';
+
+    const encryptedMessageInBase64 = await hybridEncryptMessageWithPublicKey({
+      message: originalMessage,
+      publicKeyInBase64: keys.publicKeyArmored,
+    });
+
+    const decryptedMessage = await hybridDecryptMessageWithPrivateKey({
+      encryptedMessageInBase64,
+      privateKeyInBase64: Buffer.from(keys.privateKeyArmored).toString('base64'),
+    });
+
+    const oldDecryptedMessage = await decryptMessageWithPrivateKey({
+      encryptedMessage: atob(encryptedMessageInBase64),
+      privateKeyInBase64: Buffer.from(keys.privateKeyArmored).toString('base64'),
+    });
+
+    expect(decryptedMessage).toEqual(oldDecryptedMessage);
+    expect(decryptedMessage).toEqual(originalMessage);
   });
 
   it('should encrypt a message with the given public key', async () => {

--- a/test/unit/services/utils.hash.test.ts
+++ b/test/unit/services/utils.hash.test.ts
@@ -7,6 +7,7 @@ import {
   getSha256Hasher,
   getSha512FromHex,
   getRipemd160FromHex,
+  extendSecret,
 } from '../../../src/app/crypto/services/utils';
 
 import { describe, expect, it } from 'vitest';
@@ -243,6 +244,76 @@ describe('Test getRipemd160 with test vectors published by the authors', () => {
     }
     const result = await getRipemd160FromHex(message);
     const testResult = '52783243c1697bdbe16d37f97f68f08325dc1528';
+    expect(result).toBe(testResult);
+  });
+});
+
+describe('Test extendSecret with blake3 test vectors', () => {
+  it('extendSecret should pass test with input length 0 from blake3 team', async () => {
+    const message = Buffer.from('');
+    const result = await extendSecret(message, 1048);
+    const testResult =
+      'af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262e00f03e7b69af26b7faaf09fcd333050338ddfe085b8cc869ca98b206c08243a26f5487789e8f660afe6c99ef9e0c52b92e7393024a80459cf91f476f9ffdbda7001c22e159b402631f277ca96f2defdf1078282314e763699a31c5363165421cce14d';
+    expect(result).toBe(testResult);
+  });
+
+  it('extendSecret should pass test with input length 1 from blake3 team', async () => {
+    const message = Buffer.from([0]);
+    const result = await extendSecret(message, 1048);
+    const testResult =
+      '2d3adedff11b61f14c886e35afa036736dcd87a74d27b5c1510225d0f592e213c3a6cb8bf623e20cdb535f8d1a5ffb86342d9c0b64aca3bce1d31f60adfa137b358ad4d79f97b47c3d5e79f179df87a3b9776ef8325f8329886ba42f07fb138bb502f4081cbcec3195c5871e6c23e2cc97d3c69a613eba131e5f1351f3f1da786545e5';
+    expect(result).toBe(testResult);
+  });
+
+  it('extendSecret should pass test with input length 2 from blake3 team', async () => {
+    const message = Buffer.from([0, 1]);
+    const result = await extendSecret(message, 1048);
+    const testResult =
+      '7b7015bb92cf0b318037702a6cdd81dee41224f734684c2c122cd6359cb1ee63d8386b22e2ddc05836b7c1bb693d92af006deb5ffbc4c70fb44d0195d0c6f252faac61659ef86523aa16517f87cb5f1340e723756ab65efb2f91964e14391de2a432263a6faf1d146937b35a33621c12d00be8223a7f1919cec0acd12097ff3ab00ab1';
+    expect(result).toBe(testResult);
+  });
+
+  function getBuffer(length: number) {
+    const result = Array(length);
+    let byte = 0;
+    for (let i = 0; i < length; i++) {
+      result[i] = byte;
+      byte += 1;
+      if (byte > 250) {
+        byte = 0;
+      }
+    }
+    return Buffer.from(result);
+  }
+  it('extendSecret should pass test with input length 7 from blake3 team', async () => {
+    const message = getBuffer(7);
+    const result = await extendSecret(message, 1048);
+    const testResult =
+      '3f8770f387faad08faa9d8414e9f449ac68e6ff0417f673f602a646a891419fe66036ef6e6d1a8f54baa9fed1fc11c77cfb9cff65bae915045027046ebe0c01bf5a941f3bb0f73791d3fc0b84370f9f30af0cd5b0fc334dd61f70feb60dad785f070fef1f343ed933b49a5ca0d16a503f599a365a4296739248b28d1a20b0e2cc8975c';
+    expect(result).toBe(testResult);
+  });
+
+  it('extendSecret should pass test with input length 63 from blake3 team', async () => {
+    const message = getBuffer(63);
+    const result = await extendSecret(message, 1048);
+    const testResult =
+      'e9bc37a594daad83be9470df7f7b3798297c3d834ce80ba85d6e207627b7db7b1197012b1e7d9af4d7cb7bdd1f3bb49a90a9b5dec3ea2bbc6eaebce77f4e470cbf4687093b5352f04e4a4570fba233164e6acc36900e35d185886a827f7ea9bdc1e5c3ce88b095a200e62c10c043b3e9bc6cb9b6ac4dfa51794b02ace9f98779040755';
+    expect(result).toBe(testResult);
+  });
+
+  it('extendSecret should pass test with input length 1023 from blake3 team', async () => {
+    const message = getBuffer(1023);
+    const result = await extendSecret(message, 1048);
+    const testResult =
+      '10108970eeda3eb932baac1428c7a2163b0e924c9a9e25b35bba72b28f70bd11a182d27a591b05592b15607500e1e8dd56bc6c7fc063715b7a1d737df5bad3339c56778957d870eb9717b57ea3d9fb68d1b55127bba6a906a4a24bbd5acb2d123a37b28f9e9a81bbaae360d58f85e5fc9d75f7c370a0cc09b6522d9c8d822f2f28f485';
+    expect(result).toBe(testResult);
+  });
+
+  it('extendSecret should pass test with input length 102400 from blake3 team', async () => {
+    const message = getBuffer(102400);
+    const result = await extendSecret(message, 1048);
+    const testResult =
+      'bc3e3d41a1146b069abffad3c0d44860cf664390afce4d9661f7902e7943e085e01c59dab908c04c3342b816941a26d69c2605ebee5ec5291cc55e15b76146e6745f0601156c3596cb75065a9c57f35585a52e1ac70f69131c23d611ce11ee4ab1ec2c009012d236648e77be9295dd0426f29b764d65de58eb7d01dd42248204f45f8e';
     expect(result).toBe(testResult);
   });
 });


### PR DESCRIPTION
## Description

Adds hybrid encryption functions and relevant tests. Functions are not used by drive-web yet

## Related Issues

Relates to [PB-2666](https://inxt.atlassian.net/browse/PB-2666) 

## Related Pull Requests

- Extends [feat/add_only_kyber_keys](https://github.com/internxt/drive-web/pull/1397)

## How Has This Been Tested?

Unit tests for all new functions

## Additional Notes

The second PR for Kyber migration. The idea is to make small PRs that gradually change the encryption


[PB-2666]: https://inxt.atlassian.net/browse/PB-2666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ