### PR TITLE
[_]: chore/exclude tsx and js files from sonar scan

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,5 +5,5 @@ sonar.sources=src
 sonar.tests=src,test/unit
 sonar.test.inclusions=src/**/*.test.ts,src/**/*.test.tsx,test/unit/**/*.test.ts
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.exclusions=**/*.json,**/assets/**,**/*.scss
-sonar.cpd.exclusions=**/*.json,**/assets/**,**/*.scss
+sonar.exclusions=**/*.json,**/assets/**,**/*.scss,src/**/*.tsx,src/**/*.js
+sonar.cpd.exclusions=**/*.json,**/assets/**,**/*.scss,src/**/*.tsx,src/**/*.js

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -36,8 +36,16 @@ export default defineConfig({
       provider: 'istanbul',
       reporter: ['text', 'lcov'],
       reportsDirectory: './coverage',
-      include: ['src/**/*.{js,ts,jsx,tsx}', 'test/unit/**/*.{js,ts,jsx,tsx}'],
-      exclude: ['src/app/drive/components/FileViewer/viewers/FileDocumentViewer/**'],
+      include: ['src/**/*.{ts}', 'test/unit/**/*.{ts}'],
+      exclude: [
+        'src/**/*.d.ts',
+        'src/**/*.tsx',
+        'src/**/*.js',
+        '**/node_modules/**',
+        '**/test/**',
+        '**/dist/**',
+        'src/app/drive/components/FileViewer/viewers/FileDocumentViewer/**',
+      ],
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
## Description
Exclude tsx and js files from Sonarcloud scan.


## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.

