### PR TITLE
[PB-3870]: fix/use of plainName property for backups names

### DIFF
--- a/src/app/backups/components/DeviceList/DeviceList.tsx
+++ b/src/app/backups/components/DeviceList/DeviceList.tsx
@@ -13,9 +13,10 @@ import UilWindows from '@iconscout/react-unicons/icons/uil-windows';
 import UilDesktop from '@iconscout/react-unicons/icons/uil-desktop';
 import dateService from '../../../core/services/date.service';
 import sizeService from '../../../drive/services/size.service';
-import { DriveFolderData } from '@internxt/sdk/dist/drive/storage/types';
+
 import { skinSkeleton } from 'app/shared/Skeleton';
 import { List } from '@internxt/ui';
+import { DriveFolderData } from 'app/drive/types';
 
 interface Props {
   items: (Device | DriveFolderData)[];
@@ -91,7 +92,7 @@ const DeviceList = (props: Props): JSX.Element => {
                   </div>
                   <div className="grow cursor-default truncate pr-3">
                     <button className="z-10 shrink cursor-pointer truncate" onClick={() => onDeviceClicked(device)}>
-                      {device.name}
+                      {(device as DriveFolderData).plainName}
                     </button>
                   </div>
                 </div>

--- a/src/app/backups/hooks/useBackupDeviceActions.ts
+++ b/src/app/backups/hooks/useBackupDeviceActions.ts
@@ -1,7 +1,6 @@
-import { DriveFolderData } from '@internxt/sdk/dist/drive/storage/types';
 import { Device } from 'app/backups/types';
 import { deleteBackupDeviceAsFolder } from 'app/drive/services/folder.service';
-import { DriveItemData, DriveFolderData as DriveWebFolderData } from 'app/drive/types';
+import { DriveFolderData, DriveItemData } from 'app/drive/types';
 import { AppDispatch } from 'app/store';
 import { useAppSelector } from 'app/store/hooks';
 import { backupsActions, backupsThunks } from 'app/store/slices/backups';
@@ -79,7 +78,7 @@ export const useBackupDeviceActions = (
         dispatch(backupsThunks.deleteDeviceThunk(selectedDevice));
       } else {
         await dispatch(deleteItemsThunk([selectedDevice as DriveItemData])).unwrap();
-        await deleteBackupDeviceAsFolder(selectedDevice as DriveWebFolderData);
+        await deleteBackupDeviceAsFolder(selectedDevice as DriveFolderData);
         dispatch(backupsThunks.fetchDevicesThunk());
       }
     }

--- a/src/app/backups/hooks/useBackupListActions.ts
+++ b/src/app/backups/hooks/useBackupListActions.ts
@@ -1,9 +1,8 @@
 import { Dispatch, SetStateAction, useState } from 'react';
-import { DriveItemData } from 'app/drive/types';
+import { DriveFolderData, DriveItemData } from 'app/drive/types';
 import { AppDispatch } from 'app/store';
 import { backupsActions } from 'app/store/slices/backups';
 import { PreviewFileItem } from 'app/share/types';
-import { DriveFolderData } from '@internxt/sdk/dist/drive/storage/types';
 
 export const useBackupListActions = (
   onBreadcrumbFolderChanges: Dispatch<SetStateAction<DriveFolderData[]>>,

--- a/src/app/backups/services/backups.service.ts
+++ b/src/app/backups/services/backups.service.ts
@@ -1,8 +1,8 @@
 import { aes } from '@internxt/lib';
 import { Device, DeviceBackup } from '@internxt/sdk/dist/drive/backups/types';
-import { DriveFolderData } from '@internxt/sdk/dist/drive/storage/types';
 import { SdkFactory } from '../../core/factory/sdk';
 import httpService from '../../core/services/http.service';
+import { DriveFolderData } from 'app/drive/types';
 
 const backupsService = {
   async getAllDevices(): Promise<Device[]> {
@@ -20,7 +20,6 @@ const backupsService = {
     if (res.ok) {
       const encryptedFolders = await res.json();
       return encryptedFolders.map(({ name, ...rest }: DriveFolderData) => ({
-        name: aes.decrypt(name, `${process.env.REACT_APP_CRYPTO_SECRET2}-${rest.bucket}`),
         ...rest,
         isFolder: true,
       }));

--- a/src/app/backups/views/BackupsView/BackupsView.tsx
+++ b/src/app/backups/views/BackupsView/BackupsView.tsx
@@ -12,7 +12,6 @@ import { deleteBackupDeviceAsFolder } from '../../../drive/services/folder.servi
 import { deleteFile } from '../../../drive/services/file.service';
 import { deleteItemsThunk } from '../../../store/slices/storage/storage.thunks/deleteItemsThunk';
 import { DriveFolderData as DriveWebFolderData, DriveItemData } from '../../../drive/types';
-import { DriveFolderData } from '@internxt/sdk/dist/drive/storage/types';
 import { contextMenuSelectedBackupItems } from '../../../drive/components/DriveExplorer/DriveExplorerList/DriveItemContextMenu';
 import { useBackupListActions } from 'app/backups/hooks/useBackupListActions';
 import { useBackupDeviceActions } from 'app/backups/hooks/useBackupDeviceActions';
@@ -31,7 +30,7 @@ export default function BackupsView(): JSX.Element {
   const currentDevice = useAppSelector((state) => state.backups.currentDevice);
   const selectedWorkspace = useAppSelector(workspacesSelectors.getSelectedWorkspace);
   const workspaceCredentials = useAppSelector(workspacesSelectors.getWorkspaceCredentials);
-  const [foldersInBreadcrumbs, setFoldersInBreadcrumbs] = useState<DriveFolderData[]>([]);
+  const [foldersInBreadcrumbs, setFoldersInBreadcrumbs] = useState<DriveWebFolderData[]>([]);
 
   const {
     folderUuid,

--- a/src/app/shared/components/Breadcrumbs/Containers/BreadcrumbsBackupsView.tsx
+++ b/src/app/shared/components/Breadcrumbs/Containers/BreadcrumbsBackupsView.tsx
@@ -1,4 +1,3 @@
-import { DriveFolderData } from '@internxt/sdk/dist/drive/storage/types';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { backupsActions } from 'app/store/slices/backups';
 import { t } from 'i18next';
@@ -10,6 +9,7 @@ import { DragAndDropType } from 'app/core/types';
 import { NativeTypes } from 'react-dnd-html5-backend';
 import { BreadcrumbItemData, Breadcrumbs } from '@internxt/ui';
 import { useDrop } from 'react-dnd';
+import { DriveFolderData } from 'app/drive/types';
 
 interface BreadcrumbsBackupsViewProps {
   backupsAsFoldersPath: DriveFolderData[];
@@ -39,7 +39,7 @@ const BreadcrumbsBackupsView = ({ backupsAsFoldersPath, goToFolder, goToFolderRo
     if (currentDevice && 'mac' in currentDevice) {
       items.push({
         uuid: currentDevice.id.toString(),
-        label: currentDevice.name,
+        label: (currentDevice as unknown as DriveFolderData).plainName ?? currentDevice.name,
         icon: null,
         active: false,
         isBackup: true,
@@ -55,7 +55,7 @@ const BreadcrumbsBackupsView = ({ backupsAsFoldersPath, goToFolder, goToFolderRo
         };
         items.push({
           uuid: item.uuid,
-          label: item.name,
+          label: item.plainName ?? item.name,
           icon: null,
           isBackup: true,
           ...(i === backupsAsFoldersPath.length - 1 ? { active: false } : clickableOptions),

--- a/src/app/store/slices/backups/index.ts
+++ b/src/app/store/slices/backups/index.ts
@@ -7,7 +7,7 @@ import downloadService from '../../../drive/services/download.service';
 import notificationsService, { ToastType } from '../../../notifications/services/notifications.service';
 import { DownloadBackupTask, TaskStatus, TaskType } from '../../../tasks/types';
 import tasksService from '../../../tasks/services/tasks.service';
-import { DriveFolderData } from '@internxt/sdk/dist/drive/storage/types';
+import { DriveFolderData } from 'app/drive/types';
 
 interface BackupsState {
   isLoadingDevices: boolean;


### PR DESCRIPTION
## Description

This PR updates the way user backup folder names are displayed.
Instead of decrypting the names on the client side, we now rely on the already decrypted names provided by the backend.

Previously, client-side decryption could fail in certain cases due to inconsistencies in the encryption keys used (e.g., some folders may have been encrypted with a different or outdated key). This led to runtime errors and incomplete rendering of user backups.

By using the decrypted names directly from the server, we ensure a more reliable and consistent user experience, while also reducing client-side complexity and potential decryption errors.


## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [ ] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## How Has This Been Tested?

Go to **Backups** > check that the devices name is displayed correctly (both List and Breadcrumbs components).

## Additional Notes
- 
