### PR TITLE
[PB-3698]: fix/avoid folder notifications when logout

### DIFF
--- a/src/app/core/services/error.service.ts
+++ b/src/app/core/services/error.service.ts
@@ -8,6 +8,10 @@ interface AxiosErrorResponse {
   message?: string;
 }
 
+interface ErrorWithStatus extends Error {
+  status?: number;
+}
+
 const errorService = {
   /**
    * Reports an error to Sentry
@@ -40,7 +44,7 @@ const errorService = {
     } else if (typeof err === 'string') {
       castedError = new AppError(err);
     } else if (err instanceof Error) {
-      castedError.message = err.message;
+      castedError = new AppError(err.message || 'Unknown error', (err as ErrorWithStatus).status);
     } else {
       const map = err as Record<string, unknown>;
       castedError = map.message ? new AppError(map.message as string, map.status as number) : castedError;


### PR DESCRIPTION
## Description

Avoid showing folder notifications if logout

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [x] QA Passed

## How Has This Been Tested?

Checked that when a user deactived the account, no folder notifications appear.

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
