### PR TITLE
feat: return private key in deep link

### DIFF
--- a/src/app/auth/views/UnivesalLinkSuccessView/UniversalLinkSuccessView.tsx
+++ b/src/app/auth/views/UnivesalLinkSuccessView/UniversalLinkSuccessView.tsx
@@ -25,7 +25,7 @@ export default function UniversalLinkSuccessView(): JSX.Element {
     if (!newToken) return AppView.Login;
     return `${DEEPLINK_SUCCESS_REDIRECT_BASE}?mnemonic=${btoa(user.mnemonic)}&token=${btoa(token)}&newToken=${btoa(
       newToken,
-    )}`;
+    )}&privateKey=${btoa(user.privateKey)}`;
   };
 
   // Should redirect to login in the useEffect


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise summary of the changes. Include the reason and context, if applicable. -->
Macos does not receive or ask for plain password in any step of its flow, so we need to retrieve the decrypted private key the same way we do with the mnemonic.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [ ] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.

## How Has This Been Tested?

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
