### PR TITLE
[PB-3717] bugfix/retry upload file

### DIFF
--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -378,7 +378,6 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
   }, [currentFolderId]);
 
   const onUploadFolderButtonClicked = useCallback((): void => {
-    console.log('llamada');
     errorService.addBreadcrumb({
       level: 'info',
       category: 'button',

--- a/src/app/network/upload.test.ts
+++ b/src/app/network/upload.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { uploadFile } from './upload';
+import { ConnectionLostError } from './requests';
+
+const uploadMock = vi.fn();
+
+const uploadParams = {
+  filesize: 50000,
+  filecontent: new File(['content'], 'file.txt'),
+  creds: { user: 'user', pass: 'password' },
+  mnemonic: 'mnemonic123',
+  progressCallback: vi.fn(),
+};
+
+vi.mock('./NetworkFacade', () => ({
+  NetworkFacade: vi.fn().mockImplementation(() => ({
+    uploadMultipart: vi.fn().mockResolvedValue('multipart-upload-success'),
+    upload: uploadMock,
+  })),
+}));
+
+describe('uploadFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should successfully upload a file', async () => {
+    uploadMock.mockResolvedValue('upload-success');
+
+    const result = await uploadFile('bucket123', uploadParams);
+
+    expect(result).toBe('upload-success');
+  });
+
+  it('should retry upload on failure and succeed on second attempt', async () => {
+    uploadMock.mockRejectedValueOnce(new Error('Temporary error')).mockResolvedValue('upload-success');
+
+    const result = await uploadFile('bucket123', uploadParams);
+
+    expect(result).toBe('upload-success');
+  });
+
+  it('should throw ConnectionLostError if connection is lost', async () => {
+    uploadMock.mockRejectedValue(new ConnectionLostError());
+
+    await expect(uploadFile('bucket123', uploadParams)).rejects.toThrow(ConnectionLostError);
+  });
+
+  it('should throw an error after max retries', async () => {
+    uploadMock
+      .mockRejectedValueOnce(new Error('Temporary error'))
+      .mockRejectedValueOnce(new Error('Temporary error'))
+      .mockRejectedValueOnce(new Error('Temporary error'));
+
+    await expect(uploadFile('bucket123', uploadParams)).rejects.toThrow('Temporary error');
+  });
+});

--- a/src/app/network/upload.test.ts
+++ b/src/app/network/upload.test.ts
@@ -29,6 +29,7 @@ describe('uploadFile', () => {
 
     const result = await uploadFile('bucket123', uploadParams);
 
+    expect(uploadMock).toBeCalledTimes(1);
     expect(result).toBe('upload-success');
   });
 
@@ -37,6 +38,7 @@ describe('uploadFile', () => {
 
     const result = await uploadFile('bucket123', uploadParams);
 
+    expect(uploadMock).toBeCalledTimes(2);
     expect(result).toBe('upload-success');
   });
 
@@ -53,5 +55,6 @@ describe('uploadFile', () => {
       .mockRejectedValueOnce(new Error('Temporary error'));
 
     await expect(uploadFile('bucket123', uploadParams)).rejects.toThrow('Temporary error');
+    expect(uploadMock).toBeCalledTimes(3);
   });
 });

--- a/src/app/network/upload.ts
+++ b/src/app/network/upload.ts
@@ -159,8 +159,10 @@ export async function uploadFile(bucketId: string, params: IUploadParams): Promi
         console.warn(`Attempt ${attempt} of ${MAX_TRIES} failed:`, err);
         Sentry.captureException(err, { extra: (err as ErrorWithContext).context });
 
-        if (attempt === MAX_TRIES) {
-          throw err; // ❌ Last try failed
+        const lastTryFailed = attempt === MAX_TRIES;
+
+        if (lastTryFailed) {
+          throw err;
         }
 
         await new Promise((res) => setTimeout(res, RETRY_DELAY));

--- a/src/app/network/upload.ts
+++ b/src/app/network/upload.ts
@@ -98,8 +98,6 @@ export async function uploadFile(bucketId: string, params: IUploadParams): Promi
     ),
   );
 
-  let uploadPromise: Promise<string>;
-
   const minimumMultipartThreshold = 100 * 1024 * 1024;
   const useMultipart = params.filesize > minimumMultipartThreshold;
   const partSize = 30 * 1024 * 1024;
@@ -130,34 +128,47 @@ export async function uploadFile(bucketId: string, params: IUploadParams): Promi
 
   params.abortController?.signal.addEventListener('abort', onAbort);
 
-  if (useMultipart) {
-    uploadPromise = facade.uploadMultipart(bucketId, params.mnemonic, file, {
-      uploadingCallback: params.progressCallback,
-      abortController: uploadAbortController,
-      parts: Math.ceil(params.filesize / partSize),
-      continueUploadOptions: params?.continueUploadOptions,
-    });
-  } else {
-    uploadPromise = facade.upload(bucketId, params.mnemonic, file, {
-      uploadingCallback: params.progressCallback,
-      abortController: uploadAbortController,
-      continueUploadOptions: params?.continueUploadOptions,
-    });
+  async function retryUpload(): Promise<string> {
+    const MAX_TRIES = 3;
+    const RETRY_DELAY = 1000;
+    let uploadPromise: Promise<string>;
+
+    for (let attempt = 1; attempt <= MAX_TRIES; attempt++) {
+      try {
+        if (useMultipart) {
+          uploadPromise = facade.uploadMultipart(bucketId, params.mnemonic, file, {
+            uploadingCallback: params.progressCallback,
+            abortController: uploadAbortController,
+            parts: Math.ceil(params.filesize / partSize),
+            continueUploadOptions: params?.continueUploadOptions,
+          });
+        } else {
+          uploadPromise = facade.upload(bucketId, params.mnemonic, file, {
+            uploadingCallback: params.progressCallback,
+            abortController: uploadAbortController,
+            continueUploadOptions: params?.continueUploadOptions,
+          });
+        }
+
+        return await uploadPromise;
+      } catch (err) {
+        if (connectionLost) {
+          throw new ConnectionLostError();
+        }
+
+        console.warn(`Attempt ${attempt} of ${MAX_TRIES} failed:`, err);
+        Sentry.captureException(err, { extra: (err as ErrorWithContext).context });
+
+        if (attempt === MAX_TRIES) {
+          throw err; // ❌ Last try failed
+        }
+
+        await new Promise((res) => setTimeout(res, RETRY_DELAY));
+      }
+    }
+
+    throw new Error('Unexpected error in retryUpload');
   }
 
-  return uploadPromise
-    .catch((err: ErrorWithContext) => {
-      if (connectionLost) {
-        throw new ConnectionLostError();
-      }
-
-      Sentry.captureException(err, { extra: err.context });
-
-      Sentry.captureException(err, { extra: err.context });
-
-      throw err;
-    })
-    .finally(() => {
-      console.timeEnd('multipart-upload');
-    });
+  return retryUpload().finally(() => console.timeEnd('multipart-upload'));
 }

--- a/src/app/network/upload.ts
+++ b/src/app/network/upload.ts
@@ -132,6 +132,7 @@ export async function uploadFile(bucketId: string, params: IUploadParams): Promi
     const MAX_TRIES = 3;
     const RETRY_DELAY = 1000;
     let uploadPromise: Promise<string>;
+    let lastTryError: unknown;
 
     for (let attempt = 1; attempt <= MAX_TRIES; attempt++) {
       try {
@@ -162,14 +163,12 @@ export async function uploadFile(bucketId: string, params: IUploadParams): Promi
         const lastTryFailed = attempt === MAX_TRIES;
 
         if (lastTryFailed) {
-          throw err;
-        }
-
-        await new Promise((res) => setTimeout(res, RETRY_DELAY));
+          lastTryError = err;
+        } else await new Promise((res) => setTimeout(res, RETRY_DELAY));
       }
     }
 
-    throw new Error('Unexpected error in retryUpload');
+    throw lastTryError;
   }
 
   return retryUpload().finally(() => console.timeEnd('multipart-upload'));


### PR DESCRIPTION
## Description

Retry upload request for files if something is wrong (maximum 3 attempts, waiting 1000 ms for each retry)

## Related Issues

Issue reported [here](https://inxt.atlassian.net/browse/PB-3717).

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [x] QA Passed

## How Has This Been Tested?

Tested locally, simulating uploading file is failing firsts attempts.
