### PR TITLE
[_]: fix/check if image is valid before creating thumbnails

### DIFF
--- a/src/app/drive/services/network.service/index.ts
+++ b/src/app/drive/services/network.service/index.ts
@@ -80,10 +80,6 @@ export class Network {
     continueUploadOptions: {
       taskId: string;
     },
-    analyticsServiceCallbacks?: {
-      pauseUploadCallback: () => void;
-      resumeUploadCallback: () => void;
-    },
   ): [Promise<string>, Abortable | undefined] {
     if (!bucketId) {
       throw new Error('Bucket id not provided');
@@ -95,7 +91,7 @@ export class Network {
 
     const worker: Worker = createUploadWebWorker();
     const payload: Omit<IUploadParams, 'progressCallback'> & {
-      creds: any;
+      creds: Network['creds'];
       mnemonic: string;
       continueUploadOptions: {
         taskId: string;

--- a/src/app/drive/services/thumbnail.service.ts
+++ b/src/app/drive/services/thumbnail.service.ts
@@ -50,7 +50,6 @@ const isValidImage = (file: File): Promise<boolean> => {
 const getImageThumbnail = async (file: File): Promise<ThumbnailGenerated['file']> => {
   const isValid = await isValidImage(file);
   if (!isValid) {
-    console.log('Invalid image file');
     return null;
   }
 
@@ -63,7 +62,6 @@ const getImageThumbnail = async (file: File): Promise<ThumbnailGenerated['file']
       ThumbnailConfig.Quality,
       0,
       (uri) => {
-        console.log('URI:', uri);
         if (uri && uri instanceof File) resolve(uri);
         else resolve(null);
       },
@@ -185,7 +183,6 @@ export const generateThumbnailFromFile = async (
   const fileType = fileToUpload.type ? String(fileToUpload.type).toLowerCase() : '';
   if (thumbnailableExtension.includes(fileType)) {
     try {
-      console.log('THUMBNAIL AVAILABLE ', fileType);
       const thumbnail = await getThumbnailFrom(fileToUpload);
 
       if (thumbnail.file) {
@@ -202,7 +199,6 @@ export const generateThumbnailFromFile = async (
         };
         const abortController = new AbortController();
 
-        console.log('UPLOADING THUMBNAIL');
         const thumbnailUploaded = await uploadThumbnail(
           userEmail,
           thumbnailToUpload,
@@ -210,8 +206,6 @@ export const generateThumbnailFromFile = async (
           updateProgressCallback,
           abortController,
         );
-
-        console.log('THUMBNAIL UPLOADED ACTUALLY');
 
         return {
           thumbnail: thumbnailUploaded,


### PR DESCRIPTION
## Description
Check if an image is valid (the image can be previewed) before creating an image thumbnail, because if the image is not valid, the upload will hang.

This gives a bad impression to the user because the file is uploaded but shows at 100% in the task logger all the time, as it keeps creating the thumbnail.

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
