### PR TITLE
[PB-3581]: feat/improve pagination and loading state for access logs

### DIFF
--- a/src/app/newSettings/Sections/Workspace/Logs/AccessLogsSection.tsx
+++ b/src/app/newSettings/Sections/Workspace/Logs/AccessLogsSection.tsx
@@ -239,7 +239,7 @@ export const AccessLogsSection = ({ onClosePreferences }: LogsViewProps): JSX.El
         />
 
         <ScrollableTable
-          scrollable={!isLoading && accessLogs.length > 0}
+          scrollable={accessLogs.length > 0}
           loadMoreItems={loadMoreItems}
           hasMoreItems={hasMoreItems}
           isLoading={isLoading}
@@ -251,8 +251,8 @@ export const AccessLogsSection = ({ onClosePreferences }: LogsViewProps): JSX.El
               {renderHeader()}
             </TableHeader>
             <TableBody className={'bg-surface dark:bg-gray-1'}>
+              {accessLogs.length > 0 && renderBody()}
               {isLoading && <LoadingRowSkeleton numberOfColumns={headerList.length ?? 4} />}
-              {!isLoading && accessLogs.length > 0 && renderBody()}
             </TableBody>
           </Table>
           {!isLoading && accessLogs.length === 0 && (

--- a/src/app/shared/tables/LoadingSkeleton.tsx
+++ b/src/app/shared/tables/LoadingSkeleton.tsx
@@ -1,7 +1,7 @@
 import { TableCell, TableRow } from '@internxt/ui';
 
 export const LoadingRowSkeleton = ({ numberOfColumns }: { numberOfColumns: number }) => {
-  const totalRowsArray = new Array(10).fill(null);
+  const totalRowsArray = new Array(5).fill(null);
   return (
     <>
       {totalRowsArray.map((_, rowIndex) => (

--- a/src/app/shared/tables/ScrollableTable.tsx
+++ b/src/app/shared/tables/ScrollableTable.tsx
@@ -12,6 +12,7 @@ interface ScrollableTableProps {
 export const ScrollableTable: React.FC<ScrollableTableProps> = ({
   scrollable = false,
   hasMoreItems = false,
+  isLoading,
   containerClassName = 'min-w-full relative border border-gray-10 h-full rounded-lg overflow-hidden',
   children,
   loadMoreItems,
@@ -19,7 +20,7 @@ export const ScrollableTable: React.FC<ScrollableTableProps> = ({
   const observerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (!scrollable || !hasMoreItems || !loadMoreItems) return;
+    if (!scrollable || isLoading || !hasMoreItems || !loadMoreItems) return;
 
     const observer = new IntersectionObserver(
       (entries) => {


### PR DESCRIPTION
## Description
- Show the skeleton below the access records fetched while loading more.
- Do not block scrolling while fetching more logs, so the user can scroll up if he wants to.
- The loadMore (paging) function has been blocked if items are already being fetched (`isLoading = true`).
- Reduced load skeleton from 10 rows to 5.

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [x] QA Passed

## How Has This Been Tested?
Go to Business Workspace (one account as owner and one as guest) > Make various moves like login, logout, file/folder sharing, etc inside the workspace > go to Settings > go to Logs section > scroll through to load items + apply filters to check that they works
