### PR TITLE
[PB-3646] Add random uuid to the hash

### DIFF
--- a/src/app/network/NetworkFacade.ts
+++ b/src/app/network/NetworkFacade.ts
@@ -86,9 +86,9 @@ export class NetworkFacade {
       async (algorithm, key, iv) => {
         const cipher = createCipheriv('aes-256-ctr', key as Buffer, iv as Buffer);
         const [encryptedFile, hash] = await getEncryptedFile(file, cipher);
-
+        const uuid = randomBytes(16).toString('hex');
         fileToUpload = encryptedFile;
-        fileHash = hash;
+        fileHash = uuid.concat('$', hash);
       },
       async (url: string) => {
         const useProxy = process.env.REACT_APP_DONT_USE_PROXY !== 'true' && !new URL(url).hostname.includes('internxt');
@@ -212,9 +212,6 @@ export class NetworkFacade {
               }
             }
           });
-
-        // TODO: Remove
-        blob = new Blob([]);
       });
 
       while (uploadQueue.running() > 0 || uploadQueue.length() > 0) {

--- a/src/app/network/crypto.ts
+++ b/src/app/network/crypto.ts
@@ -135,7 +135,7 @@ export async function getEncryptedFile(
   const readable = encryptReadable(plainFile.stream(), cipher).getReader();
   const hasher = await getSha256Hasher();
   hasher.init();
-  const blobParts: ArrayBuffer[] = [];
+  const blobParts: Uint8Array[] = [];
 
   let done = false;
 


### PR DESCRIPTION
## Description

Adds random 16-byte uuid to the hash, to avoid hash repeats for 1-byte files

## Related Issues

Fixes [PB-3646](https://inxt.atlassian.net/browse/PB-3646)

## Related Pull Requests


## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## How Has This Been Tested?

Tested locally - successfully uploaded 1-byte file from [PB-3580](https://inxt.atlassian.net/browse/PB-3580)

## Additional Notes

File hash now is  `fileHash = uuid$hash`. If the original hash is needed somewhere else, it needs to be extracted from the concatenated string now


[PB-3646]: https://inxt.atlassian.net/browse/PB-3646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PB-3580]: https://inxt.atlassian.net/browse/PB-3580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ