### PR TITLE
[_]: fix/remove feedback step when cancelling sub

### DIFF
--- a/src/app/newSettings/Sections/Account/Billing/BillingAccountSection.tsx
+++ b/src/app/newSettings/Sections/Account/Billing/BillingAccountSection.tsx
@@ -36,7 +36,7 @@ const BillingAccountSection = ({ changeSection, onClosePreferences }: BillingAcc
     setCurrentUsage(getCurrentUsage(plan.usageDetails));
   }, [plan.individualSubscription]);
 
-  async function cancelSubscription(feedback: string) {
+  async function cancelSubscription() {
     setCancellingSubscription(true);
     try {
       await paymentService.cancelSubscription();

--- a/src/app/newSettings/Sections/Account/Billing/components/CancelSubscription.tsx
+++ b/src/app/newSettings/Sections/Account/Billing/components/CancelSubscription.tsx
@@ -5,9 +5,9 @@ import { UserType } from '@internxt/sdk/dist/drive/payments/types';
 
 interface CancelSubscriptionProps {
   isCancelSubscriptionModalOpen: boolean;
-  setIsCancelSubscriptionModalOpen: (isCancelSubscriptionModalOpen) => void;
+  setIsCancelSubscriptionModalOpen: (isCancelSubscriptionModalOpen: boolean) => void;
   cancellingSubscription: boolean;
-  cancelSubscription: (string) => void;
+  cancelSubscription: () => void;
   planName: string;
   planInfo: string;
   currentUsage: number;

--- a/src/app/newSettings/Sections/Account/Plans/PlansSection.tsx
+++ b/src/app/newSettings/Sections/Account/Plans/PlansSection.tsx
@@ -219,7 +219,7 @@ const PlansSection = ({ changeSection, onClosePreferences }: PlansSectionProps) 
     setIsUpdatingSubscription(false);
   };
 
-  async function cancelSubscription(feedback: string) {
+  async function cancelSubscription() {
     setCancellingSubscription(true);
     try {
       await paymentService.cancelSubscription(selectedSubscriptionType);

--- a/src/app/newSettings/Sections/Workspace/Billing/BillingWorkspaceSection.tsx
+++ b/src/app/newSettings/Sections/Workspace/Billing/BillingWorkspaceSection.tsx
@@ -90,7 +90,7 @@ const BillingWorkspaceSection = ({ onClosePreferences }: BillingWorkspaceSection
     }
   };
 
-  const cancelSubscription = async (feedback: string) => {
+  const cancelSubscription = async () => {
     setCancellingSubscription(true);
     try {
       await paymentService.cancelSubscription(UserType.Business);

--- a/src/app/newSettings/Sections/Workspace/Billing/CancelSubscriptionModal.tsx
+++ b/src/app/newSettings/Sections/Workspace/Billing/CancelSubscriptionModal.tsx
@@ -252,13 +252,7 @@ const Step2 = ({
         >
           {translate('views.account.tabs.billing.cancelSubscriptionModal.cancelSubscription')}
         </Button>
-        <Button
-          className="ml-2 shadow-subtle-hard"
-          disabled={cancellingSubscription}
-          onClick={() => {
-            onClose();
-          }}
-        >
+        <Button className="ml-2 shadow-subtle-hard" disabled={cancellingSubscription} onClick={onClose}>
           {translate('views.account.tabs.billing.cancelSubscriptionModal.keepSubscription')}
         </Button>
       </div>

--- a/src/app/newSettings/Sections/Workspace/Billing/CancelSubscriptionModal.tsx
+++ b/src/app/newSettings/Sections/Workspace/Billing/CancelSubscriptionModal.tsx
@@ -32,7 +32,7 @@ const CancelSubscriptionModal = ({
 }): JSX.Element => {
   const isIndividual = userType === UserType.Individual;
   const { translate } = useTranslationContext();
-  const [step, setStep] = useState<1 | 2 | 3>(!isIndividual ? 3 : 2);
+  const [step, setStep] = useState<1 | 2>(2);
   const [couponAvailable, setCouponAvailable] = useState(false);
   const dispatch = useAppDispatch();
 
@@ -85,7 +85,7 @@ const CancelSubscriptionModal = ({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
-      {(step === 2 || step === 3) && (
+      {step === 2 && (
         <>
           <h1 className="text-2xl font-medium text-gray-80">
             {translate('views.account.tabs.billing.cancelSubscriptionModal.title')}
@@ -118,7 +118,7 @@ const Step1 = ({
   applyCoupon,
 }: {
   currentPlanName: string;
-  setStep: Dispatch<SetStateAction<3 | 2 | 1>>;
+  setStep: Dispatch<SetStateAction<2 | 1>>;
   applyCoupon: () => void;
 }): JSX.Element => {
   const { translate } = useTranslationContext();
@@ -172,7 +172,7 @@ const Step2 = ({
   currentUsage: number;
   cancellingSubscription: boolean;
   cancelSubscription: () => void;
-  setStep: Dispatch<SetStateAction<3 | 2 | 1>>;
+  setStep: Dispatch<SetStateAction<2 | 1>>;
   onClose: () => void;
 }): JSX.Element => {
   const { translate } = useTranslationContext();
@@ -248,9 +248,7 @@ const Step2 = ({
           className={'shadow-subtle-hard'}
           variant="secondary"
           disabled={cancellingSubscription}
-          onClick={() => {
-            cancelSubscription();
-          }}
+          onClick={cancelSubscription}
         >
           {translate('views.account.tabs.billing.cancelSubscriptionModal.cancelSubscription')}
         </Button>

--- a/src/app/newSettings/Sections/Workspace/Billing/CancelSubscriptionModal.tsx
+++ b/src/app/newSettings/Sections/Workspace/Billing/CancelSubscriptionModal.tsx
@@ -28,7 +28,7 @@ const CancelSubscriptionModal = ({
   currentUsage: number;
   cancellingSubscription: boolean;
   userType: UserType;
-  cancelSubscription: (feedback: string) => void;
+  cancelSubscription: () => void;
 }): JSX.Element => {
   const isIndividual = userType === UserType.Individual;
   const { translate } = useTranslationContext();
@@ -101,18 +101,11 @@ const CancelSubscriptionModal = ({
         <Step2
           currentPlanName={currentPlanName}
           onClose={onClose}
+          cancelSubscription={cancelSubscription}
+          cancellingSubscription={cancellingSubscription}
           setStep={setStep}
           currentPlanInfo={currentPlanInfo}
           currentUsage={currentUsage}
-        />
-      )}
-
-      {step === 3 && (
-        <Step3
-          currentPlanName={currentPlanName}
-          onClose={onClose}
-          cancellingSubscription={cancellingSubscription}
-          cancelSubscription={cancelSubscription}
         />
       )}
     </Modal>
@@ -170,12 +163,15 @@ const Step2 = ({
   currentPlanName,
   currentPlanInfo,
   currentUsage,
-  setStep,
+  cancellingSubscription,
+  cancelSubscription,
   onClose,
 }: {
   currentPlanName: string;
   currentPlanInfo: string;
   currentUsage: number;
+  cancellingSubscription: boolean;
+  cancelSubscription: () => void;
   setStep: Dispatch<SetStateAction<3 | 2 | 1>>;
   onClose: () => void;
 }): JSX.Element => {
@@ -251,77 +247,20 @@ const Step2 = ({
         <Button
           className={'shadow-subtle-hard'}
           variant="secondary"
-          onClick={() => {
-            setStep(3);
-          }}
-        >
-          {translate('views.account.tabs.billing.cancelSubscriptionModal.continue')}
-        </Button>
-        <Button
-          className="ml-2 shadow-subtle-hard"
-          onClick={() => {
-            onClose();
-          }}
-        >
-          {translate('views.account.tabs.billing.cancelSubscriptionModal.keepSubscription')}
-        </Button>
-      </div>
-    </>
-  );
-};
-
-const Step3 = ({
-  currentPlanName,
-  onClose,
-  cancellingSubscription,
-  cancelSubscription,
-}: {
-  currentPlanName: string;
-  onClose: () => void;
-  cancellingSubscription: boolean;
-  cancelSubscription: (feedback: string) => void;
-}): JSX.Element => {
-  const { translate } = useTranslationContext();
-  const [otherFeedback, setOtherFeedback] = useState<string>('');
-
-  const MAX_OTHERFEEDBACK_LENGTH = 1000;
-
-  return (
-    <>
-      <p className="mt-4 text-gray-100">
-        {translate('views.account.tabs.billing.cancelSubscriptionModal.giveUsFeedback', {
-          currentPlanName,
-        })}
-      </p>
-      <div>
-        <textarea
           disabled={cancellingSubscription}
-          value={otherFeedback}
-          placeholder={translate('views.account.tabs.billing.cancelSubscriptionModal.feedback.placeholder')}
-          rows={4}
-          className="mt-4 w-full max-w-lg resize-none rounded-md border border-gray-20 bg-transparent p-3 pl-4 outline-none"
-          onChange={(e) => setOtherFeedback(String(e.target.value))}
-        />
-        <div className="flex w-full max-w-lg justify-end">
-          <span className={`text-sm ${(otherFeedback.length > MAX_OTHERFEEDBACK_LENGTH && 'text-red') || ''}`}>
-            {otherFeedback.length}/{MAX_OTHERFEEDBACK_LENGTH}
-          </span>
-        </div>
-      </div>
-
-      <div className="mt-4 flex justify-end">
-        <Button
-          loading={cancellingSubscription}
-          disabled={otherFeedback.length > MAX_OTHERFEEDBACK_LENGTH || otherFeedback.length <= 0}
-          variant="secondary"
-          className="shadow-subtle-hard"
           onClick={() => {
-            cancelSubscription(otherFeedback.trim());
+            cancelSubscription();
           }}
         >
           {translate('views.account.tabs.billing.cancelSubscriptionModal.cancelSubscription')}
         </Button>
-        <Button disabled={cancellingSubscription} className="ml-2 shadow-subtle-hard" onClick={onClose}>
+        <Button
+          className="ml-2 shadow-subtle-hard"
+          disabled={cancellingSubscription}
+          onClick={() => {
+            onClose();
+          }}
+        >
           {translate('views.account.tabs.billing.cancelSubscriptionModal.keepSubscription')}
         </Button>
       </div>


### PR DESCRIPTION
## Description

Removing the final step (feedback) when cancelling subscription.

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.

## How Has This Been Tested?
Purchase a subscription > cancel subscription - as you can see, feedback step has been removed.

