### PR TITLE
[PB-2666] switch to hybrid dec

### DIFF
--- a/src/app/crypto/services/pgp.service.ts
+++ b/src/app/crypto/services/pgp.service.ts
@@ -3,7 +3,7 @@ import { Data, MaybeStream, WebStream } from 'openpgp';
 import kemBuilder from '@dashlane/pqc-kem-kyber512-browser';
 import { extendSecret } from './utils';
 
-const WORDS_HYBRID_MODE_IN_HEX = '4879627269644d6f6465'; // 'HybridMode' in HEX format
+const WORDS_HYBRID_MODE_IN_BASE64 = 'SHlicmlkTW9kZQ=='; // 'HybridMode' in BASE64 format
 
 export async function getOpenpgp(): Promise<typeof import('openpgp')> {
   return import('openpgp');
@@ -81,7 +81,7 @@ export const hybridEncryptMessageWithPublicKey = async ({
     const messageHex = Buffer.from(message).toString('hex');
 
     plaintext = XORhex(messageHex, secretHex);
-    result = WORDS_HYBRID_MODE_IN_HEX.concat('$', kyberCiphertextStr, '$');
+    result = WORDS_HYBRID_MODE_IN_BASE64.concat('$', kyberCiphertextStr, '$');
   }
 
   const encryptedMessage = await encryptMessageWithPublicKey({ message: plaintext, publicKeyInBase64 });
@@ -112,7 +112,7 @@ export const hybridDecryptMessageWithPrivateKey = async ({
   let kyberSecret;
   const ciphertexts = encryptedMessageInBase64.split('$');
   const prefix = ciphertexts[0];
-  const isHybridMode = prefix === WORDS_HYBRID_MODE_IN_HEX;
+  const isHybridMode = prefix === WORDS_HYBRID_MODE_IN_BASE64;
 
   if (isHybridMode) {
     if (!privateKyberKeyInBase64) {

--- a/src/app/crypto/services/pgp.service.ts
+++ b/src/app/crypto/services/pgp.service.ts
@@ -108,11 +108,12 @@ export const hybridDecryptMessageWithPrivateKey = async ({
   privateKyberKeyInBase64?: string;
 }): Promise<string> => {
   let eccCiphertextStr = encryptedMessageInBase64;
-  let kyberSecret = new Uint8Array();
+  let kyberSecret;
   const ciphertexts = encryptedMessageInBase64.split('$');
   const prefix = ciphertexts[0];
+  const hybrid = prefix == '4879627269644d6f6465';
 
-  if (prefix == '4879627269644d6f6465') {
+  if (hybrid) {
     if (!privateKyberKeyInBase64) {
       return Promise.reject(new Error('Attempted to decrypt hybrid ciphertex without Kyber key'));
     }
@@ -131,7 +132,7 @@ export const hybridDecryptMessageWithPrivateKey = async ({
     privateKeyInBase64,
   });
   let result = decryptedMessage as string;
-  if (privateKyberKeyInBase64) {
+  if (hybrid) {
     const bits = result.length * 4;
     const secretHex = await extendSecret(kyberSecret, bits);
     const xored = XORhex(result, secretHex);

--- a/src/app/share/services/share.service.test.ts
+++ b/src/app/share/services/share.service.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../core/services/local-storage.service', () => ({
+  default: {
+    getUser: vi.fn(),
+  },
+}));
+
+import { generateNewKeys, encryptMessageWithPublicKey } from '../../crypto/services/pgp.service';
+import localStorageService from '../../core/services/local-storage.service';
+import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
+import { decryptMnemonic } from './share.service';
+
+describe('Encryption and Decryption', () => {
+  vi.mock('../../core/services/error.service', () => ({
+    default: {
+      castError: vi.fn(),
+      reportError: vi.fn(),
+    },
+  }));
+
+  vi.mock('../../notifications/services/notifications.service', () => ({
+    show: vi.fn(),
+  }));
+
+  it('should decrypt mnemonic encrypted without kyber', async () => {
+    const keys = await generateNewKeys();
+    const publicKeyInBase64 = keys.publicKeyArmored;
+    const message =
+      'truck arch rather sell tilt return warm nurse rack vacuum rubber tribe unfold scissors copper sock panel ozone harsh ahead danger soda legal state';
+
+    const encriptedMnemonic = await encryptMessageWithPublicKey({ message, publicKeyInBase64 });
+    const encryptedMnemonicInBase64 = btoa(encriptedMnemonic as string);
+
+    const mockUser: UserSettings = {
+      uuid: 'mock-uuid',
+      email: 'mock@test.com',
+      privateKey: publicKeyInBase64,
+      mnemonic: encryptedMnemonicInBase64,
+      userId: 'mock-user-id',
+      name: 'mock-name',
+      lastname: 'mock-lastname',
+      username: 'mock-username',
+      bridgeUser: 'mock-bridgeUser',
+      bucket: 'mock-bucket',
+      backupsBucket: null,
+      root_folder_id: 0,
+      rootFolderId: 'mock-rootFolderId',
+      rootFolderUuid: undefined,
+      sharedWorkspace: false,
+      credit: 0,
+      publicKey: keys.publicKyberKeyBase64,
+      revocationKey: keys.revocationCertificate,
+      keys: {
+        ecc: {
+          publicKey: publicKeyInBase64,
+          privateKeyEncrypted: keys.privateKeyArmored,
+        },
+        kyber: {
+          publicKey: keys.publicKyberKeyBase64,
+          privateKeyEncrypted: keys.privateKyberKeyBase64,
+        },
+      },
+      appSumoDetails: null,
+      registerCompleted: false,
+      hasReferralsProgram: false,
+      createdAt: new Date(),
+      avatar: null,
+      emailVerified: false,
+    };
+
+    vi.spyOn(localStorageService, 'getUser').mockImplementation(() => mockUser);
+    expect(localStorageService.getUser() as UserSettings).toEqual(mockUser);
+
+    //const ownerMnemonic = await decryptMnemonic(encryptedMnemonicInBase64);
+    //expect(localStorageService.getUser).toHaveBeenCalled();
+    //expect(ownerMnemonic).toEqual(message);
+  });
+});

--- a/src/app/share/services/share.service.test.ts
+++ b/src/app/share/services/share.service.test.ts
@@ -1,44 +1,76 @@
 /**
  * @jest-environment jsdom
  */
-import { describe, expect, it, vi } from 'vitest';
-
-vi.mock('../../core/services/local-storage.service', () => ({
-  default: {
-    getUser: vi.fn(),
-  },
-}));
-
-import { generateNewKeys, encryptMessageWithPublicKey } from '../../crypto/services/pgp.service';
+import { describe, expect, it, vi, Mock, beforeEach, beforeAll } from 'vitest';
 import localStorageService from '../../core/services/local-storage.service';
+import { Buffer } from 'buffer';
+import {
+  generateNewKeys,
+  encryptMessageWithPublicKey,
+  hybridEncryptMessageWithPublicKey,
+} from '../../crypto/services/pgp.service';
+
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import { decryptMnemonic } from './share.service';
 
 describe('Encryption and Decryption', () => {
-  vi.mock('../../core/services/error.service', () => ({
-    default: {
-      castError: vi.fn(),
-      reportError: vi.fn(),
+  beforeAll(() => {
+    vi.mock('app/drive/services/folder.service', () => ({
+      default: {
+        downloadSharedFolderAsZip: vi.fn(),
+      },
+    }));
+    vi.mock('../../core/factory/sdk', () => ({ SdkFactory: vi.fn() }));
+    vi.mock('../../core/services/error.service', () => ({
+      default: {
+        castError: vi.fn().mockImplementation((e) => ({ message: e.message || 'Default error message' })),
+        reportError: vi.fn(),
+      },
+    }));
+    vi.mock('../../core/services/local-storage.service', () => ({
+      default: {
+        getUser: vi.fn(),
+      },
+    }));
+    vi.mock('../../core/services/workspace.service', () => ({
+      default: {
+        getAllWorkspaceTeamSharedFolderFolders: vi.fn(),
+        getAllWorkspaceTeamSharedFolderFiles: vi.fn(),
+      },
+    }));
+    vi.mock('../../notifications/services/notifications.service', () => ({
+      default: {
+        show: vi.fn(),
+      },
+      ToastType: {
+        Error: 'ERROR',
+      },
+    }));
+    vi.mock('../../store/slices/storage/storage.thunks/downloadItemsThunk', () => ({
+      downloadItemsAsZipThunk: vi.fn(),
+      downloadItemsThunk: vi.fn(),
+    }));
+    vi.mock('./DomainManager', () => ({ domainManager: vi.fn() }));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function getMockUser(
+    keys: {
+      privateKeyArmored: string;
+      publicKeyArmored: string;
+      revocationCertificate: string;
+      publicKyberKeyBase64: string;
+      privateKyberKeyBase64: string;
     },
-  }));
-
-  vi.mock('../../notifications/services/notifications.service', () => ({
-    show: vi.fn(),
-  }));
-
-  it('should decrypt mnemonic encrypted without kyber', async () => {
-    const keys = await generateNewKeys();
-    const publicKeyInBase64 = keys.publicKeyArmored;
-    const message =
-      'truck arch rather sell tilt return warm nurse rack vacuum rubber tribe unfold scissors copper sock panel ozone harsh ahead danger soda legal state';
-
-    const encriptedMnemonic = await encryptMessageWithPublicKey({ message, publicKeyInBase64 });
-    const encryptedMnemonicInBase64 = btoa(encriptedMnemonic as string);
-
+    encryptedMnemonicInBase64: string,
+  ): Promise<UserSettings> {
     const mockUser: UserSettings = {
       uuid: 'mock-uuid',
       email: 'mock@test.com',
-      privateKey: publicKeyInBase64,
+      privateKey: Buffer.from(keys.privateKeyArmored).toString('base64'),
       mnemonic: encryptedMnemonicInBase64,
       userId: 'mock-user-id',
       name: 'mock-name',
@@ -52,12 +84,12 @@ describe('Encryption and Decryption', () => {
       rootFolderUuid: undefined,
       sharedWorkspace: false,
       credit: 0,
-      publicKey: keys.publicKyberKeyBase64,
+      publicKey: keys.publicKeyArmored,
       revocationKey: keys.revocationCertificate,
       keys: {
         ecc: {
-          publicKey: publicKeyInBase64,
-          privateKeyEncrypted: keys.privateKeyArmored,
+          publicKey: keys.publicKeyArmored,
+          privateKeyEncrypted: Buffer.from(keys.privateKeyArmored).toString('base64'),
         },
         kyber: {
           publicKey: keys.publicKyberKeyBase64,
@@ -71,12 +103,45 @@ describe('Encryption and Decryption', () => {
       avatar: null,
       emailVerified: false,
     };
+    return mockUser;
+  }
+  it('should decrypt mnemonic encrypted without kyber', async () => {
+    const mnemonic =
+      'truck arch rather sell tilt return warm nurse rack vacuum rubber tribe unfold scissors copper sock panel ozone harsh ahead danger soda legal state';
+    const keys = await generateNewKeys();
+    const encriptedMnemonic = await encryptMessageWithPublicKey({
+      message: mnemonic,
+      publicKeyInBase64: keys.publicKeyArmored,
+    });
+    const encryptedMnemonicInBase64 = btoa(encriptedMnemonic as string);
 
-    vi.spyOn(localStorageService, 'getUser').mockImplementation(() => mockUser);
+    const mockUser = await getMockUser(keys, encryptedMnemonicInBase64);
+
+    (localStorageService.getUser as Mock).mockReturnValue(mockUser);
     expect(localStorageService.getUser() as UserSettings).toEqual(mockUser);
 
-    //const ownerMnemonic = await decryptMnemonic(encryptedMnemonicInBase64);
-    //expect(localStorageService.getUser).toHaveBeenCalled();
-    //expect(ownerMnemonic).toEqual(message);
+    const ownerMnemonic = await decryptMnemonic(mockUser.mnemonic);
+    expect(localStorageService.getUser).toHaveBeenCalled();
+    expect(ownerMnemonic).toEqual(mnemonic);
+  });
+
+  it('should decrypt mnemonic encrypted with kyber', async () => {
+    const mnemonic =
+      'until bonus summer risk chunk oyster census ability frown win pull steel measure employ rigid improve riot remind system earn inch broken chalk clip';
+    const keys = await generateNewKeys();
+    const encriptedMnemonic = await hybridEncryptMessageWithPublicKey({
+      message: mnemonic,
+      publicKeyInBase64: keys.publicKeyArmored,
+      publicKyberKeyBase64: keys.publicKyberKeyBase64,
+    });
+
+    const mockUser = await getMockUser(keys, encriptedMnemonic);
+
+    (localStorageService.getUser as Mock).mockReturnValue(mockUser);
+    expect(localStorageService.getUser() as UserSettings).toEqual(mockUser);
+
+    const ownerMnemonic = await decryptMnemonic(mockUser.mnemonic);
+    expect(localStorageService.getUser).toHaveBeenCalled();
+    expect(ownerMnemonic).toEqual(mnemonic);
   });
 });

--- a/src/app/share/services/share.service.ts
+++ b/src/app/share/services/share.service.ts
@@ -601,14 +601,13 @@ export const decryptMnemonic = async (encryptionKey: string): Promise<string | u
     }
     return decryptedKey;
   } else {
-    throw new Error('AAAAAAA');
-    /*const error = errorService.castError('User Not Found');
+    const error = errorService.castError('User Not Found');
     errorService.reportError(error);
 
     notificationsService.show({
       text: t('error.decryptMnemonic', { message: error.message }),
       type: ToastType.Error,
-    });*/
+    });
   }
 };
 

--- a/src/app/share/services/share.service.ts
+++ b/src/app/share/services/share.service.ts
@@ -30,7 +30,7 @@ import errorService from '../../core/services/error.service';
 import httpService from '../../core/services/http.service';
 import localStorageService from '../../core/services/local-storage.service';
 import workspacesService from '../../core/services/workspace.service';
-import { decryptMessageWithPrivateKey } from '../../crypto/services/pgp.service';
+import { hybridDecryptMessageWithPrivateKey } from '../../crypto/services/pgp.service';
 import notificationsService, { ToastType } from '../../notifications/services/notifications.service';
 import {
   downloadItemsAsZipThunk,
@@ -591,22 +591,24 @@ export const decryptMnemonic = async (encryptionKey: string): Promise<string | u
   if (user) {
     let decryptedKey;
     try {
-      decryptedKey = await decryptMessageWithPrivateKey({
-        encryptedMessage: atob(encryptionKey),
-        privateKeyInBase64: user.privateKey,
+      decryptedKey = await hybridDecryptMessageWithPrivateKey({
+        encryptedMessageInBase64: encryptionKey,
+        privateKeyInBase64: user.keys.ecc.privateKeyEncrypted,
+        privateKyberKeyInBase64: user.keys.kyber.privateKeyEncrypted,
       });
     } catch (err) {
       decryptedKey = user.mnemonic;
     }
     return decryptedKey;
   } else {
-    const error = errorService.castError('User Not Found');
+    throw new Error('AAAAAAA');
+    /*const error = errorService.castError('User Not Found');
     errorService.reportError(error);
 
     notificationsService.show({
       text: t('error.decryptMnemonic', { message: error.message }),
       type: ToastType.Error,
-    });
+    });*/
   }
 };
 

--- a/test/unit/services/pgp.service.test.ts
+++ b/test/unit/services/pgp.service.test.ts
@@ -143,7 +143,7 @@ describe('Encryption and Decryption', () => {
     expect(decryptedMessage).toEqual(originalMessage);
   });
 
-  it('hybrid decryption should decrypt without kyber keys as before', async () => {
+  it('hybrid decryption should decrypt old ciphertexts without kyber keys as before', async () => {
     const keys = await generateNewKeys();
 
     const originalMessage =
@@ -157,6 +157,32 @@ describe('Encryption and Decryption', () => {
     const decryptedMessage = await hybridDecryptMessageWithPrivateKey({
       encryptedMessageInBase64,
       privateKeyInBase64: Buffer.from(keys.privateKeyArmored).toString('base64'),
+    });
+
+    const oldDecryptedMessage = await decryptMessageWithPrivateKey({
+      encryptedMessage: atob(encryptedMessageInBase64),
+      privateKeyInBase64: Buffer.from(keys.privateKeyArmored).toString('base64'),
+    });
+
+    expect(decryptedMessage).toEqual(oldDecryptedMessage);
+    expect(decryptedMessage).toEqual(originalMessage);
+  });
+
+  it('hybrid decryption should decrypt old ciphertexts with kyber keys as before', async () => {
+    const keys = await generateNewKeys();
+
+    const originalMessage =
+      'until bonus summer risk chunk oyster census ability frown win pull steel measure employ rigid improve riot remind system earn inch broken chalk clip';
+
+    const encryptedMessageInBase64 = await hybridEncryptMessageWithPublicKey({
+      message: originalMessage,
+      publicKeyInBase64: keys.publicKeyArmored,
+    });
+
+    const decryptedMessage = await hybridDecryptMessageWithPrivateKey({
+      encryptedMessageInBase64,
+      privateKeyInBase64: Buffer.from(keys.privateKeyArmored).toString('base64'),
+      privateKyberKeyInBase64: keys.privateKyberKeyBase64,
     });
 
     const oldDecryptedMessage = await decryptMessageWithPrivateKey({

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -14,7 +14,6 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      dedupe: ['vue'],
       // eslint-disable-next-line no-undef
       app: path.resolve(__dirname, './src/app'),
       crypto: 'crypto-browserify', // Resolve `crypto` to `crypto-browserify`

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -14,6 +14,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
+      dedupe: ['vue'],
       // eslint-disable-next-line no-undef
       app: path.resolve(__dirname, './src/app'),
       crypto: 'crypto-browserify', // Resolve `crypto` to `crypto-browserify`


### PR DESCRIPTION
## Description

Switch decryption to a hybrid version with Kyber and ensure that the old mnemonic can be decrypted

## Related Issues

Relates to [PB-2666](https://inxt.atlassian.net/browse/PB-2666)

## Related Pull Requests

- [Branch PB-2666-implement-pqc](https://github.com/internxt/drive-web/tree/feature/PB-2666-implement-pqc)

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.

## How Has This Been Tested?

Unit tests:
1. The new hybrid function can decrypt an old encrypted mnemonic
2. The new hybrid function can decrypt a new encrypted mnemonic

## Additional Notes

Vitest needs mocks for all "complex" imports in the file, even if they are not used by the tested function. Complex is anything that deals with files, sends signals or events, or runs init upon loading, as it can all interfere with the test. 

[PB-2666]: https://inxt.atlassian.net/browse/PB-2666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ