### PR TITLE
Added try catch to avoid infite loop when token expire

### DIFF
--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -42,6 +42,7 @@ import { initializeUserThunk, userActions, userThunks } from 'app/store/slices/u
 import { workspaceThunks } from 'app/store/slices/workspaces/workspacesStore';
 import { generateMnemonic, validateMnemonic } from 'bip39';
 import { SdkFactory } from '../../core/factory/sdk';
+import errorService from '../../core/services/error.service';
 import httpService from '../../core/services/http.service';
 
 type ProfileInfo = {
@@ -82,11 +83,16 @@ export type AuthenticateUserParams = {
 };
 
 export async function logOut(loginParams?: Record<string, string>): Promise<void> {
-  const token = localStorageService.get('xNewToken') || undefined;
-  if (token) {
-    const authClient = SdkFactory.getNewApiInstance().createAuthClient();
-    await authClient.logout(token);
+  try {
+    const token = localStorageService.get('xNewToken') || undefined;
+    if (token) {
+      const authClient = SdkFactory.getNewApiInstance().createAuthClient();
+      await authClient.logout(token);
+    }
+  } catch (error) {
+    errorService.reportError(error);
   }
+
   await databaseService.clear();
   localStorageService.clear();
   RealtimeService.getInstance().stop();


### PR DESCRIPTION
## Description

- Fix access logs logout when token expire

## Related Issues

-

## Related Pull Requests

-

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.

## How Has This Been Tested?

- Open two web browser windows, one in incognito and another normal
- Log in in two browsers
- Change password in incognito one
- Token has expired in normal one and logout automatically, but has to let user log in again
