### PR TITLE
[PB-3774]: feat/auth for vpn extension

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ import { initializeUserThunk } from './app/store/slices/user';
 import { workspaceThunks } from './app/store/slices/workspaces/workspacesStore';
 import { manager } from './app/utils/dnd-utils';
 import useBeforeUnload from './hooks/useBeforeUnload';
-import useVpnAuthIfUserIsLoggedIn from './hooks/useVpnAuth';
+import useVpnAuth from './hooks/useVpnAuth';
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
 
@@ -73,7 +73,9 @@ const App = (props: AppProps): JSX.Element => {
   const { isDialogOpen } = useActionDialog();
   const isOpen = isDialogOpen(ActionDialog.ModifyStorage);
   const token = localStorageService.get('xToken');
+  const newToken = localStorageService.get('xNewToken');
   const params = new URLSearchParams(window.location.search);
+  const isVpnAuth = params.get('vpnAuth') === 'true';
   const skipSignupIfLoggedIn = params.get('skipSignupIfLoggedIn') === 'true';
   const queryParameters = navigationService.history.location.search;
   const havePreferencesParamsChanged = usePreferencesParamsChange();
@@ -85,7 +87,7 @@ const App = (props: AppProps): JSX.Element => {
   const selectedWorkspace = useAppSelector(workspacesSelectors.getSelectedWorkspace);
   const isWorkspaceIdParam = params.get('workspaceid');
 
-  useVpnAuthIfUserIsLoggedIn();
+  useVpnAuth(isVpnAuth, newToken);
 
   useBeforeUnload();
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,10 +71,8 @@ const App = (props: AppProps): JSX.Element => {
   const { isDialogOpen } = useActionDialog();
   const isOpen = isDialogOpen(ActionDialog.ModifyStorage);
   const token = localStorageService.get('xToken');
-  const newToken = localStorageService.get('xNewToken');
   const params = new URLSearchParams(window.location.search);
   const skipSignupIfLoggedIn = params.get('skipSignupIfLoggedIn') === 'true';
-  const isVpnAuth = params.get('vpnAuth') === 'true';
   const queryParameters = navigationService.history.location.search;
   const havePreferencesParamsChanged = usePreferencesParamsChange();
   const routes = getRoutes();
@@ -90,26 +88,6 @@ const App = (props: AppProps): JSX.Element => {
   useEffect(() => {
     initializeInitialAppState();
     i18next.changeLanguage();
-
-    /**
-     * This function handles the VPN extension authentication if the user is already logged in
-     * @param event - The event object we receive from the message event listener
-     */
-    const handleVpnReady = (event: MessageEvent) => {
-      if (event.data && event.data.source === 'drive-extension' && event.data.payload === 'ready') {
-        if (isVpnAuth && newToken) {
-          authService.vpnExtensionAuth(newToken);
-        }
-
-        window.removeEventListener('message', handleVpnReady);
-      }
-    };
-
-    window.addEventListener('message', handleVpnReady);
-
-    return () => {
-      window.removeEventListener('message', handleVpnReady);
-    };
   }, []);
 
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,23 +91,24 @@ const App = (props: AppProps): JSX.Element => {
     initializeInitialAppState();
     i18next.changeLanguage();
 
-    const handleReady = (event: MessageEvent) => {
+    /**
+     * This function handles the VPN extension authentication if the user is already logged in
+     * @param event - The event object we receive from the message event listener
+     */
+    const handleVpnReady = (event: MessageEvent) => {
       if (event.data && event.data.source === 'drive-extension' && event.data.payload === 'ready') {
         if (isVpnAuth && newToken) {
-          console.log('Sending token to extension');
           authService.vpnExtensionAuth(newToken);
         }
 
-        window.removeEventListener('message', handleReady);
+        window.removeEventListener('message', handleVpnReady);
       }
     };
 
-    if (isVpnAuth && newToken) {
-      window.addEventListener('message', handleReady);
-    }
+    window.addEventListener('message', handleVpnReady);
 
     return () => {
-      window.removeEventListener('message', handleReady);
+      window.removeEventListener('message', handleVpnReady);
     };
   }, []);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { DndProvider } from 'react-dnd';
 import { Toaster } from 'react-hot-toast';
 import { connect } from 'react-redux';
@@ -71,8 +71,10 @@ const App = (props: AppProps): JSX.Element => {
   const { isDialogOpen } = useActionDialog();
   const isOpen = isDialogOpen(ActionDialog.ModifyStorage);
   const token = localStorageService.get('xToken');
+  const newToken = localStorageService.get('xNewToken');
   const params = new URLSearchParams(window.location.search);
   const skipSignupIfLoggedIn = params.get('skipSignupIfLoggedIn') === 'true';
+  const isVpnAuth = params.get('vpnAuth') === 'true';
   const queryParameters = navigationService.history.location.search;
   const havePreferencesParamsChanged = usePreferencesParamsChange();
   const routes = getRoutes();
@@ -82,6 +84,34 @@ const App = (props: AppProps): JSX.Element => {
   });
   const selectedWorkspace = useAppSelector(workspacesSelectors.getSelectedWorkspace);
   const isWorkspaceIdParam = params.get('workspaceid');
+  const [extReady, setExtReady] = useState<boolean>(false);
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data?.event === 'wxt:content-script-started') {
+        console.log('THE EXTENSION IS AVAILABLE');
+        setExtReady(true);
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
+  useEffect(() => {
+    if (extReady) {
+      console.log('¡THE EXTENSION IS AVAILABLE! STORING THE USER TOKEN');
+      const handleVpnReady = (event: MessageEvent) => {
+        if (event.data && event.data.source === 'drive-extension' && event.data.payload === 'ready') {
+          if (isVpnAuth && newToken) {
+            authService.vpnExtensionAuth(newToken);
+          }
+        }
+      };
+
+      window.addEventListener('message', handleVpnReady);
+    }
+  }, [extReady]);
 
   useBeforeUnload();
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,7 +95,7 @@ const App = (props: AppProps): JSX.Element => {
       if (event.data && event.data.source === 'drive-extension' && event.data.payload === 'ready') {
         if (isVpnAuth && newToken) {
           console.log('Sending token to extension');
-          window.postMessage({ source: 'drive-web', payload: newToken }, '*');
+          authService.vpnExtensionAuth(newToken);
         }
 
         window.removeEventListener('message', handleReady);

--- a/src/app/auth/components/LogIn/LogIn.tsx
+++ b/src/app/auth/components/LogIn/LogIn.tsx
@@ -74,10 +74,6 @@ export default function LogIn(): JSX.Element {
     }
   }, []);
 
-  function sendMessageToExtension({ newToken }: { newToken: string }) {
-    window.postMessage({ source: 'drive-web', payload: newToken }, '*');
-  }
-
   useEffect(() => {
     if (user && mnemonic) {
       dispatch(userActions.setUser(user));
@@ -156,7 +152,7 @@ export default function LogIn(): JSX.Element {
         const isVPNAuth = urlParams.get('vpnAuth');
         const newToken = localStorageService.get('xNewToken');
         if (isVPNAuth && newToken) {
-          sendMessageToExtension({ newToken });
+          authService.vpnExtensionAuth(newToken);
         }
 
         redirectWithCredentials(user, mnemonic, { universalLinkMode: isUniversalLinkMode, isSharingInvitation });

--- a/src/app/auth/components/LogIn/LogIn.tsx
+++ b/src/app/auth/components/LogIn/LogIn.tsx
@@ -28,8 +28,6 @@ import PasswordInput from '../PasswordInput/PasswordInput';
 import TextInput from '../TextInput/TextInput';
 import { AuthMethodTypes } from 'app/payment/types';
 
-const UNAUTHORIZED_STATUS_CODE = 401;
-
 const showNotification = ({ text, isError }: { text: string; isError: boolean }) => {
   notificationsService.show({
     text,

--- a/src/app/auth/components/LogIn/LogIn.tsx
+++ b/src/app/auth/components/LogIn/LogIn.tsx
@@ -77,36 +77,22 @@ export default function LogIn(): JSX.Element {
   }, []);
 
   useEffect(() => {
-    if (!newToken) return;
-
-    window.postMessage(
-      {
-        source: 'drive-web',
-        payload: newToken,
-      },
-      'https://staging.drive.internxt.com',
-    );
-
-    console.log('Mensaje enviado al content script con newToken:', newToken);
-  }, [newToken]);
-
-  useEffect(() => {
     if (user && mnemonic) {
       dispatch(userActions.setUser(user));
 
-      // /**
-      //  * This function handles the VPN extension authentication if the user is already logged in
-      //  * @param event - The event object we receive from the message event listener
-      //  */
-      // const handleVpnReady = (event: MessageEvent) => {
-      //   if (event.data && event.data.source === 'drive-extension' && event.data.payload === 'ready') {
-      //     if (isVpnAuth && newToken) {
-      //       authService.vpnExtensionAuth(newToken);
-      //     }
-      //   }
-      // };
+      /**
+       * This function handles the VPN extension authentication if the user is already logged in
+       * @param event - The event object we receive from the message event listener
+       */
+      const handleVpnReady = (event: MessageEvent) => {
+        if (event.data && event.data.source === 'drive-extension' && event.data.payload === 'ready') {
+          if (isVpnAuth && newToken) {
+            authService.vpnExtensionAuth(newToken);
+          }
+        }
+      };
 
-      // window.addEventListener('message', handleVpnReady);
+      window.addEventListener('message', handleVpnReady);
 
       redirectWithCredentials(
         user,

--- a/src/app/auth/components/LogIn/LogIn.tsx
+++ b/src/app/auth/components/LogIn/LogIn.tsx
@@ -80,19 +80,19 @@ export default function LogIn(): JSX.Element {
     if (user && mnemonic) {
       dispatch(userActions.setUser(user));
 
-      /**
-       * This function handles the VPN extension authentication if the user is already logged in
-       * @param event - The event object we receive from the message event listener
-       */
-      const handleVpnReady = (event: MessageEvent) => {
-        if (event.data && event.data.source === 'drive-extension' && event.data.payload === 'ready') {
-          if (isVpnAuth && newToken) {
-            authService.vpnExtensionAuth(newToken);
-          }
-        }
-      };
+      // /**
+      //  * This function handles the VPN extension authentication if the user is already logged in
+      //  * @param event - The event object we receive from the message event listener
+      //  */
+      // const handleVpnReady = (event: MessageEvent) => {
+      //   if (event.data && event.data.source === 'drive-extension' && event.data.payload === 'ready') {
+      //     if (isVpnAuth && newToken) {
+      //       authService.vpnExtensionAuth(newToken);
+      //     }
+      //   }
+      // };
 
-      window.addEventListener('message', handleVpnReady);
+      // window.addEventListener('message', handleVpnReady);
 
       redirectWithCredentials(
         user,

--- a/src/app/auth/components/LogIn/LogIn.tsx
+++ b/src/app/auth/components/LogIn/LogIn.tsx
@@ -77,26 +77,36 @@ export default function LogIn(): JSX.Element {
   }, []);
 
   useEffect(() => {
+    if (!newToken) return;
+
+    window.postMessage(
+      {
+        source: 'drive-web',
+        payload: newToken,
+      },
+      'https://staging.drive.internxt.com',
+    );
+
+    console.log('Mensaje enviado al content script con newToken:', newToken);
+  }, [newToken]);
+
+  useEffect(() => {
     if (user && mnemonic) {
       dispatch(userActions.setUser(user));
 
-      /**
-       * This function handles the VPN extension authentication if the user is already logged in
-       * @param event - The event object we receive from the message event listener
-       */
-      const handleVpnReady = (event: MessageEvent) => {
-        if (event.data && event.data.source === 'drive-extension' && event.data.payload === 'ready') {
-          setTimeout(() => {
-            if (isVpnAuth && newToken) {
-              authService.vpnExtensionAuth(newToken);
-            }
+      // /**
+      //  * This function handles the VPN extension authentication if the user is already logged in
+      //  * @param event - The event object we receive from the message event listener
+      //  */
+      // const handleVpnReady = (event: MessageEvent) => {
+      //   if (event.data && event.data.source === 'drive-extension' && event.data.payload === 'ready') {
+      //     if (isVpnAuth && newToken) {
+      //       authService.vpnExtensionAuth(newToken);
+      //     }
+      //   }
+      // };
 
-            window.removeEventListener('message', handleVpnReady);
-          }, 1000);
-        }
-      };
-
-      window.addEventListener('message', handleVpnReady);
+      // window.addEventListener('message', handleVpnReady);
 
       redirectWithCredentials(
         user,

--- a/src/app/auth/components/LogIn/LogIn.tsx
+++ b/src/app/auth/components/LogIn/LogIn.tsx
@@ -76,6 +76,10 @@ export default function LogIn(): JSX.Element {
     }
   }, []);
 
+  function sendMessageToExtension({ newToken }: { newToken: string }) {
+    window.postMessage({ source: 'drive-web', payload: newToken }, '*');
+  }
+
   useEffect(() => {
     if (user && mnemonic) {
       dispatch(userActions.setUser(user));
@@ -93,14 +97,6 @@ export default function LogIn(): JSX.Element {
     () => authService.extractOneUseCredentialsForAutoSubmit(new URLSearchParams(window.location.search)),
     [],
   );
-
-  const getLoginErrorMessage = (err: unknown): string => {
-    const appError = err as AppError;
-    if (appError?.status === UNAUTHORIZED_STATUS_CODE) {
-      return translate('auth.login.wrongLogin');
-    }
-    return appError?.message || 'An unexpected error occurred';
-  };
 
   const {
     register,
@@ -158,6 +154,13 @@ export default function LogIn(): JSX.Element {
         if (redirectUrl && !isUniversalLinkMode && !isSharingInvitation) {
           window.location.replace(redirectUrl);
         }
+
+        const isVPNAuth = urlParams.get('vpnAuth');
+        const newToken = localStorageService.get('xNewToken');
+        if (isVPNAuth && newToken) {
+          sendMessageToExtension({ newToken });
+        }
+
         redirectWithCredentials(user, mnemonic, { universalLinkMode: isUniversalLinkMode, isSharingInvitation });
       } else {
         setShowTwoFactor(true);

--- a/src/app/auth/components/LogIn/LogIn.tsx
+++ b/src/app/auth/components/LogIn/LogIn.tsx
@@ -39,7 +39,6 @@ export default function LogIn(): JSX.Element {
   const { translate } = useTranslationContext();
   const dispatch = useAppDispatch();
   const urlParams = new URLSearchParams(window.location.search);
-  const isVpnAuth = urlParams.get('vpnAuth') === 'true';
 
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [showTwoFactor, setShowTwoFactor] = useState(false);
@@ -48,7 +47,6 @@ export default function LogIn(): JSX.Element {
 
   const user = useSelector((state: RootState) => state.user.user) as UserSettings;
   const mnemonic = localStorageService.get('xMnemonic');
-  const newToken = localStorageService.get('xNewToken');
 
   const {
     isUniversalLinkMode,
@@ -79,20 +77,6 @@ export default function LogIn(): JSX.Element {
   useEffect(() => {
     if (user && mnemonic) {
       dispatch(userActions.setUser(user));
-
-      // /**
-      //  * This function handles the VPN extension authentication if the user is already logged in
-      //  * @param event - The event object we receive from the message event listener
-      //  */
-      // const handleVpnReady = (event: MessageEvent) => {
-      //   if (event.data && event.data.source === 'drive-extension' && event.data.payload === 'ready') {
-      //     if (isVpnAuth && newToken) {
-      //       authService.vpnExtensionAuth(newToken);
-      //     }
-      //   }
-      // };
-
-      // window.addEventListener('message', handleVpnReady);
 
       redirectWithCredentials(
         user,

--- a/src/app/auth/components/SignUp/SignUp.tsx
+++ b/src/app/auth/components/SignUp/SignUp.tsx
@@ -169,10 +169,6 @@ function SignUp(props: SignUpProps): JSX.Element {
     }
   };
 
-  function sendMessageToExtension({ newToken }: { newToken: string }) {
-    window.postMessage({ source: 'drive-web', payload: newToken }, '*');
-  }
-
   const redirectTheUserAfterRegistration = async (
     xToken: string,
     xNewToken: string,
@@ -187,7 +183,7 @@ function SignUp(props: SignUpProps): JSX.Element {
     const isVPNAuth = urlParams.get('vpnAuth');
 
     if (isVPNAuth && xNewToken) {
-      sendMessageToExtension({ newToken: xNewToken });
+      authService.vpnExtensionAuth(xNewToken);
     }
 
     if (redirectUrl) {

--- a/src/app/auth/services/auth.service.test.ts
+++ b/src/app/auth/services/auth.service.test.ts
@@ -252,6 +252,7 @@ describe('logIn', () => {
 
     expect(result).toEqual({
       token: mockToken,
+      newToken: mockNewToken,
       user: mockClearUser,
       mnemonic: mockMnemonic,
     });
@@ -339,6 +340,7 @@ describe('logIn', () => {
 
     expect(result).toEqual({
       token: mockToken,
+      newToken: mockNewToken,
       user: mockClearUser,
       mnemonic: mockMnemonic,
     });
@@ -421,6 +423,7 @@ describe('signUp', () => {
 
     expect(result).toEqual({
       token: mockToken,
+      newToken: mockNewToken,
       user: {
         ...mockUser,
         mnemonic: mockMnemonicNotEnc,
@@ -530,6 +533,7 @@ describe('signUp', () => {
 
     expect(result).toEqual({
       token: mockToken,
+      newToken: mockNewToken,
       user: {
         ...mockUser,
         mnemonic: mockMnemonicNotEnc,

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -557,7 +557,7 @@ export const authenticateUser = async (params: AuthenticateUserParams): Promise<
 };
 
 export const vpnExtensionAuth = (newToken: string, source = 'drive-web') => {
-  const targetUrl = envService.isProduction() ? process.env.REACT_APP_HOSTNAME : 'http://localhost:3000';
+  const targetUrl = envService.isProduction() ? 'https://staging.drive.internxt.com' : 'http://localhost:3000';
   window.postMessage({ source: source, payload: newToken }, targetUrl);
 };
 

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -48,6 +48,7 @@ import httpService from '../../core/services/http.service';
 type ProfileInfo = {
   user: UserSettings;
   token: string;
+  newToken: string;
   mnemonic: string;
 };
 
@@ -195,6 +196,7 @@ export const doLogin = async (
       return {
         user: clearUser,
         token: token,
+        newToken,
         mnemonic: clearMnemonic,
       };
     })
@@ -502,12 +504,12 @@ export const signUp = async (params: SignUpParams) => {
   if (isNewUser) dispatch(referralsThunks.initializeThunk());
   await trackSignUp(xUser.uuid, email);
 
-  return { token: xToken, user: xUser, mnemonic };
+  return { token: xToken, user: xUser, mnemonic, newToken: xNewToken };
 };
 
 export const logIn = async (params: LogInParams): Promise<ProfileInfo> => {
   const { email, password, twoFactorCode, dispatch, loginType = 'web' } = params;
-  const { token, user, mnemonic } = await doLogin(email, password, twoFactorCode, loginType);
+  const { token, newToken, user, mnemonic } = await doLogin(email, password, twoFactorCode, loginType);
   dispatch(userActions.setUser(user));
 
   try {
@@ -525,7 +527,7 @@ export const logIn = async (params: LogInParams): Promise<ProfileInfo> => {
 
   userActions.setUser(user);
 
-  return { token, user, mnemonic };
+  return { token, user, mnemonic, newToken };
 };
 
 export const authenticateUser = async (params: AuthenticateUserParams): Promise<ProfileInfo> => {

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -557,7 +557,7 @@ export const authenticateUser = async (params: AuthenticateUserParams): Promise<
 };
 
 export const vpnExtensionAuth = (newToken: string, source = 'drive-web') => {
-  const targetUrl = envService.isProduction() ? 'https://staging.drive.internxt.com' : 'http://localhost:3000';
+  const targetUrl = envService.isProduction() ? 'https://staging.drive.internxt.com' : 'http://localhost:3001';
   window.postMessage({ source: source, payload: newToken }, targetUrl);
 };
 

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -557,7 +557,7 @@ export const authenticateUser = async (params: AuthenticateUserParams): Promise<
 };
 
 export const vpnExtensionAuth = (newToken: string, source = 'drive-web') => {
-  const targetUrl = envService.isProduction() ? 'https://staging.drive.internxt.com' : 'http://localhost:3001';
+  const targetUrl = envService.isProduction() ? 'https://staging.drive.internxt.com' : 'http://localhost:3000';
   window.postMessage({ source: source, payload: newToken }, targetUrl);
 };
 

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -44,7 +44,6 @@ import { generateMnemonic, validateMnemonic } from 'bip39';
 import { SdkFactory } from '../../core/factory/sdk';
 import errorService from '../../core/services/error.service';
 import httpService from '../../core/services/http.service';
-import envService from 'app/core/services/env.service';
 
 type ProfileInfo = {
   user: UserSettings;
@@ -557,7 +556,7 @@ export const authenticateUser = async (params: AuthenticateUserParams): Promise<
 };
 
 export const vpnExtensionAuth = (newToken: string, source = 'drive-web') => {
-  const targetUrl = envService.isProduction() ? 'https://staging.drive.internxt.com' : 'http://localhost:3000';
+  const targetUrl = process.env.REACT_APP_HOSTNAME;
   window.postMessage({ source: source, payload: newToken }, targetUrl);
 };
 

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -44,6 +44,7 @@ import { generateMnemonic, validateMnemonic } from 'bip39';
 import { SdkFactory } from '../../core/factory/sdk';
 import errorService from '../../core/services/error.service';
 import httpService from '../../core/services/http.service';
+import envService from 'app/core/services/env.service';
 
 type ProfileInfo = {
   user: UserSettings;
@@ -555,6 +556,11 @@ export const authenticateUser = async (params: AuthenticateUserParams): Promise<
   }
 };
 
+export const vpnExtensionAuth = (newToken: string, source = 'drive-web') => {
+  const targetUrl = envService.isProduction() ? process.env.REACT_APP_HOSTNAME : 'http://localhost:3000';
+  window.postMessage({ source: source, payload: newToken }, targetUrl);
+};
+
 const authService = {
   logOut,
   check2FANeeded: is2FANeeded,
@@ -570,6 +576,7 @@ const authService = {
   requestUnblockAccount,
   unblockAccount,
   authenticateUser,
+  vpnExtensionAuth,
 };
 
 export default authService;

--- a/src/hooks/useVpnAuth.test.ts
+++ b/src/hooks/useVpnAuth.test.ts
@@ -20,7 +20,6 @@ describe('VPN authentication management', () => {
     const isVpnAuth = true;
 
     test('When there is new token and the VPN does not have the user token, then we should listen to the events and trigger the token', async () => {
-      const isVpnAuth = true;
       renderHook(() => useVpnAuth(isVpnAuth, newToken));
 
       act(() => {
@@ -33,8 +32,6 @@ describe('VPN authentication management', () => {
     });
 
     test('When there is no new token, then we should not listen to events', async () => {
-      const isVpnAuth = true;
-
       const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
 
       renderHook(() => useVpnAuth(isVpnAuth, null));
@@ -51,7 +48,6 @@ describe('VPN authentication management', () => {
     });
 
     test('When the VPN has the user token, then we should not send it', async () => {
-      const isVpnAuth = true;
       renderHook(() => useVpnAuth(isVpnAuth, newToken));
 
       act(() => {

--- a/src/hooks/useVpnAuth.test.ts
+++ b/src/hooks/useVpnAuth.test.ts
@@ -1,0 +1,94 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import useVpnAuth from './useVpnAuth';
+import authService from 'app/auth/services/auth.service';
+
+const newToken = 'user-token';
+
+vi.mock('app/auth/services/auth.service', () => ({
+  default: {
+    vpnExtensionAuth: vi.fn(),
+  },
+}));
+
+describe('VPN authentication management', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('VPN auth is enabled', () => {
+    const isVpnAuth = true;
+
+    test('When there is new token and the VPN does not have the user token, then we should listen to the events and trigger the token', async () => {
+      const isVpnAuth = true;
+      renderHook(() => useVpnAuth(isVpnAuth, newToken));
+
+      act(() => {
+        window.postMessage({ source: 'drive-extension', tokenStatus: 'token-not-found' }, '*');
+      });
+
+      await waitFor(() => {
+        expect(authService.vpnExtensionAuth).toHaveBeenCalledWith(newToken);
+      });
+    });
+
+    test('When there is no new token, then we should not listen to events', async () => {
+      const isVpnAuth = true;
+
+      const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+
+      renderHook(() => useVpnAuth(isVpnAuth, null));
+
+      expect(addEventListenerSpy).not.toHaveBeenCalledWith('message', expect.any(Function));
+
+      act(() => {
+        window.postMessage({ source: 'drive-extension', tokenStatus: 'token-not-found' }, '*');
+      });
+
+      await waitFor(() => {
+        expect(authService.vpnExtensionAuth).not.toHaveBeenCalled();
+      });
+    });
+
+    test('When the VPN has the user token, then we should not send it', async () => {
+      const isVpnAuth = true;
+      renderHook(() => useVpnAuth(isVpnAuth, newToken));
+
+      act(() => {
+        window.postMessage({ source: 'drive-extension', tokenStatus: 'token-found' }, '*');
+      });
+
+      await waitFor(() => {
+        expect(authService.vpnExtensionAuth).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('VPN auth is disabled', () => {
+    const isVpnAuth = false;
+    test('When the VPN auth is not enabled, then do nothing', async () => {
+      renderHook(() => useVpnAuth(isVpnAuth, newToken));
+
+      act(() => {
+        window.postMessage({ source: 'drive-extension', tokenStatus: 'token-not-found' }, '*');
+      });
+
+      await waitFor(() => {
+        expect(authService.vpnExtensionAuth).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Event listener management', () => {
+    test('When we are done listening to the events, then remove them correctly', () => {
+      const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+      const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+      const { unmount } = renderHook(() => useVpnAuth(true, 'token'));
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
+      unmount();
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
+    });
+  });
+});

--- a/src/hooks/useVpnAuth.ts
+++ b/src/hooks/useVpnAuth.ts
@@ -1,12 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import authService from 'app/auth/services/auth.service';
-import localStorageService from 'app/core/services/local-storage.service';
 
-const useVpnAuthIfUserIsLoggedIn = () => {
-  const params = new URLSearchParams(window.location.search);
-  const isVpnAuth = params.get('vpnAuth') === 'true';
-  const newToken = localStorageService.get('xNewToken');
-
+const useVpnAuth = (isVpnAuth: boolean, newToken: string | null) => {
   const [isVpnAuthNeeded, setIsVpnAuthNeeded] = useState<boolean>(false);
 
   useEffect(() => {
@@ -28,13 +23,13 @@ const useVpnAuthIfUserIsLoggedIn = () => {
     return () => {
       window.removeEventListener('message', handleVpnAuth);
     };
-  }, [isVpnAuthNeeded]);
+  }, [isVpnAuthNeeded, newToken]);
 
-  const handleVpnAuth = () => {
+  const handleVpnAuth = useCallback(() => {
     if (!newToken) return;
     authService.vpnExtensionAuth(newToken);
     setIsVpnAuthNeeded(false);
-  };
+  }, [newToken]);
 };
 
-export default useVpnAuthIfUserIsLoggedIn;
+export default useVpnAuth;

--- a/src/hooks/useVpnAuth.ts
+++ b/src/hooks/useVpnAuth.ts
@@ -33,6 +33,7 @@ const useVpnAuthIfUserIsLoggedIn = () => {
   const handleVpnAuth = () => {
     if (!newToken) return;
     authService.vpnExtensionAuth(newToken);
+    setIsVpnAuthNeeded(false);
   };
 };
 

--- a/src/hooks/useVpnAuth.ts
+++ b/src/hooks/useVpnAuth.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import authService from 'app/auth/services/auth.service';
+import localStorageService from 'app/core/services/local-storage.service';
+
+const useVpnAuthIfUserIsLoggedIn = () => {
+  const params = new URLSearchParams(window.location.search);
+  const isVpnAuth = params.get('vpnAuth') === 'true';
+  const newToken = localStorageService.get('xNewToken');
+
+  const [isVpnAuthNeeded, setIsVpnAuthNeeded] = useState<boolean>(false);
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data?.source === 'drive-extension' && event.data?.tokenStatus === 'token-not-found' && isVpnAuth) {
+        setIsVpnAuthNeeded(true);
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
+  useEffect(() => {
+    if (isVpnAuthNeeded && newToken) {
+      window.addEventListener('message', handleVpnAuth);
+    }
+
+    return () => {
+      window.removeEventListener('message', handleVpnAuth);
+    };
+  }, [isVpnAuthNeeded]);
+
+  const handleVpnAuth = () => {
+    if (!newToken) return;
+    authService.vpnExtensionAuth(newToken);
+  };
+};
+
+export default useVpnAuthIfUserIsLoggedIn;

--- a/src/hooks/useVpnAuth.ts
+++ b/src/hooks/useVpnAuth.ts
@@ -10,7 +10,7 @@ const useVpnAuth = (isVpnAuth: boolean, newToken: string | null) => {
         setIsVpnAuthNeeded(true);
       }
     },
-    [isVpnAuth],
+    [setIsVpnAuthNeeded],
   );
 
   useEffect(() => {
@@ -18,7 +18,7 @@ const useVpnAuth = (isVpnAuth: boolean, newToken: string | null) => {
       window.addEventListener('message', handleMessage);
       return () => window.removeEventListener('message', handleMessage);
     }
-  }, [isVpnAuth, handleMessage]);
+  }, [isVpnAuth, newToken, handleMessage]);
 
   useEffect(() => {
     if (isVpnAuthNeeded && newToken) {


### PR DESCRIPTION
## Description
New implementation to obtain the new token when the user authenticates from VPN to use premium features.

We use `window.postMessage` to send the token to the extension, where the extension can get it via a web worker.

## Related Pull Requests
[VPN PR](https://github.com/internxt/vpn/pull/6)

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## How Has This Been Tested?

-  Open Chrome browser
- Enable Developer Mode
- Add the extension build folder (ask me by DM for it - this folder points to staging, so if you want to test it, we should deploy this branch in Staging. If not, we can merge this PR in production and I can package the extension as if it were for production to point to drive.internxt.com).
- Open the extension.
- Test the authentication (we jus get the user token).
