### PR TITLE
[_]: feat/Show space in the checkout for users of pc components

### DIFF
--- a/src/app/payment/components/checkout/CheckoutProductCard.tsx
+++ b/src/app/payment/components/checkout/CheckoutProductCard.tsx
@@ -106,6 +106,9 @@ export const CheckoutProductCard = ({
       : undefined;
 
   const getPlanFeaturePath = () => {
+    if (couponCodeData?.codeName === 'PCCOMPONENTES') {
+      return bytes;
+    }
     const PLAN_TYPES = {
       FREE: translate('preferences.account.plans.types.free'),
       ESSENTIAL: translate('preferences.account.plans.types.essential'),


### PR DESCRIPTION
## Description
This PR implements a change in the checkout to show the plan space to be purchased when the user comes from the PcComponents page.

## Checklist

- [ ] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

