### PR TITLE
[_]: feature/Added default stripe error messages in order to display original erro…

### DIFF
--- a/src/app/notifications/components/NotificationToast/LongNotificationToast.tsx
+++ b/src/app/notifications/components/NotificationToast/LongNotificationToast.tsx
@@ -4,7 +4,7 @@ import { CheckCircle, Info, Warning, WarningOctagon, X } from '@phosphor-icons/r
 import { NavLink } from 'react-router-dom';
 import { ToastShowProps, ToastType } from '../../services/notifications.service';
 
-const NotificationToast = ({
+const LongNotificationToast = ({
   text,
   type,
   action,
@@ -14,7 +14,6 @@ const NotificationToast = ({
 }: Omit<ToastShowProps, 'duration'> & { visible: boolean; onClose: () => void }): JSX.Element => {
   let Icon: typeof CheckCircle | undefined;
   let IconColor: string | undefined;
-
   switch (type) {
     case ToastType.Success:
       Icon = CheckCircle;
@@ -36,7 +35,6 @@ const NotificationToast = ({
       IconColor = 'text-primary';
       break;
   }
-
   return (
     <Transition
       appear
@@ -49,35 +47,37 @@ const NotificationToast = ({
       show={visible}
     >
       <div
-        className="flex max-w-xl items-center rounded-lg border border-gray-10 bg-surface p-3 dark:bg-gray-5"
+        className="flex max-w-xl items-start rounded-lg border border-gray-10 bg-surface p-3 dark:bg-gray-5"
         style={{ minWidth: '300px' }}
       >
-        {type === ToastType.Loading && <Loader classNameLoader="mr-1.5 h-6 w-6" />}
-        {Icon && <Icon weight="fill" className={`${IconColor} mr-1.5`} size={24} />}
-
-        <p className="line-clamp-2 flex-1 whitespace-pre break-words text-gray-80">{text}</p>
-        {action &&
-          (action.to ? (
-            <NavLink
-              className="ml-3 truncate font-medium text-primary no-underline"
-              exact
-              to={action.to}
-              onClick={action.onClick}
-            >
-              {action.text}
-            </NavLink>
-          ) : (
-            <button onClick={action.onClick} className="ml-3 truncate font-medium text-primary">
-              {action.text}
-            </button>
-          ))}
-
+        <div className="flex-shrink-0 pt-0.5">
+          {type === ToastType.Loading && <Loader classNameLoader="mr-1.5 h-6 w-6" />}
+          {Icon && <Icon weight="fill" className={`${IconColor} mr-1.5`} size={24} />}
+        </div>
+        <div className="ml-1.5 flex-1">
+          <p className="whitespace-normal break-words text-gray-80">{text}</p>
+          {action &&
+            (action.to ? (
+              <NavLink
+                className="mt-1 block truncate font-medium text-primary no-underline"
+                exact
+                to={action.to}
+                onClick={action.onClick}
+              >
+                {action.text}
+              </NavLink>
+            ) : (
+              <button onClick={action.onClick} className="mt-1 block truncate font-medium text-primary">
+                {action.text}
+              </button>
+            ))}
+        </div>
         {closable && (
           <button
             onClick={() => {
               onClose();
             }}
-            className="ml-3 text-gray-40"
+            className="ml-2 flex-shrink-0 text-gray-40 items-center justify-center"
           >
             <X size={20} />
           </button>
@@ -87,4 +87,4 @@ const NotificationToast = ({
   );
 };
 
-export default NotificationToast;
+export default LongNotificationToast;

--- a/src/app/notifications/services/longNotification.service.ts
+++ b/src/app/notifications/services/longNotification.service.ts
@@ -1,0 +1,42 @@
+import { createElement } from 'react';
+import toast from 'react-hot-toast';
+import LongNotificationToast from '../components/NotificationToast/LongNotificationToast';
+
+export enum ToastType {
+  Success = 'success',
+  Error = 'error',
+  Warning = 'warning',
+  Info = 'info',
+  Loading = 'loading',
+}
+
+export type ToastShowProps = {
+  text: string;
+  type?: ToastType;
+  action?: { text: string; to?: string; onClick: () => void };
+  duration?: number;
+  closable?: boolean;
+};
+
+const longNotificationsService = {
+  show: ({ text, type, action, duration = 5000, closable = true }: ToastShowProps): string => {
+    const id = toast.custom(
+      (t) =>
+        createElement(LongNotificationToast, {
+          text,
+          type,
+          visible: t.visible,
+          action,
+          closable,
+          onClose() {
+            toast.dismiss(id);
+          },
+        }),
+      { duration },
+    );
+    return id;
+  },
+  dismiss: toast.dismiss,
+};
+
+export default longNotificationsService;

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
@@ -14,11 +14,12 @@ import errorService from '../../../core/services/error.service';
 import localStorageService from '../../../core/services/local-storage.service';
 import navigationService from '../../../core/services/navigation.service';
 import RealtimeService from '../../../core/services/socket.service';
-import { AppView, IFormValues } from '../../../core/types';
+import AppError, { AppView, IFormValues } from '../../../core/types';
 import databaseService from '../../../database/services/database.service';
 import { getDatabaseProfileAvatar } from '../../../drive/services/database.service';
 import { useTranslationContext } from '../../../i18n/provider/TranslationProvider';
 import ChangePlanDialog from '../../../newSettings/Sections/Account/Plans/components/ChangePlanDialog';
+import longNotificationsService from '../../../notifications/services/longNotification.service';
 import notificationsService, { ToastType } from '../../../notifications/services/notifications.service';
 import checkoutService from '../../../payment/services/checkout.service';
 import paymentService from '../../../payment/services/payment.service';
@@ -86,6 +87,7 @@ const STATUS_CODE_ERROR = {
   COUPON_NOT_VALID: 422,
   PROMO_CODE_BY_NAME_NOT_FOUND: 404,
   BAD_REQUEST: 400,
+  INTERNAL_SERVER_ERROR: 500,
 };
 
 function savePaymentDataInLocalStorage(
@@ -285,18 +287,23 @@ const CheckoutViewWrapper = () => {
     [translate],
   );
 
-  const showCancelSubscriptionErrorNotification = useCallback(
-    () =>
-      notificationsService.show({
-        text: translate('notificationMessages.errorCancelSubscription'),
-        type: ToastType.Error,
-      }),
-    [translate],
-  );
-
   const handlePaymentSuccess = () => {
     showSuccessSubscriptionNotification();
     dispatch(planThunks.initializeThunk()).unwrap();
+  };
+
+  const handleErrorMessage = (error: AppError, defaultErrorMessage: string) => {
+    if (error?.status && error?.status >= STATUS_CODE_ERROR.INTERNAL_SERVER_ERROR) {
+      notificationsService.show({
+        text: defaultErrorMessage,
+        type: ToastType.Error,
+      });
+    } else {
+      longNotificationsService.show({
+        type: ToastType.Error,
+        text: error?.message,
+      });
+    }
   };
 
   const handleSubscriptionPayment = async (priceId: string) => {
@@ -322,16 +329,14 @@ const CheckoutViewWrapper = () => {
           })
           .catch((err) => {
             const error = errorService.castError(err);
-            errorService.reportError(error);
-            showCancelSubscriptionErrorNotification();
+            handleErrorMessage(error, translate('notificationMessages.errorCancelSubscription'));
           });
       } else {
         handlePaymentSuccess();
       }
     } catch (err) {
       const error = errorService.castError(err);
-      errorService.reportError(error);
-      showCancelSubscriptionErrorNotification();
+      handleErrorMessage(error, translate('notificationMessages.errorCancelSubscription'));
     }
   };
 
@@ -441,6 +446,7 @@ const CheckoutViewWrapper = () => {
       }
     } catch (err) {
       const statusCode = (err as any).status;
+      const castedError = errorService.castError(err);
 
       if (statusCode === STATUS_CODE_ERROR.BAD_REQUEST) {
         notificationsService.show({
@@ -455,13 +461,8 @@ const CheckoutViewWrapper = () => {
           type: ToastType.Error,
         });
       } else {
-        notificationsService.show({
-          text: translate('notificationMessages.errorCreatingSubscription'),
-          type: ToastType.Error,
-        });
+        handleErrorMessage(castedError, translate('notificationMessages.errorCreatingSubscription'));
       }
-
-      errorService.reportError(err);
     } finally {
       setIsUserPaying(false);
     }

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
@@ -448,12 +448,7 @@ const CheckoutViewWrapper = () => {
       const statusCode = (err as any).status;
       const castedError = errorService.castError(err);
 
-      if (statusCode === STATUS_CODE_ERROR.BAD_REQUEST) {
-        notificationsService.show({
-          text: translate('notificationMessages.invalidTaxIdIsProvided'),
-          type: ToastType.Error,
-        });
-      } else if (statusCode === STATUS_CODE_ERROR.USER_EXISTS) {
+      if (statusCode === STATUS_CODE_ERROR.USER_EXISTS) {
         setIsUpdateSubscriptionDialogOpen(true);
       } else if (statusCode === STATUS_CODE_ERROR.COUPON_NOT_VALID) {
         notificationsService.show({


### PR DESCRIPTION
## Description

- Added default stripe error messages in order to display original error while buying a plan

## Related Issues

-
## Related Pull Requests

-

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## How Has This Been Tested?

- Tried to buy plans with fake credit cards
-  I have tried to update a plan with a user that stripe says has a plan but in payments it doesn't exist, and checked that it display the backend error as long as it is not a 500.

## Additional Notes

-