### PR TITLE
[_]: feat/remove monthly switch for individual plans

### DIFF
--- a/src/app/newSettings/Sections/Account/Plans/PlansSection.tsx
+++ b/src/app/newSettings/Sections/Account/Plans/PlansSection.tsx
@@ -312,11 +312,13 @@ const PlansSection = ({ changeSection, onClosePreferences }: PlansSectionProps) 
         </div>
         <div className="flex justify-center">
           <div className="flex flex-row rounded-lg bg-gray-5 p-0.5 text-sm">
-            <IntervalSwitch
-              active={selectedInterval === 'month'}
-              text={translate('general.renewal.monthly')}
-              onClick={() => setSelectedInterval('month')}
-            />
+            {!isIndividualSubscriptionSelected && (
+              <IntervalSwitch
+                active={selectedInterval === 'month'}
+                text={translate('general.renewal.monthly')}
+                onClick={() => setSelectedInterval('month')}
+              />
+            )}
             <IntervalSwitch
               active={selectedInterval === 'year'}
               text={translate('general.renewal.annually')}

--- a/src/app/newSettings/Sections/Account/Plans/components/PlanSelection/PlanSelectionCard.tsx
+++ b/src/app/newSettings/Sections/Account/Plans/components/PlanSelection/PlanSelectionCard.tsx
@@ -52,7 +52,7 @@ const PlanSelectionCard = ({
             <RoleBadge roleText={t('preferences.account.plans.current')} role={'current'} size={'small'} />
           )}
         </div>
-        <span className=" text-base font-normal leading-5 text-gray-60">{displayText}</span>
+        <span className=" text-base font-normal leading-5 text-gray-60 text-left">{displayText}</span>
       </button>
     </div>
   );


### PR DESCRIPTION
## Description

This PR eliminates the “Monthly” switch for Individual plans as the new plans are only for Annual and Lifetime billing type.
Business plans keep the monthly plans and the switch.

On the other hand, the product pricing/billing label has been moved to the left.

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed
