### PR TITLE
[PB-4187] feature/Enhance task logger indicator to display current progress and completed files

### DIFF
--- a/src/app/tasks/components/TaskLogger/TaskLogger.tsx
+++ b/src/app/tasks/components/TaskLogger/TaskLogger.tsx
@@ -7,9 +7,9 @@ import TaskLoggerItem from '../TaskLoggerItem/TaskLoggerItem';
 
 import { CaretDown, CircleNotch, X } from '@phosphor-icons/react';
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
+import RetryManager, { FileToRetry } from 'app/network/RetryManager';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { uiActions } from '../../../store/slices/ui';
-import RetryManager, { FileToRetry } from 'app/network/RetryManager';
 
 const TaskLogger = (): JSX.Element => {
   const { translate } = useTranslationContext();
@@ -21,8 +21,9 @@ const TaskLogger = (): JSX.Element => {
 
   const allNotifications = useTaskManagerGetNotifications();
   const finishedNotifications = useTaskManagerGetNotifications({
-    status: [TaskStatus.Error, TaskStatus.Success, TaskStatus.Cancelled],
+    status: [TaskStatus.Error, TaskStatus.Success, TaskStatus.Cancelled, TaskStatus.InProcess],
   });
+
   const filesToRetryGroupedByTask = useMemo(
     () =>
       filesToRetry.reduce<Record<string, FileToRetry[]>>((acc, file) => {


### PR DESCRIPTION
## Description
The task logger currently does not count the files in process in its files processing message, this is misleading when it is a very long list, with files of a certain size, as it is difficult to see if it is processing the first ones because it indicates 0 for a while. 
Have to add files in progress for it to count them

## Related Issues
-

## Related Pull Requests
-

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## How Has This Been Tested?

- Upload some large files, and check that the file currently being uploaded is counted in the **Processing** counter

## Additional Notes

-