### PR TITLE
[PB-3627] Send re-encrypted kyber key on pwd change

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@internxt/inxt-js": "=1.2.21",
     "@internxt/lib": "^1.2.0",
     "@internxt/ui": "0.0.10",
-    "@internxt/sdk": "=1.9.1",
+    "@internxt/sdk": "=1.9.3",
     "@phosphor-icons/react": "^2.1.7",
     "@popperjs/core": "^2.11.6",
     "@reduxjs/toolkit": "^1.6.0",

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -284,8 +284,11 @@ export const changePassword = async (newPassword: string, currentPassword: strin
 
   // Encrypt the mnemonic
   const encryptedMnemonic = encryptTextWithKey(user.mnemonic, newPassword);
-  const privateKey = Buffer.from(user.privateKey, 'base64').toString();
+  const privateKey = Buffer.from(user.keys.ecc.privateKey, 'base64').toString();
   const privateKeyEncrypted = aes.encrypt(privateKey, newPassword, getAesInitFromEnv());
+
+  const privateKyberKey = Buffer.from(user.keys.kyber.privateKey, 'base64').toString();
+  const privateKyberKeyEncrypted = aes.encrypt(privateKyberKey, newPassword, getAesInitFromEnv());
 
   const usersClient = SdkFactory.getNewApiInstance().createNewUsersClient();
 
@@ -296,6 +299,10 @@ export const changePassword = async (newPassword: string, currentPassword: strin
       newEncryptedSalt: encryptedNewSalt,
       encryptedMnemonic: encryptedMnemonic,
       encryptedPrivateKey: privateKeyEncrypted,
+      keys:{
+        encryptedPrivateKey: privateKeyEncrypted,
+        encryptedPrivateKyberKey: privateKyberKeyEncrypted,
+      },
       encryptVersion: StorageTypes.EncryptionVersion.Aes03,
     })
     .then((res) => {

--- a/src/app/share/services/share.service.test.ts
+++ b/src/app/share/services/share.service.test.ts
@@ -89,11 +89,11 @@ describe('Encryption and Decryption', () => {
       keys: {
         ecc: {
           publicKey: keys.publicKeyArmored,
-          privateKeyEncrypted: Buffer.from(keys.privateKeyArmored).toString('base64'),
+          privateKey: Buffer.from(keys.privateKeyArmored).toString('base64'),
         },
         kyber: {
           publicKey: keys.publicKyberKeyBase64,
-          privateKeyEncrypted: keys.privateKyberKeyBase64,
+          privateKey: keys.privateKyberKeyBase64,
         },
       },
       appSumoDetails: null,

--- a/src/app/share/services/share.service.ts
+++ b/src/app/share/services/share.service.ts
@@ -593,8 +593,8 @@ export const decryptMnemonic = async (encryptionKey: string): Promise<string | u
     try {
       decryptedKey = await hybridDecryptMessageWithPrivateKey({
         encryptedMessageInBase64: encryptionKey,
-        privateKeyInBase64: user.keys.ecc.privateKeyEncrypted,
-        privateKyberKeyInBase64: user.keys.kyber.privateKeyEncrypted,
+        privateKeyInBase64: user.keys.ecc.privateKey,
+        privateKyberKeyInBase64: user.keys.kyber.privateKey,
       });
     } catch (err) {
       decryptedKey = user.mnemonic;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2014,10 +2014,10 @@
   resolved "https://npm.pkg.github.com/download/@internxt/prettier-config/1.0.2/5bd220b8de76734448db5475b3e0c01f9d22c19b#5bd220b8de76734448db5475b3e0c01f9d22c19b"
   integrity sha512-t4HiqvCbC7XgQepwWlIaFJe3iwW7HCf6xOSU9nKTV0tiGqOPz7xMtIgLEloQrDA34Cx4PkOYBXrvFPV6RxSFAA==
 
-"@internxt/sdk@=1.9.1":
-  version "1.9.1"
-  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.9.1/f78fe79c261782bb2ff181977558ba25fd546aca#f78fe79c261782bb2ff181977558ba25fd546aca"
-  integrity sha512-4FgFjlLqcPy5btZ3BNsLjFSkot0giTA6UgbFzIS7mtvpNAD12ce3l7Ok7uhAvcs9ujy9TMr0cW/aj5HyrY70rg==
+"@internxt/sdk@=1.9.3":
+  version "1.9.3"
+  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.9.3/d8076550a1a61d1db2a67d5d378dc0785edd8e98#d8076550a1a61d1db2a67d5d378dc0785edd8e98"
+  integrity sha512-mHV/M9Hf8NLtRoYKE9LtgGAGdIkB38rWkEnXRgwrbFF7U9F49zIBX6JwFm5bYz3XXVzZaPsUNcR30AifLxGrow==
   dependencies:
     axios "^0.24.0"
     query-string "^7.1.0"


### PR DESCRIPTION
## Description

Re-encrypt and send Kyber key on password update, upgrade to SDK 1.9.3

## Related Issues

Relates to [PB-3627](https://inxt.atlassian.net/browse/PB-3627)

## Related Pull Requests

- [Branch PB-2666-implement-pqc](https://github.com/internxt/drive-web/tree/feature/PB-2666-implement-pqc)

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## How Has This Been Tested?



## Additional Notes

Backend changes are pending


[PB-3627]: https://inxt.atlassian.net/browse/PB-3627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ