### PR TITLE
[_]: feat/upgrade UI for lifetime users

### DIFF
--- a/src/app/core/components/Sidenav/Sidenav.tsx
+++ b/src/app/core/components/Sidenav/Sidenav.tsx
@@ -23,7 +23,7 @@ import { t } from 'i18next';
 import { Loader } from '@internxt/ui';
 import localStorageService, { STORAGE_KEYS } from '../../../core/services/local-storage.service';
 
-const HUNDRED_TB = 109951162777600;
+export const HUNDRED_TB = 109951162777600;
 
 interface SidenavProps {
   user: UserSettings | undefined;

--- a/src/app/core/components/Sidenav/Sidenav.tsx
+++ b/src/app/core/components/Sidenav/Sidenav.tsx
@@ -23,6 +23,8 @@ import { t } from 'i18next';
 import { Loader } from '@internxt/ui';
 import localStorageService, { STORAGE_KEYS } from '../../../core/services/local-storage.service';
 
+const HUNDRED_TB = 109951162777600;
+
 interface SidenavProps {
   user: UserSettings | undefined;
   subscription: UserSubscription | null;
@@ -170,6 +172,12 @@ const Sidenav = ({
     navigationService.push(AppView.Drive, {}, workspaceUuid);
   };
 
+  const isUpgradeAvailable = () => {
+    const isLifetimeAvailable = subscription?.type === 'lifetime' && planLimit < HUNDRED_TB;
+
+    return subscription?.type === 'free' || isLifetimeAvailable;
+  };
+
   return (
     <div className="flex w-64 flex-col">
       {isLoadingCredentials && <LoadingSpinner text={translate('workspaces.messages.switchingWorkspace')} />}
@@ -192,7 +200,7 @@ const Sidenav = ({
           <PlanUsage
             limit={planLimit}
             usage={planUsage}
-            subscriptionType={subscription?.type}
+            isUpgradeAvailable={isUpgradeAvailable}
             isLoading={isLoadingPlanUsage || isLoadingPlanLimit}
           />
         </div>

--- a/src/app/drive/components/PlanUsage/PlanUsage.tsx
+++ b/src/app/drive/components/PlanUsage/PlanUsage.tsx
@@ -12,13 +12,13 @@ export default function PlanUsage({
   limit,
   usage,
   isLoading,
-  subscriptionType,
+  isUpgradeAvailable,
   className = '',
 }: {
   limit: number;
   usage: number;
   isLoading: boolean;
-  subscriptionType?: string;
+  isUpgradeAvailable: () => boolean;
   className?: string;
 }): JSX.Element {
   const { translate } = useTranslationContext();
@@ -50,7 +50,7 @@ export default function PlanUsage({
       <div className="mt-1 flex h-1.5 w-full justify-start overflow-hidden rounded-lg bg-gray-5">
         <div className={`h-full ${componentColor}`} style={{ width: isLoading ? 0 : `${usagePercent}%` }} />
       </div>
-      {subscriptionType === 'free' && (
+      {isUpgradeAvailable() && (
         <p
           onClick={onUpgradeButtonClicked}
           className={`mt-3 h-full cursor-pointer text-sm font-medium ${isLimitReached ? 'text-red' : 'text-primary'}`}

--- a/src/app/drive/services/limit.service.ts
+++ b/src/app/drive/services/limit.service.ts
@@ -1,7 +1,6 @@
 import { bytesToString } from './size.service';
 import { SdkFactory } from '../../core/factory/sdk';
-
-export const INFINITE_LIMIT = 108851651149824;
+import { HUNDRED_TB } from 'app/core/components/Sidenav/Sidenav';
 
 async function fetchLimit(): Promise<number> {
   const storageClient = SdkFactory.getInstance().createStorageClient();
@@ -14,7 +13,7 @@ const formatLimit = (limit: number): string => {
   let result = '...';
 
   if (limit > 0) {
-    result = limit === INFINITE_LIMIT ? '\u221E' : bytesToString(limit);
+    result = limit > HUNDRED_TB ? '\u221E' : bytesToString(limit);
   }
 
   return result;

--- a/src/app/newSettings/Sections/Account/Plans/components/ChangePlanDialog.tsx
+++ b/src/app/newSettings/Sections/Account/Plans/components/ChangePlanDialog.tsx
@@ -81,7 +81,7 @@ const ChangePlanDialog = ({
   };
 
   const displayAmount = (value) => {
-    return (value / 100).toFixed(2);
+    return parseFloat((value / 100).toFixed(2));
   };
 
   return (

--- a/src/app/newSettings/Sections/Account/Plans/components/ChangePlanDialog.tsx
+++ b/src/app/newSettings/Sections/Account/Plans/components/ChangePlanDialog.tsx
@@ -43,12 +43,16 @@ const ChangePlanDialog = ({
   } = plan;
 
   const subscription = isIndividualSubscription ? individualSubscription : businessSubscription;
+  const userHasLifetimeSub = individualSubscription?.type === 'lifetime';
   const selectedPlan: DisplayPrice = prices.find((price) => price.id === priceIdSelected) as DisplayPrice;
 
   const selectedPlanSize = selectedPlan?.bytes;
-  const selectedPlanSizeString = bytesToString(selectedPlanSize);
   const selectedPlanAmount = selectedPlan?.amount;
   const selectedPlanInterval = selectedPlan?.interval;
+  const selectedPlanSizeString =
+    userHasLifetimeSub && selectedPlanInterval === 'lifetime'
+      ? bytesToString(selectedPlanSize + planLimit)
+      : bytesToString(selectedPlanSize);
   const currentPlanSizeString = bytesToString(
     isIndividualSubscription ? planLimit : (businessPlan?.storageLimit ?? businessPlanLimit),
   );

--- a/src/app/newSettings/Sections/Account/Plans/components/PlanCard.tsx
+++ b/src/app/newSettings/Sections/Account/Plans/components/PlanCard.tsx
@@ -127,7 +127,7 @@ const PlanDetailsList = ({
 
   const featureKeys = Array.from({ length: planTypeTextPath !== 'freeFeatures' ? 8 : 3 }, (_, i) => `feature${i + 1}`);
 
-  const commingSoonFeatureKeys = ['feature1', 'feature2'];
+  const comingSoonFeatureKeys = ['feature1', 'feature2'];
 
   return (
     <div className="flex flex-col space-y-2">
@@ -175,7 +175,7 @@ const PlanDetailsList = ({
             <span className="text-sm font-semibold text-gray-100">
               {t('preferences.account.plans.planFeaturesList.commingSoon')}
             </span>
-            {commingSoonFeatureKeys.map((key) => (
+            {comingSoonFeatureKeys.map((key) => (
               <div key={key} className="flex flex-row space-x-2">
                 <div className="mt-1">
                   <Check size={20} className="dark:text-black" />

--- a/src/app/newSettings/Sections/Account/Plans/utils/planUtils.ts
+++ b/src/app/newSettings/Sections/Account/Plans/utils/planUtils.ts
@@ -34,6 +34,10 @@ const determineSubscriptionChangeType = ({
   }
 
   if (isIntervalSelected) {
+    if (currentUserSubscription?.type === 'lifetime' && priceSelected.interval === 'lifetime') {
+      return 'upgrade';
+    }
+
     if (currentStorage < selectedPlanStorage) {
       return 'upgrade';
     }

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
@@ -80,9 +80,7 @@ export interface CheckoutViewManager {
 
 const ONE_YEAR_IN_MONTHS = 12;
 const IS_PRODUCTION = envService.isProduction();
-const RETURN_URL_DOMAIN = IS_PRODUCTION
-  ? process.env.REACT_APP_HOSTNAME
-  : 'https://drive-web-git-fix-pc-cloud-flow-internxt-web-team.vercel.app';
+const RETURN_URL_DOMAIN = IS_PRODUCTION ? process.env.REACT_APP_HOSTNAME : 'http://localhost:3000';
 const STATUS_CODE_ERROR = {
   USER_EXISTS: 409,
   COUPON_NOT_VALID: 422,

--- a/src/app/shared/components/CurrentPlan/index.tsx
+++ b/src/app/shared/components/CurrentPlan/index.tsx
@@ -1,3 +1,4 @@
+import { HUNDRED_TB } from 'app/core/components/Sidenav/Sidenav';
 import { bytesToString } from '../../../drive/services/size.service';
 import { Button } from '@internxt/ui';
 
@@ -16,7 +17,7 @@ export default function CurrentPlan({
   button?: string;
   onButtonClick?: () => void;
 }): JSX.Element {
-  const showInfinite = bytesInPlan >= 108851651149824;
+  const showInfinite = bytesInPlan >= HUNDRED_TB;
 
   return (
     <div className={`${className} flex items-center justify-between`}>


### PR DESCRIPTION
## Description

The user interface (UI) has been enhanced to provide a clearer indication to lifetime users regarding their ability to purchase additional lifetime plans. The update ensures that users understand that any new lifetime storage plan they acquire will be seamlessly integrated with their existing storage capacity. This means that each subsequent purchase will cumulatively increase their total available storage, reinforcing the flexibility and scalability of the lifetime plan offering.

## Related Pull Requests

- [payments-server/feat/handle-stack-storage-when-user-purchases-a-lifetime](https://github.com/internxt/payments-server/pull/185)

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

