### PR TITLE
[PB-4214]: fix/header of the files/folders area is over any of the dropdown elements

### DIFF
--- a/src/app/core/components/Navbar/NavbarGlobalSearch.tsx
+++ b/src/app/core/components/Navbar/NavbarGlobalSearch.tsx
@@ -222,136 +222,139 @@ const Navbar = (props: NavbarProps) => {
 
   return (
     <div className="flex h-14 w-full items-center justify-between border-b border-gray-5 text-gray-40 dark:bg-gray-1">
-      {hideSearch ? (
-        <div />
-      ) : (
-        <form className="relative flex h-full w-full items-center" onSubmitCapture={handleSubmit}>
-          <label
-            className={`${
-              openSearchBox ? 'max-w-screen-sm' : 'max-w-sm'
-            } relative flex w-full items-center rounded-lg transition-all duration-150 ease-out`}
-            htmlFor="globalSearchInput"
-          >
-            <MagnifyingGlass
-              className="pointer-events-none absolute left-2.5 top-1/2 z-1 -translate-y-1/2 text-gray-60 focus-within:text-gray-80"
-              size={20}
-            />
-            <input
-              ref={searchInput}
-              id="globalSearchInput"
-              data-cy="globalSearchInput"
-              autoComplete="off"
-              spellCheck="false"
-              type="text"
-              value={query}
-              className="inxt-input left-icon h-10 w-full appearance-none rounded-lg border border-transparent bg-gray-5 px-9 text-lg text-gray-100 placeholder-gray-60 outline-none ring-1 ring-gray-10 transition-all duration-150 ease-out hover:shadow-sm hover:ring-gray-20 focus:border-primary focus:bg-surface focus:placeholder-gray-80 focus:shadow-none focus:ring-3 focus:ring-primary/10 dark:focus:bg-gray-1 dark:focus:ring-primary/20"
-              onChange={(e) => {
-                setQuery(e.target.value);
-                handleSearch();
-              }}
-              onKeyDownCapture={handleKeyDown}
-              onKeyUpCapture={(e) => {
-                if (e.key === 'Escape') {
-                  e.currentTarget.blur();
-                } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
-                  e.preventDefault();
-                }
-              }}
-              onBlurCapture={(e) => {
-                if (preventBlur) {
-                  e.currentTarget.focus();
-                } else {
-                  setOpenSearchBox(false);
-                }
-              }}
-              onFocusCapture={() => setOpenSearchBox(true)}
-              placeholder={translate('general.searchBar.placeholder')}
-            />
+      <div className="flex h-full w-full items-center justify-between z-20">
+        {hideSearch ? (
+          <div />
+        ) : (
+          <form className="relative flex h-full w-full items-center" onSubmitCapture={handleSubmit}>
+            <label
+              className={`${
+                openSearchBox ? 'max-w-screen-sm' : 'max-w-sm'
+              } relative flex w-full items-center rounded-lg transition-all duration-150 ease-out`}
+              htmlFor="globalSearchInput"
+            >
+              <MagnifyingGlass
+                className="pointer-events-none absolute left-2.5 top-1/2 z-1 -translate-y-1/2 text-gray-60 focus-within:text-gray-80"
+                size={20}
+              />
+              <input
+                ref={searchInput}
+                id="globalSearchInput"
+                data-cy="globalSearchInput"
+                autoComplete="off"
+                spellCheck="false"
+                type="text"
+                value={query}
+                className="inxt-input left-icon h-10 w-full appearance-none rounded-lg border border-transparent bg-gray-5 px-9 text-lg text-gray-100 placeholder-gray-60 outline-none ring-1 ring-gray-10 transition-all duration-150 ease-out hover:shadow-sm hover:ring-gray-20 focus:border-primary focus:bg-surface focus:placeholder-gray-80 focus:shadow-none focus:ring-3 focus:ring-primary/10 dark:focus:bg-gray-1 dark:focus:ring-primary/20"
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  handleSearch();
+                }}
+                onKeyDownCapture={handleKeyDown}
+                onKeyUpCapture={(e) => {
+                  if (e.key === 'Escape') {
+                    e.currentTarget.blur();
+                  } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+                    e.preventDefault();
+                  }
+                }}
+                onBlurCapture={(e) => {
+                  if (preventBlur) {
+                    e.currentTarget.focus();
+                  } else {
+                    setOpenSearchBox(false);
+                  }
+                }}
+                onFocusCapture={() => setOpenSearchBox(true)}
+                placeholder={translate('general.searchBar.placeholder')}
+              />
+              <div
+                className={`${
+                  openSearchBox && 'opacity-0'
+                } pointer-events-none absolute right-2.5 top-1/2 z-1 -translate-y-1/2 rounded-md bg-gray-10 px-2 py-1 text-sm text-gray-50`}
+              >
+                {isMacOs ? '⌘F' : 'Ctrl F'}
+              </div>
+              <X
+                className={`${
+                  (query.length === 0 || !openSearchBox) && 'pointer-events-none opacity-0'
+                } absolute right-2.5 top-1/2 z-1 -translate-y-1/2 cursor-pointer text-gray-60 transition-all duration-100 ease-out`}
+                onMouseDownCapture={() => {
+                  setQuery('');
+                  setSearchResult([]);
+                }}
+                onMouseLeave={() => query.length === 0 && searchInput.current?.focus()}
+                size={20}
+              />
+            </label>
+
             <div
               className={`${
-                openSearchBox && 'opacity-0'
-              } pointer-events-none absolute right-2.5 top-1/2 z-1 -translate-y-1/2 rounded-md bg-gray-10 px-2 py-1 text-sm text-gray-50`}
+                openSearchBox
+                  ? 'translate-y-1.5 scale-100 opacity-100'
+                  : 'pointer-events-none -translate-y-0.5 scale-98 opacity-0'
+              } absolute top-12 z-10 flex h-80 w-full max-w-screen-sm origin-top flex-col overflow-hidden rounded-xl bg-surface text-gray-100 shadow-subtle-hard ring-1 ring-gray-10 transition-all duration-150 ease-out dark:bg-gray-5`}
+              onMouseEnter={() => setPreventBlur(true)}
+              onMouseLeave={() => setPreventBlur(false)}
             >
-              {isMacOs ? '⌘F' : 'Ctrl F'}
-            </div>
-            <X
-              className={`${
-                (query.length === 0 || !openSearchBox) && 'pointer-events-none opacity-0'
-              } absolute right-2.5 top-1/2 z-1 -translate-y-1/2 cursor-pointer text-gray-60 transition-all duration-100 ease-out`}
-              onMouseDownCapture={() => {
-                setQuery('');
-                setSearchResult([]);
-              }}
-              onMouseLeave={() => query.length === 0 && searchInput.current?.focus()}
-              size={20}
-            />
-          </label>
-
-          <div
-            className={`${
-              openSearchBox
-                ? 'translate-y-1.5 scale-100 opacity-100'
-                : 'pointer-events-none -translate-y-0.5 scale-98 opacity-0'
-            } absolute top-12 z-10 flex h-80 w-full max-w-screen-sm origin-top flex-col overflow-hidden rounded-xl bg-surface text-gray-100 shadow-subtle-hard ring-1 ring-gray-10 transition-all duration-150 ease-out dark:bg-gray-5`}
-            onMouseEnter={() => setPreventBlur(true)}
-            onMouseLeave={() => setPreventBlur(false)}
-          >
-            <div className="flex w-full shrink-0 items-center justify-between border-b border-gray-5 px-2.5 py-2.5 dark:border-gray-10">
-              <button type="button" className="flex items-center space-x-2">
-                {filterItems.map((item) => (
-                  <FilterItem
-                    key={item.id}
-                    id={item.id}
-                    Icon={item.Icon}
-                    name={item.name}
-                    filters={filters}
-                    setFilters={setFilters}
-                  />
-                ))}
-              </button>
-
-              <button
-                type="button"
-                className={`${
-                  filters.length === 0 && 'pointer-events-none opacity-0'
-                } flex h-8 cursor-pointer items-center space-x-2 rounded-full bg-gray-1 px-3 text-sm font-medium text-gray-60 transition-all duration-100 ease-out hover:bg-gray-5 dark:hover:bg-surface`}
-                onClick={() => setFilters([])}
-              >
-                {translate('general.searchBar.filters.clear')}
-              </button>
-            </div>
-
-            {(filters.length === 0 && searchResult.length > 0) || (filters.length > 0 && filteredResults.length > 0) ? (
-              <ul ref={searchResultList} className="flex h-full flex-col overflow-y-auto pb-4">
-                {(filteredResults.length > 0 ? filteredResults : searchResult).map((item, index) => {
-                  const isFolder = item.itemType === 'FOLDER' || item.itemType === 'folder';
-                  const Icon = iconService.getItemIcon(isFolder, item.item.type);
-                  return (
-                    <li
+              <div className="flex w-full shrink-0 items-center justify-between border-b border-gray-5 px-2.5 py-2.5 dark:border-gray-10">
+                <button type="button" className="flex items-center space-x-2">
+                  {filterItems.map((item) => (
+                    <FilterItem
                       key={item.id}
-                      id={`searchResult_${item.id}`}
-                      role="option"
-                      aria-selected={selectedResult === index}
-                      className={`${
-                        selectedResult === index && 'bg-gray-5 dark:bg-gray-10'
-                      } flex h-11 shrink-0 cursor-pointer items-center space-x-2.5 px-4 text-gray-100`}
-                      onMouseEnter={() => setSelectedResult(index)}
-                      onClickCapture={() => openItem(item)}
-                    >
-                      <Icon className="h-7 w-7 drop-shadow-soft" />
-                      <p className="w-full overflow-hidden text-ellipsis whitespace-nowrap">{item.name}</p>
-                    </li>
-                  );
-                })}
-              </ul>
-            ) : query.length > 0 && !loadingSearch ? (
-              <NotFoundState />
-            ) : (
-              <EmptyState />
-            )}
-          </div>
-        </form>
-      )}
+                      id={item.id}
+                      Icon={item.Icon}
+                      name={item.name}
+                      filters={filters}
+                      setFilters={setFilters}
+                    />
+                  ))}
+                </button>
+
+                <button
+                  type="button"
+                  className={`${
+                    filters.length === 0 && 'pointer-events-none opacity-0'
+                  } flex h-8 cursor-pointer items-center space-x-2 rounded-full bg-gray-1 px-3 text-sm font-medium text-gray-60 transition-all duration-100 ease-out hover:bg-gray-5 dark:hover:bg-surface`}
+                  onClick={() => setFilters([])}
+                >
+                  {translate('general.searchBar.filters.clear')}
+                </button>
+              </div>
+
+              {(filters.length === 0 && searchResult.length > 0) ||
+              (filters.length > 0 && filteredResults.length > 0) ? (
+                <ul ref={searchResultList} className="flex h-full flex-col overflow-y-auto pb-4">
+                  {(filteredResults.length > 0 ? filteredResults : searchResult).map((item, index) => {
+                    const isFolder = item.itemType === 'FOLDER' || item.itemType === 'folder';
+                    const Icon = iconService.getItemIcon(isFolder, item.item.type);
+                    return (
+                      <li
+                        key={item.id}
+                        id={`searchResult_${item.id}`}
+                        role="option"
+                        aria-selected={selectedResult === index}
+                        className={`${
+                          selectedResult === index && 'bg-gray-5 dark:bg-gray-10'
+                        } flex h-11 shrink-0 cursor-pointer items-center space-x-2.5 px-4 text-gray-100`}
+                        onMouseEnter={() => setSelectedResult(index)}
+                        onClickCapture={() => openItem(item)}
+                      >
+                        <Icon className="h-7 w-7 drop-shadow-soft" />
+                        <p className="w-full overflow-hidden text-ellipsis whitespace-nowrap">{item.name}</p>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : query.length > 0 && !loadingSearch ? (
+                <NotFoundState />
+              ) : (
+                <EmptyState />
+              )}
+            </div>
+          </form>
+        )}
+      </div>
 
       <div className="flex shrink-0">
         <button

--- a/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/app/drive/components/DriveExplorer/DriveExplorer.tsx
@@ -685,7 +685,7 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
         <div className="flex w-1 grow flex-col">
           <div className="z-10 flex flex-wrap min-h-14 max-w-full shrink-0 justify-between px-5 py-2 ">
             <div
-              className={`mr-20 ${isTrash ? 'min-w-0' : 'min-w-[200px]'} flex w-full flex-1 flex-row flex-wrap items-center text-lg ${titleClassName ?? ''}`}
+              className={`mr-20 ${isTrash ? 'min-w-0' : 'min-w-[200px]'} flex w-full z-20 flex-1 flex-row flex-wrap items-center text-lg ${titleClassName ?? ''}`}
             >
               {title}
             </div>


### PR DESCRIPTION
## Description
This PR corrects the z-index of a couple of components to render them on top of each other so that they are not clipped.


## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## How Has This Been Tested?
- Make the window small (820x920 in my case).
- Open the search bar that we have in the header > Check that the dropdown is not cut by the buttons or Breadcrumbs.
- Open the Breadcrumbs dropdown (by clicking on the current breadcrumb) > Check that the dropdown is not cut by the buttons.

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
