### PR TITLE
[PB-3581]: fix/settings dialog larger than the viewport

### DIFF
--- a/src/app/newSettings/PreferencesDialog.tsx
+++ b/src/app/newSettings/PreferencesDialog.tsx
@@ -70,7 +70,7 @@ const PreferencesDialog = (props: PreferencesDialogProps) => {
   return (
     <Modal
       maxWidth="max-w-4xl"
-      className="m-0 flex h-640 overflow-hidden shadow-sm"
+      className="m-0 flex max-h-640 h-screen overflow-hidden shadow-sm"
       isOpen={isPreferencesDialogOpen}
       onClose={() => onClosePreferences()}
     >

--- a/src/app/shared/tables/ScrollableTable.tsx
+++ b/src/app/shared/tables/ScrollableTable.tsx
@@ -37,7 +37,7 @@ export const ScrollableTable: React.FC<ScrollableTableProps> = ({
   }, [scrollable, hasMoreItems, loadMoreItems]);
 
   return (
-    <div className={`${containerClassName} ${scrollable ? 'max-h-[80vh] overflow-y-auto' : ''}`}>
+    <div className={`${containerClassName} ${scrollable ? 'max-h-[70vh] overflow-y-auto' : ''}`}>
       {children}
       {/* Invisible div to observe and trigger load more */}
       {scrollable && hasMoreItems && <div ref={observerRef} className="h-2" />}


### PR DESCRIPTION
## Description
Fixed bug where in some screens, the access logs table was bigger than the dialog itself, so pagination did not work.

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [x] QA Passed
