### PR TITLE
[_]: feature/Restore stripe checkout for mobile app

### DIFF
--- a/src/app/core/config/views.ts
+++ b/src/app/core/config/views.ts
@@ -31,6 +31,7 @@ import ChangeEmailView from '../views/ChangeEmailView';
 import NotFoundView from '../views/NotFoundView/NotFoundView';
 import VerifyEmailView from '../views/VerifyEmailView';
 import CheckoutViewWrapper from '../../payment/views/IntegratedCheckoutView/CheckoutViewWrapper';
+import { CheckoutSessionId } from 'app/payment/views/CheckoutSession/CheckoutSessionId';
 
 const views: Array<{
   id: string;
@@ -57,6 +58,7 @@ const views: Array<{
   { id: AppView.Deactivation, component: DeactivationView },
   { id: AppView.CheckoutSuccess, component: CheckoutSuccessView },
   { id: AppView.CheckoutCancel, component: CheckoutCancelView },
+  { id: AppView.CheckoutSession, component: CheckoutSessionId },
   { id: AppView.Checkout, component: CheckoutViewWrapper },
   { id: AppView.RecoveryLink, component: RecoveryLinkView },
   { id: AppView.ShareFileToken, component: ShareFileView },

--- a/src/app/core/types.ts
+++ b/src/app/core/types.ts
@@ -127,6 +127,7 @@ export enum AppView {
   CheckoutSuccess = 'checkout-success',
   CheckoutCancel = 'checkout-cancel',
   Checkout = 'checkout',
+  CheckoutSession = 'checkout-session',
   RecoveryLink = 'recovery-link',
   ShareFileToken = 'share-token',
   ShareFileToken2 = 'share-token-2',

--- a/src/app/payment/views/CheckoutSession/CheckoutSessionId.tsx
+++ b/src/app/payment/views/CheckoutSession/CheckoutSessionId.tsx
@@ -1,0 +1,31 @@
+import errorService from 'app/core/services/error.service';
+import navigationService from 'app/core/services/navigation.service';
+import { AppView } from 'app/core/types';
+import paymentService from 'app/payment/services/payment.service';
+import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+
+export const CheckoutSessionId = () => {
+  const { sessionId } = useParams<{ sessionId: string }>();
+
+  const checkSessionId = (id: string): boolean => {
+    const pattern = /^cs_(test|live)_[a-zA-Z0-9]+$/;
+    return pattern.test(id);
+  };
+
+  useEffect(() => {
+    if (sessionId) {
+      const isValid = checkSessionId(sessionId);
+
+      if (isValid) {
+        paymentService.redirectToCheckout({ sessionId }).catch((err) => {
+          errorService.reportError(err);
+          navigationService.push(AppView.CheckoutCancel);
+        });
+        return;
+      }
+    }
+  }, [sessionId]);
+
+  return <></>;
+};

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
@@ -1,10 +1,14 @@
-import { BaseSyntheticEvent, useCallback, useEffect, useReducer, useRef } from 'react';
-import { Elements } from '@stripe/react-stripe-js';
-import { useSelector } from 'react-redux';
-import { Stripe, StripeElements, StripeElementsOptionsMode } from '@stripe/stripe-js';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
+import { Elements } from '@stripe/react-stripe-js';
+import { Stripe, StripeElements, StripeElementsOptionsMode } from '@stripe/stripe-js';
+import { BaseSyntheticEvent, useCallback, useEffect, useReducer, useRef } from 'react';
+import { useSelector } from 'react-redux';
 
+import { Loader } from '@internxt/ui';
+import { bytesToString } from 'app/drive/services/size.service';
+import { getProductAmount } from 'app/payment/utils/getProductAmount';
 import { useCheckout } from 'hooks/checkout/useCheckout';
+import { useParams } from 'react-router-dom';
 import { useSignUp } from '../../../auth/components/SignUp/useSignUp';
 import envService from '../../../core/services/env.service';
 import errorService from '../../../core/services/error.service';
@@ -15,6 +19,7 @@ import { AppView, IFormValues } from '../../../core/types';
 import databaseService from '../../../database/services/database.service';
 import { getDatabaseProfileAvatar } from '../../../drive/services/database.service';
 import { useTranslationContext } from '../../../i18n/provider/TranslationProvider';
+import ChangePlanDialog from '../../../newSettings/Sections/Account/Plans/components/ChangePlanDialog';
 import notificationsService, { ToastType } from '../../../notifications/services/notifications.service';
 import checkoutService from '../../../payment/services/checkout.service';
 import paymentService from '../../../payment/services/payment.service';
@@ -26,11 +31,6 @@ import authCheckoutService from '../../services/auth-checkout.service';
 import { checkoutReducer, initialStateForCheckout } from '../../store/checkoutReducer';
 import { AuthMethodTypes, CouponCodeData, RequestedPlanData } from '../../types';
 import CheckoutView from './CheckoutView';
-import ChangePlanDialog from '../../../newSettings/Sections/Account/Plans/components/ChangePlanDialog';
-import { getProductAmount } from 'app/payment/utils/getProductAmount';
-import { bytesToString } from 'app/drive/services/size.service';
-import { Loader } from '@internxt/ui';
-import { useParams } from 'react-router-dom';
 
 export const THEME_STYLES = {
   dark: {
@@ -204,15 +204,10 @@ const CheckoutViewWrapper = () => {
       const isValid = checkSessionId(sessionId);
 
       if (isValid) {
-        paymentService
-          .redirectToCheckout({ sessionId })
-          .then(() => {
-            console.log('Redirecting the user to Stripe...');
-          })
-          .catch((err) => {
-            console.error('Error while redirecting the user to Stripe:', err);
-            navigationService.push(AppView.CheckoutCancel);
-          });
+        paymentService.redirectToCheckout({ sessionId }).catch((err) => {
+          errorService.reportError(err);
+          navigationService.push(AppView.CheckoutCancel);
+        });
       }
     }
   }, [sessionId]);

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
@@ -200,6 +200,13 @@ const CheckoutViewWrapper = () => {
   };
 
   useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const planId = params.get('planId');
+    const promotionCode = params.get('couponCode');
+    const currency = params.get('currency');
+
+    const currencyValue = currency ?? 'eur';
+
     if (sessionId) {
       const isValid = checkSessionId(sessionId);
 
@@ -208,17 +215,9 @@ const CheckoutViewWrapper = () => {
           errorService.reportError(err);
           navigationService.push(AppView.CheckoutCancel);
         });
+        return;
       }
     }
-  }, [sessionId]);
-
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const planId = params.get('planId');
-    const promotionCode = params.get('couponCode');
-    const currency = params.get('currency');
-
-    const currencyValue = currency ?? 'eur';
 
     if (!planId) {
       navigationService.push(AppView.Drive);
@@ -258,7 +257,7 @@ const CheckoutViewWrapper = () => {
           navigationService.push(AppView.Signup);
         }
       });
-  }, [checkoutTheme]);
+  }, [checkoutTheme, sessionId]);
 
   useEffect(() => {
     if (isAuthenticated && user) {

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
@@ -8,7 +8,6 @@ import { Loader } from '@internxt/ui';
 import { bytesToString } from 'app/drive/services/size.service';
 import { getProductAmount } from 'app/payment/utils/getProductAmount';
 import { useCheckout } from 'hooks/checkout/useCheckout';
-import { useParams } from 'react-router-dom';
 import { useSignUp } from '../../../auth/components/SignUp/useSignUp';
 import envService from '../../../core/services/env.service';
 import errorService from '../../../core/services/error.service';
@@ -115,7 +114,6 @@ const CheckoutViewWrapper = () => {
   const dispatch = useAppDispatch();
   const { translate } = useTranslationContext();
   const { checkoutTheme } = useThemeContext();
-  const { sessionId } = useParams<{ sessionId: string }>();
   const [state, dispatchReducer] = useReducer(checkoutReducer, initialStateForCheckout);
   const isAuthenticated = useAppSelector((state) => state.user.isAuthenticated);
   const user = useSelector<RootState, UserSettings | undefined>((state) => state.user.user);
@@ -194,11 +192,6 @@ const CheckoutViewWrapper = () => {
     amount: plan?.upsellPlan?.decimalAmount,
   };
 
-  const checkSessionId = (sessionId: string): boolean => {
-    const pattern = /^cs_(test|live)_[a-zA-Z0-9]+$/;
-    return pattern.test(sessionId);
-  };
-
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const planId = params.get('planId');
@@ -206,18 +199,6 @@ const CheckoutViewWrapper = () => {
     const currency = params.get('currency');
 
     const currencyValue = currency ?? 'eur';
-
-    if (sessionId) {
-      const isValid = checkSessionId(sessionId);
-
-      if (isValid) {
-        paymentService.redirectToCheckout({ sessionId }).catch((err) => {
-          errorService.reportError(err);
-          navigationService.push(AppView.CheckoutCancel);
-        });
-        return;
-      }
-    }
 
     if (!planId) {
       navigationService.push(AppView.Drive);
@@ -257,7 +238,7 @@ const CheckoutViewWrapper = () => {
           navigationService.push(AppView.Signup);
         }
       });
-  }, [checkoutTheme, sessionId]);
+  }, [checkoutTheme]);
 
   useEffect(() => {
     if (isAuthenticated && user) {

--- a/src/app/routes/paths.json
+++ b/src/app/routes/paths.json
@@ -132,7 +132,7 @@
     {
       "id": "checkout",
       "layout": "empty",
-      "path": "/checkout/:sessionId",
+      "path": "/checkout/:sessionId?",
       "exact": false,
       "auth": false
     },

--- a/src/app/routes/paths.json
+++ b/src/app/routes/paths.json
@@ -132,7 +132,7 @@
     {
       "id": "checkout",
       "layout": "empty",
-      "path": "/checkout",
+      "path": "/checkout/:sessionId",
       "exact": false,
       "auth": false
     },

--- a/src/app/routes/paths.json
+++ b/src/app/routes/paths.json
@@ -132,7 +132,14 @@
     {
       "id": "checkout",
       "layout": "empty",
-      "path": "/checkout/:sessionId?",
+      "path": "/checkout",
+      "exact": false,
+      "auth": false
+    },
+    {
+      "id": "checkout-session",
+      "layout": "empty",
+      "path": "/checkout/:sessionId",
       "exact": false,
       "auth": false
     },


### PR DESCRIPTION
## Description

- Restored old checkout to make it work in mobile apps 

## Related Issues
- 

## Related Pull Requests
- 

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## How Has This Been Tested?

- Open mobile drive app and navigated to manage subscription view, try to buy a new one and the payment stripe has to be open

## Additional Notes

- To test it in staging we have to generate custom app pointing to staging
