### PR TITLE
[PB-3627]: put checks to avoid errors if user.keys does not exist

### DIFF
--- a/src/app/auth/components/ChangePassword/ChangePassword.tsx
+++ b/src/app/auth/components/ChangePassword/ChangePassword.tsx
@@ -124,7 +124,7 @@ export default function ChangePassword(props: Readonly<ChangePasswordProps>): JS
     }
 
     try {
-      await authService.updateCredentialsWithToken(token, password, mnemonic, '');
+      await authService.updateCredentialsWithToken(token, password, mnemonic);
       localStorageService.clear();
       setIsEmailSent(true);
     } catch (error) {

--- a/src/app/auth/components/SignUp/WorkspaceGuestSignUp.tsx
+++ b/src/app/auth/components/SignUp/WorkspaceGuestSignUp.tsx
@@ -132,23 +132,27 @@ function WorkspaceGuestSingUpView(): JSX.Element {
       localStorageService.set('xNewToken', xNewToken);
 
       const decryptedPrivateKey = decryptPrivateKey(xUser.privateKey, password);
-      const decryptedPrivateKyberKey = decryptPrivateKey(xUser.keys.kyber.privateKey, password);
-
       const privateKey = xUser.privateKey ? Buffer.from(decryptedPrivateKey).toString('base64') : undefined;
-      const privateKyberKey = xUser.keys.kyber.privateKey
-        ? Buffer.from(decryptedPrivateKyberKey).toString('base64')
-        : '';
+
+      let privateKyberKey = '';
+      if (xUser.keys.kyber.privateKey) {
+        const decryptedPrivateKyberKey = decryptPrivateKey(xUser.keys.kyber.privateKey, password);
+        privateKyberKey = Buffer.from(decryptedPrivateKyberKey).toString('base64');
+      }
+
+      const publicKey = xUser.keys.ecc.publicKey ?? xUser.publicKey;
+      const publicKyberKey = xUser.keys.kyber.publicKey ?? '';
 
       const user = {
         ...xUser,
         privateKey,
         keys: {
           ecc: {
-            publicKey: xUser.keys.ecc.publicKey,
+            publicKey: publicKey,
             privateKey: privateKey,
           },
           kyber: {
-            publicKey: xUser.keys.kyber.publicKey,
+            publicKey: publicKyberKey,
             privateKey: privateKyberKey,
           },
         },

--- a/src/app/auth/components/SignUp/WorkspaceGuestSignUp.tsx
+++ b/src/app/auth/components/SignUp/WorkspaceGuestSignUp.tsx
@@ -6,7 +6,7 @@ import errorService from 'app/core/services/error.service';
 import localStorageService from 'app/core/services/local-storage.service';
 import navigationService from 'app/core/services/navigation.service';
 import { AppView, IFormValues } from 'app/core/types';
-import { decryptPrivateKey } from 'app/crypto/services/keys.service';
+import { parseAndDecryptUserKeys } from 'app/crypto/services/keys.service';
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
 import ExpiredLink from 'app/shared/views/ExpiredLink/ExpiredLinkView';
 import { RootState } from 'app/store';
@@ -131,17 +131,7 @@ function WorkspaceGuestSingUpView(): JSX.Element {
       const xNewToken = await getNewToken();
       localStorageService.set('xNewToken', xNewToken);
 
-      const decryptedPrivateKey = decryptPrivateKey(xUser.privateKey, password);
-      const privateKey = xUser.privateKey ? Buffer.from(decryptedPrivateKey).toString('base64') : undefined;
-
-      let privateKyberKey = '';
-      if (xUser.keys?.kyber?.privateKey) {
-        const decryptedPrivateKyberKey = decryptPrivateKey(xUser.keys.kyber.privateKey, password);
-        privateKyberKey = Buffer.from(decryptedPrivateKyberKey).toString('base64');
-      }
-
-      const publicKey = xUser.keys?.ecc?.publicKey ?? xUser.publicKey;
-      const publicKyberKey = xUser.keys?.kyber?.publicKey ?? '';
+      const { publicKey, privateKey, publicKyberKey, privateKyberKey } = parseAndDecryptUserKeys(xUser, password);
 
       const user = {
         ...xUser,

--- a/src/app/auth/components/SignUp/WorkspaceGuestSignUp.tsx
+++ b/src/app/auth/components/SignUp/WorkspaceGuestSignUp.tsx
@@ -135,13 +135,13 @@ function WorkspaceGuestSingUpView(): JSX.Element {
       const privateKey = xUser.privateKey ? Buffer.from(decryptedPrivateKey).toString('base64') : undefined;
 
       let privateKyberKey = '';
-      if (xUser.keys.kyber.privateKey) {
+      if (xUser.keys?.kyber?.privateKey) {
         const decryptedPrivateKyberKey = decryptPrivateKey(xUser.keys.kyber.privateKey, password);
         privateKyberKey = Buffer.from(decryptedPrivateKyberKey).toString('base64');
       }
 
-      const publicKey = xUser.keys.ecc.publicKey ?? xUser.publicKey;
-      const publicKyberKey = xUser.keys.kyber.publicKey ?? '';
+      const publicKey = xUser.keys?.ecc?.publicKey ?? xUser.publicKey;
+      const publicKyberKey = xUser.keys?.kyber?.publicKey ?? '';
 
       const user = {
         ...xUser,

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -479,12 +479,12 @@ export const signUp = async (params: SignUpParams) => {
     ? Buffer.from(decryptPrivateKey(xUser.privateKey, password)).toString('base64')
     : undefined;
 
-  const privateKyberKey = xUser.keys.kyber.privateKey
+  const privateKyberKey = xUser.keys?.kyber?.privateKey
     ? Buffer.from(decryptPrivateKey(xUser.keys.kyber.privateKey, password)).toString('base64')
     : '';
 
-  const publicKey = xUser.keys.ecc.publicKey ?? xUser.publicKey;
-  const publicKyberKey = xUser.keys.kyber.publicKey ?? '';
+  const publicKey = xUser.keys?.ecc?.publicKey ?? xUser.publicKey;
+  const publicKyberKey = xUser.keys?.kyber?.publicKey ?? '';
 
   const user = {
     ...xUser,

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -483,16 +483,19 @@ export const signUp = async (params: SignUpParams) => {
     ? Buffer.from(decryptPrivateKey(xUser.keys.kyber.privateKey, password)).toString('base64')
     : '';
 
+  const publicKey = xUser.keys.ecc.publicKey ?? xUser.publicKey;
+  const publicKyberKey = xUser.keys.kyber.publicKey ?? '';
+
   const user = {
     ...xUser,
     privateKey,
     keys: {
       ecc: {
-        publicKey: xUser.keys.ecc.publicKey,
+        publicKey: publicKey,
         privateKey: privateKey,
       },
       kyber: {
-        publicKey: xUser.keys.kyber.publicKey,
+        publicKey: publicKyberKey,
         privateKey: privateKyberKey,
       },
     },

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -154,8 +154,8 @@ export const doLogin = async (
       const { user, token, newToken } = data;
 
       const { privateKey, publicKey, keys } = user;
-      const publicKyberKey = keys.kyber.publicKey;
-      const privateKyberKey = keys.kyber.privateKey;
+      const publicKyberKey = keys?.kyber?.publicKey ?? '';
+      const privateKyberKey = keys?.kyber?.privateKey ?? '';
 
       Sentry.setUser({
         id: user.uuid,

--- a/src/app/share/services/share.service.test.ts
+++ b/src/app/share/services/share.service.test.ts
@@ -144,4 +144,51 @@ describe('Encryption and Decryption', () => {
     expect(localStorageService.getUser).toHaveBeenCalled();
     expect(ownerMnemonic).toEqual(mnemonic);
   });
+
+  it('should decrypt mnemonic encrypted without key field', async () => {
+    const mnemonic =
+      'truck arch rather sell tilt return warm nurse rack vacuum rubber tribe unfold scissors copper sock panel ozone harsh ahead danger soda legal state';
+    const keys = await generateNewKeys();
+    const encriptedMnemonic = await encryptMessageWithPublicKey({
+      message: mnemonic,
+      publicKeyInBase64: keys.publicKeyArmored,
+    });
+    const encryptedMnemonicInBase64 = btoa(encriptedMnemonic as string);
+
+    const mockOldUser: Partial<UserSettings> = {
+      uuid: 'mock-uuid',
+      email: 'mock@test.com',
+      privateKey: Buffer.from(keys.privateKeyArmored).toString('base64'),
+      mnemonic: encryptedMnemonicInBase64,
+      userId: 'mock-user-id',
+      name: 'mock-name',
+      lastname: 'mock-lastname',
+      username: 'mock-username',
+      bridgeUser: 'mock-bridgeUser',
+      bucket: 'mock-bucket',
+      backupsBucket: null,
+      root_folder_id: 0,
+      rootFolderId: 'mock-rootFolderId',
+      rootFolderUuid: undefined,
+      sharedWorkspace: false,
+      credit: 0,
+      publicKey: keys.publicKeyArmored,
+      revocationKey: keys.revocationCertificate,
+      appSumoDetails: null,
+      registerCompleted: false,
+      hasReferralsProgram: false,
+      createdAt: new Date(),
+      avatar: null,
+      emailVerified: false,
+    };
+
+    const mockUser = mockOldUser as UserSettings;
+
+    (localStorageService.getUser as Mock).mockReturnValue(mockUser);
+    expect(localStorageService.getUser() as UserSettings).toEqual(mockUser);
+
+    const ownerMnemonic = await decryptMnemonic(mockUser.mnemonic);
+    expect(localStorageService.getUser).toHaveBeenCalled();
+    expect(ownerMnemonic).toEqual(mnemonic);
+  });
 });

--- a/src/app/share/services/share.service.ts
+++ b/src/app/share/services/share.service.ts
@@ -590,11 +590,13 @@ export const decryptMnemonic = async (encryptionKey: string): Promise<string | u
   const user = localStorageService.getUser();
   if (user) {
     let decryptedKey;
+    const privateKey = user.keys.ecc.privateKey ?? user.privateKey;
+    const privateKyberKey = user.keys.kyber.privateKey ?? '';
     try {
       decryptedKey = await hybridDecryptMessageWithPrivateKey({
         encryptedMessageInBase64: encryptionKey,
-        privateKeyInBase64: user.keys.ecc.privateKey,
-        privateKyberKeyInBase64: user.keys.kyber.privateKey,
+        privateKeyInBase64: privateKey,
+        privateKyberKeyInBase64: privateKyberKey,
       });
     } catch (err) {
       decryptedKey = user.mnemonic;

--- a/src/app/share/services/share.service.ts
+++ b/src/app/share/services/share.service.ts
@@ -590,8 +590,8 @@ export const decryptMnemonic = async (encryptionKey: string): Promise<string | u
   const user = localStorageService.getUser();
   if (user) {
     let decryptedKey;
-    const privateKey = user.keys.ecc.privateKey ?? user.privateKey;
-    const privateKyberKey = user.keys.kyber.privateKey ?? '';
+    const privateKey = user.keys?.ecc?.privateKey ?? user.privateKey;
+    const privateKyberKey = user.keys?.kyber?.privateKey ?? '';
     try {
       decryptedKey = await hybridDecryptMessageWithPrivateKey({
         encryptedMessageInBase64: encryptionKey,

--- a/src/app/share/views/SharedGuestSignUp/ShareGuestSingUpView.tsx
+++ b/src/app/share/views/SharedGuestSignUp/ShareGuestSingUpView.tsx
@@ -11,7 +11,7 @@ import errorService from 'app/core/services/error.service';
 import localStorageService from 'app/core/services/local-storage.service';
 import navigationService from 'app/core/services/navigation.service';
 import { AppView, IFormValues } from 'app/core/types';
-import { decryptPrivateKey } from 'app/crypto/services/keys.service';
+import { parseAndDecryptUserKeys } from 'app/crypto/services/keys.service';
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
 import shareService from 'app/share/services/share.service';
 import { Button } from '@internxt/ui';
@@ -169,17 +169,7 @@ function ShareGuestSingUpView(): JSX.Element {
       const xNewToken = await getNewToken();
       localStorageService.set('xNewToken', xNewToken);
 
-      const decryptedPrivateKey = decryptPrivateKey(parsedUser.privateKey, password);
-      const privateKey = parsedUser.privateKey ? Buffer.from(decryptedPrivateKey).toString('base64') : undefined;
-
-      let privateKyberKey = '';
-      if (parsedUser.keys?.kyber?.privateKey) {
-        const decryptedPrivateKyberKey = decryptPrivateKey(parsedUser.keys.kyber.privateKey, password);
-        privateKyberKey = Buffer.from(decryptedPrivateKyberKey).toString('base64');
-      }
-
-      const publicKey = parsedUser.keys?.ecc?.publicKey ?? parsedUser.publicKey;
-      const publicKyberKey = parsedUser.keys?.kyber?.publicKey ?? '';
+      const { publicKey, privateKey, publicKyberKey, privateKyberKey } = parseAndDecryptUserKeys(xUser, password);
 
       const user = {
         ...parsedUser,

--- a/src/app/share/views/SharedGuestSignUp/ShareGuestSingUpView.tsx
+++ b/src/app/share/views/SharedGuestSignUp/ShareGuestSingUpView.tsx
@@ -173,12 +173,13 @@ function ShareGuestSingUpView(): JSX.Element {
       const privateKey = parsedUser.privateKey ? Buffer.from(decryptedPrivateKey).toString('base64') : undefined;
 
       let privateKyberKey = '';
-      if (parsedUser.keys.kyber.privateKey) {
+      if (parsedUser.keys?.kyber?.privateKey) {
         const decryptedPrivateKyberKey = decryptPrivateKey(parsedUser.keys.kyber.privateKey, password);
         privateKyberKey = Buffer.from(decryptedPrivateKyberKey).toString('base64');
       }
 
-      const publicKey = parsedUser.keys.ecc.publicKey ?? parsedUser.publicKey;
+      const publicKey = parsedUser.keys?.ecc?.publicKey ?? parsedUser.publicKey;
+      const publicKyberKey = parsedUser.keys?.kyber?.publicKey ?? '';
 
       const user = {
         ...parsedUser,
@@ -189,7 +190,7 @@ function ShareGuestSingUpView(): JSX.Element {
             privateKey: privateKey,
           },
           kyber: {
-            publicKey: parsedUser.keys.kyber.publicKey,
+            publicKey: publicKyberKey,
             privateKey: privateKyberKey,
           },
         },

--- a/src/app/share/views/SharedGuestSignUp/ShareGuestSingUpView.tsx
+++ b/src/app/share/views/SharedGuestSignUp/ShareGuestSingUpView.tsx
@@ -170,19 +170,22 @@ function ShareGuestSingUpView(): JSX.Element {
       localStorageService.set('xNewToken', xNewToken);
 
       const decryptedPrivateKey = decryptPrivateKey(parsedUser.privateKey, password);
-      const decryptedPrivateKyberKey = decryptPrivateKey(parsedUser.keys.kyber.privateKey, password);
-
       const privateKey = parsedUser.privateKey ? Buffer.from(decryptedPrivateKey).toString('base64') : undefined;
-      const privateKyberKey = parsedUser.keys.kyber.privateKey
-        ? Buffer.from(decryptedPrivateKyberKey).toString('base64')
-        : '';
+
+      let privateKyberKey = '';
+      if (parsedUser.keys.kyber.privateKey) {
+        const decryptedPrivateKyberKey = decryptPrivateKey(parsedUser.keys.kyber.privateKey, password);
+        privateKyberKey = Buffer.from(decryptedPrivateKyberKey).toString('base64');
+      }
+
+      const publicKey = parsedUser.keys.ecc.publicKey ?? parsedUser.publicKey;
 
       const user = {
         ...parsedUser,
         privateKey,
         keys: {
           ecc: {
-            publicKey: parsedUser.keys.ecc.publicKey,
+            publicKey: publicKey,
             privateKey: privateKey,
           },
           kyber: {


### PR DESCRIPTION
## Description

This is just in case users who are already logged in and have a user without field `keys` in their local storage. 

## Related Issues



## Related Pull Requests


## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## How Has This Been Tested?

unit tests

## Additional Notes

Maybe it's not necessary for parsedUser
