### PR TITLE
chore: migrate upload thumbnails to new server-wip endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@internxt/css-config": "^1.0.3",
     "@internxt/inxt-js": "=1.2.21",
     "@internxt/lib": "^1.2.0",
-    "@internxt/sdk": "=1.9.15",
+    "@internxt/sdk": "=1.9.18",
     "@internxt/ui": "^0.0.23",
     "@phosphor-icons/react": "^2.1.7",
     "@popperjs/core": "^2.11.6",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@internxt/css-config": "^1.0.3",
     "@internxt/inxt-js": "=1.2.21",
     "@internxt/lib": "^1.2.0",
-    "@internxt/sdk": "=1.9.9",
+    "@internxt/sdk": "=1.9.15",
     "@internxt/ui": "^0.0.23",
     "@phosphor-icons/react": "^2.1.7",
     "@popperjs/core": "^2.11.6",

--- a/src/app/auth/services/user.service.test.ts
+++ b/src/app/auth/services/user.service.test.ts
@@ -1,9 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import localStorageService from 'app/core/services/local-storage.service';
 import userService from './user.service';
 
 const testToken = 'testToken';
 const testEmail = 'test@initnxt.com';
+
+vi.mock('app/core/services/local-storage.service', () => ({
+  default: {
+    get: vi.fn(() => testToken),
+    set: vi.fn(),
+    clear: vi.fn(),
+  },
+  STORAGE_KEYS: {},
+}));
 
 const usersClientMock = {
   initialize: vi.fn(),
@@ -25,7 +33,6 @@ const authClientMock = {
   sendUserDeactivationEmail: vi.fn(),
 };
 
-vi.spyOn(localStorageService, 'get').mockReturnValue(testToken);
 vi.mock('../../core/factory/sdk', () => ({
   SdkFactory: {
     getNewApiInstance: vi.fn(() => ({
@@ -109,7 +116,7 @@ describe('userService', () => {
   it('should send a verification email', async () => {
     usersClientMock.sendVerificationEmail.mockResolvedValue({ success: true });
     await userService.sendVerificationEmail();
-    expect(usersClientMock.sendVerificationEmail).toHaveBeenCalled();
+    expect(usersClientMock.sendVerificationEmail).toHaveBeenCalledWith(testToken);
   });
 
   it('should get public key by email', async () => {

--- a/src/app/core/components/Sidenav/Sidenav.tsx
+++ b/src/app/core/components/Sidenav/Sidenav.tsx
@@ -18,7 +18,7 @@ import { useAppSelector } from 'app/store/hooks';
 import workspacesSelectors from '../../../store/slices/workspaces/workspaces.selectors';
 import WorkspaceSelectorContainer from './WorkspaceSelectorContainer';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
-import { UserSubscription } from '@internxt/sdk/dist/drive/payments/types';
+import { UserSubscription } from '@internxt/sdk/dist/drive/payments/types/types';
 import { t } from 'i18next';
 import { Loader } from '@internxt/ui';
 import localStorageService, { STORAGE_KEYS } from '../../../core/services/local-storage.service';

--- a/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
+++ b/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
@@ -270,6 +270,7 @@ const FileViewerWrapper = ({
 
     if (isDifferentThumbnailOrNotExists && thumbnailGenerated.file) {
       const thumbnailToUpload: ThumbnailToUpload = {
+        fileUuid: driveFile.uuid,
         fileId: driveFile.id,
         size: thumbnailGenerated.file.size,
         max_width: thumbnailGenerated.max_width,

--- a/src/app/drive/services/download.service/index.ts
+++ b/src/app/drive/services/download.service/index.ts
@@ -1,15 +1,15 @@
 import downloadBackup from './downloadBackup';
 import downloadFile from './downloadFile';
 import downloadFileFromBlob from './downloadFileFromBlob';
-import downloadFolder from './downloadFolder';
 import fetchFileBlob from './fetchFileBlob';
+import downloadFolder from './downloadFolder';
 
 const downloadService = {
   fetchFileBlob,
   downloadFileFromBlob,
   downloadFile,
-  downloadFolder,
   downloadBackup,
+  downloadFolder,
 };
 
 export default downloadService;

--- a/src/app/drive/services/file.service/uploadFile.test.ts
+++ b/src/app/drive/services/file.service/uploadFile.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import uploadFile from './uploadFile';
+import { Network, getEnvironmentConfig } from '../network.service';
+import navigationService from '../../../core/services/navigation.service';
+import localStorageService from '../../../core/services/local-storage.service';
+import notificationsService from '../../../notifications/services/notifications.service';
+import { SdkFactory } from '../../../core/factory/sdk';
+import * as thumbnailService from '../thumbnail.service';
+import workspacesService from '../../../core/services/workspace.service';
+
+vi.mock('../network.service', () => ({
+  Network: vi.fn(),
+  getEnvironmentConfig: vi.fn(),
+}));
+
+vi.mock('../../../core/services/navigation.service', () => ({
+  default: {
+    push: vi.fn(),
+  },
+}));
+
+vi.mock('../../../core/services/local-storage.service', () => ({
+  default: {
+    clear: vi.fn(),
+  },
+}));
+
+vi.mock('../../../notifications/services/notifications.service', () => ({
+  default: {
+    show: vi.fn(),
+  },
+  ToastType: {
+    Warning: 'warning',
+  },
+}));
+
+vi.mock('../../../core/factory/sdk', () => ({
+  SdkFactory: {
+    getNewApiInstance: vi.fn(),
+    getInstance: vi.fn(),
+  },
+}));
+
+vi.mock('../thumbnail.service', () => ({
+  generateThumbnailFromFile: vi.fn(),
+}));
+
+vi.mock('../../../core/services/workspace.service', () => ({
+  default: {
+    createFileEntry: vi.fn(),
+  },
+}));
+
+describe('uploadFile', () => {
+  const mockFile = {
+    content: new File(['test content'], 'test.txt', { type: 'text/plain' }),
+    name: 'test.txt',
+    size: 12,
+    type: 'text/plain',
+    parentFolderId: 'parent-folder-uuid',
+  };
+
+  const mockBucketId = 'bucket-123';
+  const mockFileId = 'file-id-123';
+  const mockUserEmail = 'test@example.com';
+  const mockEnvironmentConfig = {
+    bridgeUser: 'user',
+    bridgePass: 'pass',
+    encryptionKey: 'key',
+    bucketId: mockBucketId,
+  };
+
+  const mockStorageClient = {
+    createFileEntryByUuid: vi.fn(),
+  };
+
+  const mockUpdateProgressCallback = vi.fn();
+  const mockUploadPromise = Promise.resolve(mockFileId);
+  const mockUploadAbort = { abort: vi.fn() };
+  const mockNetworkUploadFile = vi.fn().mockReturnValue([mockUploadPromise, mockUploadAbort]);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    (Network as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      uploadFile: mockNetworkUploadFile,
+    }));
+
+    (getEnvironmentConfig as ReturnType<typeof vi.fn>).mockReturnValue(mockEnvironmentConfig);
+
+    const mockNewApiInstance = {
+      createNewStorageClient: vi.fn().mockReturnValue(mockStorageClient),
+    };
+    (SdkFactory.getNewApiInstance as ReturnType<typeof vi.fn>).mockReturnValue(mockNewApiInstance);
+  });
+
+  it('should throw an error if bucketId is not found', async () => {
+    (getEnvironmentConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      ...mockEnvironmentConfig,
+      bucketId: null,
+    });
+
+    await expect(
+      uploadFile(
+        mockUserEmail,
+        mockFile,
+        mockUpdateProgressCallback,
+        { isTeam: false },
+        { taskId: 'task-id', isPaused: false, isRetriedUpload: false },
+      ),
+    ).rejects.toThrow('Bucket not found!');
+
+    expect(notificationsService.show).toHaveBeenCalled();
+    expect(localStorageService.clear).toHaveBeenCalled();
+    expect(navigationService.push).toHaveBeenCalled();
+  });
+
+  it('should upload a file and create a file entry', async () => {
+    const mockResponse = {
+      id: 123,
+      uuid: 'file-uuid-123',
+      thumbnails: [],
+    };
+    mockStorageClient.createFileEntryByUuid.mockResolvedValue(mockResponse);
+    (thumbnailService.generateThumbnailFromFile as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const result = await uploadFile(
+      mockUserEmail,
+      mockFile,
+      mockUpdateProgressCallback,
+      { isTeam: false },
+      { taskId: 'task-id', isPaused: false, isRetriedUpload: false },
+    );
+
+    expect(mockNetworkUploadFile).toHaveBeenCalledWith(
+      mockBucketId,
+      expect.objectContaining({
+        filecontent: mockFile.content,
+        filesize: mockFile.size,
+      }),
+      { taskId: 'task-id', isPaused: false, isRetriedUpload: false },
+    );
+
+    expect(mockStorageClient.createFileEntryByUuid).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: mockFileId,
+        name: mockFile.name,
+        folder_id: mockFile.parentFolderId,
+      }),
+      undefined,
+    );
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('should handle workspace file uploads', async () => {
+    const mockWorkspaceId = 'workspace-123';
+    const workspacesToken = 'workspace-token';
+    const resourcesToken = 'resources-token';
+    const mockResponse = {
+      id: 123,
+      uuid: 'file-uuid-123',
+      thumbnails: [],
+    };
+
+    (workspacesService.createFileEntry as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+    (thumbnailService.generateThumbnailFromFile as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    // For workspace uploads, we need to set the owner authentication data AND mock the environment config
+    const ownerAuthData = {
+      workspaceId: mockWorkspaceId,
+      workspacesToken,
+      resourcesToken,
+      bridgeUser: 'workspace-user',
+      bridgePass: 'workspace-pass',
+      encryptionKey: 'workspace-key',
+      bucketId: 'workspace-bucket',
+      token: 'workspace-access-token',
+    };
+
+    const result = await uploadFile(
+      mockUserEmail,
+      mockFile,
+      mockUpdateProgressCallback,
+      {
+        isTeam: false,
+        ownerUserAuthenticationData: ownerAuthData,
+      },
+      { taskId: 'task-id', isPaused: false, isRetriedUpload: false },
+    );
+
+    expect(workspacesService.createFileEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: mockFile.name,
+        fileId: mockFileId,
+        folderUuid: mockFile.parentFolderId,
+      }),
+      mockWorkspaceId,
+      resourcesToken,
+    );
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('should generate and attach a thumbnail when possible', async () => {
+    const mockFileResponse = {
+      id: 123,
+      uuid: 'file-uuid-123',
+      thumbnails: [],
+    };
+
+    const mockThumbnail = {
+      id: 'thumbnail-id',
+      bucket_id: 'bucket-id',
+      bucket_file: 'bucket-file',
+    };
+
+    const mockThumbnailFile = new File(['thumbnail content'], 'thumbnail.jpg');
+
+    mockStorageClient.createFileEntryByUuid.mockResolvedValue(mockFileResponse);
+    (thumbnailService.generateThumbnailFromFile as ReturnType<typeof vi.fn>).mockResolvedValue({
+      thumbnail: mockThumbnail,
+      thumbnailFile: mockThumbnailFile,
+    });
+
+    const result = await uploadFile(
+      mockUserEmail,
+      mockFile,
+      mockUpdateProgressCallback,
+      { isTeam: false },
+      { taskId: 'task-id', isPaused: false, isRetriedUpload: false },
+    );
+
+    expect(thumbnailService.generateThumbnailFromFile).toHaveBeenCalledWith(
+      mockFile,
+      mockFileResponse.id,
+      mockFileResponse.uuid,
+      mockUserEmail,
+      false,
+    );
+
+    expect(result.thumbnails).toContain(mockThumbnail);
+    expect(result.currentThumbnail).toBe(mockThumbnail);
+    expect(result.currentThumbnail?.urlObject).toBeDefined();
+  });
+});

--- a/src/app/drive/services/file.service/uploadFile.ts
+++ b/src/app/drive/services/file.service/uploadFile.ts
@@ -112,7 +112,13 @@ export async function uploadFile(
     };
   }
 
-  const generatedThumbnail = await generateThumbnailFromFile(file, response.id, userEmail, options.isTeam);
+  const generatedThumbnail = await generateThumbnailFromFile(
+    file,
+    response.id,
+    response.uuid,
+    userEmail,
+    options.isTeam,
+  );
   if (generatedThumbnail?.thumbnail) {
     response.thumbnails.push(generatedThumbnail.thumbnail);
     if (generatedThumbnail.thumbnailFile) {

--- a/src/app/drive/services/plan.service.ts
+++ b/src/app/drive/services/plan.service.ts
@@ -1,4 +1,4 @@
-import { StoragePlan } from '@internxt/sdk/dist/drive/payments/types';
+import { StoragePlan } from '@internxt/sdk/dist/drive/payments/types/types';
 import httpService from '../../core/services/http.service';
 import { Workspace } from '../../core/types';
 

--- a/src/app/drive/services/thumbnail.service.test.ts
+++ b/src/app/drive/services/thumbnail.service.test.ts
@@ -127,6 +127,7 @@ interface MockEnvironmentConfig {
 describe('uploadThumbnail', () => {
   const userEmail = 'test@example.com';
   const thumbnailToUpload = {
+    fileId: 1,
     fileUuid: 'uuid-123',
     size: 1024,
     max_width: 100,

--- a/src/app/drive/services/thumbnail.service.test.ts
+++ b/src/app/drive/services/thumbnail.service.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { uploadThumbnail } from './thumbnail.service';
+import { StorageTypes } from '@internxt/sdk/dist/drive';
+import { AppView } from '../../core/types';
+
+vi.mock('./network.service', () => ({
+  getEnvironmentConfig: vi.fn(),
+  MAX_ALLOWED_UPLOAD_SIZE: 40 * 1024 * 1024 * 1024, // 40GB
+  Network: class MockNetwork {
+    uploadFile = vi.fn();
+    downloadFile = vi.fn();
+    getFileInfo = vi.fn();
+  },
+}));
+
+vi.mock('app/network/upload', () => ({
+  uploadFile: vi.fn(),
+  uploadFileBlob: vi.fn(),
+}));
+
+// Mock app/store and related modules to prevent circular dependencies
+vi.mock('app/store', () => ({
+  AppDispatch: vi.fn(),
+}));
+
+vi.mock('app/store/slices/storage', () => ({
+  storageActions: {
+    patchItem: vi.fn(),
+  },
+}));
+
+vi.mock('app/store/slices/storage/storage.thunks', () => ({
+  default: {
+    createFolderThunk: vi.fn(),
+    renameItemThunk: vi.fn(),
+    moveItemsThunk: vi.fn(),
+    deleteItemsThunk: vi.fn(),
+  },
+}));
+
+vi.mock('../../notifications/services/notifications.service', () => ({
+  default: {
+    show: vi.fn(),
+  },
+  ToastType: {
+    Success: 'success',
+    Warning: 'warning',
+    Error: 'error',
+    Info: 'info',
+  },
+}));
+
+vi.mock('../../core/services/local-storage.service', () => ({
+  default: {
+    clear: vi.fn(),
+    get: vi.fn(),
+    set: vi.fn(),
+  },
+  STORAGE_KEYS: {
+    TUTORIAL_COMPLETED_ID: 'signUpTutorialCompleted',
+    B2B_WORKSPACE: 'b2bWorkspace',
+    WORKSPACE_CREDENTIALS: 'workspace_credentials',
+    FOLDER_ACCESS_TOKEN: 'folderAccessToken',
+    FILE_ACCESS_TOKEN: 'fileAccessToken',
+  },
+}));
+
+vi.mock('../../core/services/navigation.service', () => ({
+  default: {
+    push: vi.fn(),
+  },
+}));
+
+vi.mock('@internxt/sdk/dist/drive', () => ({
+  StorageTypes: {
+    EncryptionVersion: {
+      Aes03: 'AES03',
+    },
+  },
+}));
+
+vi.mock('../../core/factory/sdk', () => ({
+  SdkFactory: {
+    getNewApiInstance: vi.fn(),
+  },
+}));
+
+vi.mock('react-pdf', () => ({
+  pdfjs: {
+    getDocument: vi.fn().mockReturnValue({
+      promise: Promise.resolve({
+        getPage: vi.fn().mockResolvedValue({
+          getViewport: vi.fn().mockReturnValue({}),
+          render: vi.fn().mockReturnValue({ promise: Promise.resolve() }),
+        }),
+        destroy: vi.fn(),
+      }),
+    }),
+    GlobalWorkerOptions: { workerSrc: '' },
+  },
+}));
+
+vi.mock('react-image-file-resizer', () => ({
+  default: {
+    imageFileResizer: vi.fn(),
+  },
+}));
+
+vi.mock('./download.service/fetchFileBlob', () => ({
+  default: vi.fn(),
+}));
+
+import { getEnvironmentConfig } from './network.service';
+import * as uploadModule from 'app/network/upload';
+import { SdkFactory } from '../../core/factory/sdk';
+import localStorageService from '../../core/services/local-storage.service';
+import navigationService from '../../core/services/navigation.service';
+import notificationsService, { ToastType } from '../../notifications/services/notifications.service';
+
+interface MockEnvironmentConfig {
+  bridgeUser: string;
+  bridgePass: string;
+  encryptionKey: string;
+  bucketId: string | null;
+  useProxy: boolean;
+}
+
+describe('uploadThumbnail', () => {
+  const userEmail = 'test@example.com';
+  const thumbnailToUpload = {
+    fileId: 1,
+    fileUuid: 'uuid-123',
+    size: 1024,
+    max_width: 100,
+    max_height: 100,
+    type: 'jpeg',
+    content: new File(['dummy content'], 'thumbnail.jpg', { type: 'image/jpeg' }),
+  };
+  const isTeam = false;
+  const updateProgressCallback = vi.fn();
+  const abortController = new AbortController();
+  const mockCreateThumbnailEntryWithUUID = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.spyOn(SdkFactory, 'getNewApiInstance').mockReturnValue({
+      createNewStorageClient: vi.fn().mockReturnValue({
+        createThumbnailEntryWithUUID: mockCreateThumbnailEntryWithUUID,
+      }),
+    } as any);
+  });
+
+  it('should upload a thumbnail successfully', async () => {
+    const mockEnvConfig: MockEnvironmentConfig = {
+      bridgeUser: 'user',
+      bridgePass: 'pass',
+      encryptionKey: 'key',
+      bucketId: 'bucket-123',
+      useProxy: false,
+    };
+
+    vi.mocked(getEnvironmentConfig).mockReturnValue(mockEnvConfig as any);
+    vi.mocked(uploadModule.uploadFile).mockResolvedValue('bucket-file-id');
+    mockCreateThumbnailEntryWithUUID.mockResolvedValue({ id: 'thumbnail-id' });
+
+    const result = await uploadThumbnail(userEmail, thumbnailToUpload, isTeam, updateProgressCallback, abortController);
+
+    expect(getEnvironmentConfig).toHaveBeenCalledWith(isTeam);
+    expect(uploadModule.uploadFile).toHaveBeenCalledWith(mockEnvConfig.bucketId, {
+      creds: {
+        user: mockEnvConfig.bridgeUser,
+        pass: mockEnvConfig.bridgePass,
+      },
+      filecontent: thumbnailToUpload.content,
+      filesize: thumbnailToUpload.size,
+      mnemonic: mockEnvConfig.encryptionKey,
+      progressCallback: expect.any(Function),
+      abortController,
+    });
+    expect(mockCreateThumbnailEntryWithUUID).toHaveBeenCalledWith({
+      fileId: thumbnailToUpload.fileId,
+      fileUuid: thumbnailToUpload.fileUuid,
+      maxWidth: thumbnailToUpload.max_width,
+      maxHeight: thumbnailToUpload.max_height,
+      type: thumbnailToUpload.type,
+      size: thumbnailToUpload.size,
+      bucketId: mockEnvConfig.bucketId,
+      bucketFile: 'bucket-file-id',
+      encryptVersion: StorageTypes.EncryptionVersion.Aes03,
+    });
+    expect(result).toEqual({ id: 'thumbnail-id' });
+    expect(notificationsService.show).not.toHaveBeenCalled();
+    expect(localStorageService.clear).not.toHaveBeenCalled();
+    expect(navigationService.push).not.toHaveBeenCalled();
+  });
+
+  it('should throw an error and show notification if bucketId is not found', async () => {
+    const mockEnvConfig: MockEnvironmentConfig = {
+      bridgeUser: 'user',
+      bridgePass: 'pass',
+      encryptionKey: 'key',
+      bucketId: null,
+      useProxy: false,
+    };
+
+    vi.mocked(getEnvironmentConfig).mockReturnValue(mockEnvConfig as any);
+
+    await expect(
+      uploadThumbnail(userEmail, thumbnailToUpload, isTeam, updateProgressCallback, abortController),
+    ).rejects.toThrow('Bucket not found!');
+
+    expect(getEnvironmentConfig).toHaveBeenCalledWith(isTeam);
+    expect(notificationsService.show).toHaveBeenCalledWith({
+      text: 'Login again to start uploading files',
+      type: ToastType.Warning,
+    });
+    expect(localStorageService.clear).toHaveBeenCalled();
+    expect(navigationService.push).toHaveBeenCalledWith(AppView.Login);
+    expect(uploadModule.uploadFile).not.toHaveBeenCalled();
+    expect(mockCreateThumbnailEntryWithUUID).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/drive/services/thumbnail.service.test.ts
+++ b/src/app/drive/services/thumbnail.service.test.ts
@@ -18,7 +18,6 @@ vi.mock('app/network/upload', () => ({
   uploadFileBlob: vi.fn(),
 }));
 
-// Mock app/store and related modules to prevent circular dependencies
 vi.mock('app/store', () => ({
   AppDispatch: vi.fn(),
 }));
@@ -128,7 +127,6 @@ interface MockEnvironmentConfig {
 describe('uploadThumbnail', () => {
   const userEmail = 'test@example.com';
   const thumbnailToUpload = {
-    fileId: 1,
     fileUuid: 'uuid-123',
     size: 1024,
     max_width: 100,
@@ -179,7 +177,6 @@ describe('uploadThumbnail', () => {
       abortController,
     });
     expect(mockCreateThumbnailEntryWithUUID).toHaveBeenCalledWith({
-      fileId: thumbnailToUpload.fileId,
       fileUuid: thumbnailToUpload.fileUuid,
       maxWidth: thumbnailToUpload.max_width,
       maxHeight: thumbnailToUpload.max_height,

--- a/src/app/drive/services/thumbnail.service.ts
+++ b/src/app/drive/services/thumbnail.service.ts
@@ -134,7 +134,6 @@ export const uploadThumbnail = async (
   const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
 
   const thumbnailEntry: StorageTypes.CreateThumbnailEntryPayload = {
-    fileId: thumbnailToUpload.fileId,
     fileUuid: thumbnailToUpload.fileUuid,
     maxWidth: thumbnailToUpload.max_width,
     maxHeight: thumbnailToUpload.max_height,

--- a/src/app/drive/services/thumbnail.service.ts
+++ b/src/app/drive/services/thumbnail.service.ts
@@ -24,6 +24,7 @@ import { FileToUpload } from './file.service/types';
 
 export interface ThumbnailToUpload {
   fileId: number;
+  fileUuid: string;
   size: number;
   max_width: number;
   max_height: number;
@@ -130,19 +131,21 @@ export const uploadThumbnail = async (
     abortController,
   });
 
-  const storageClient = SdkFactory.getInstance().createStorageClient();
-  const thumbnailEntry: StorageTypes.ThumbnailEntry = {
-    file_id: thumbnailToUpload.fileId,
-    max_width: thumbnailToUpload.max_width,
-    max_height: thumbnailToUpload.max_height,
+  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+
+  const thumbnailEntry: StorageTypes.CreateThumbnailEntryPayload = {
+    fileId: thumbnailToUpload.fileId,
+    fileUuid: thumbnailToUpload.fileUuid,
+    maxWidth: thumbnailToUpload.max_width,
+    maxHeight: thumbnailToUpload.max_height,
     type: thumbnailToUpload.type,
     size: thumbnailToUpload.size,
-    bucket_id: bucketId,
-    bucket_file: bucketFile,
-    encrypt_version: StorageTypes.EncryptionVersion.Aes03,
+    bucketId: bucketId,
+    bucketFile: bucketFile,
+    encryptVersion: StorageTypes.EncryptionVersion.Aes03,
   };
 
-  return await storageClient.createThumbnailEntry(thumbnailEntry);
+  return await storageClient.createThumbnailEntryWithUUID(thumbnailEntry);
 };
 
 /**
@@ -177,6 +180,7 @@ export const getThumbnailFrom = async (fileToUpload: FileToUpload): Promise<Thum
 export const generateThumbnailFromFile = async (
   fileToUpload: FileToUpload,
   fileId: number,
+  fileUuid: string,
   userEmail: string,
   isTeam: boolean,
 ): Promise<{ thumbnail: Thumbnail; thumbnailFile: File } | null> => {
@@ -188,6 +192,7 @@ export const generateThumbnailFromFile = async (
       if (thumbnail.file) {
         const thumbnailToUpload: ThumbnailToUpload = {
           fileId: fileId,
+          fileUuid: fileUuid,
           size: thumbnail.file.size,
           max_width: thumbnail.max_width,
           max_height: thumbnail.max_height,

--- a/src/app/drive/types/index.ts
+++ b/src/app/drive/types/index.ts
@@ -1,4 +1,4 @@
-import { RenewalPeriod } from '@internxt/sdk/dist/drive/payments/types';
+import { RenewalPeriod } from '@internxt/sdk/dist/drive/payments/types/types';
 import { ShareLink } from '@internxt/sdk/dist/drive/share/types';
 import { UserResumeData } from '@internxt/sdk/dist/drive/users/types';
 import { AppSumoDetails } from '@internxt/sdk/dist/shared/types/appsumo';

--- a/src/app/newSettings/Sections/Account/Billing/BillingAccountSection.tsx
+++ b/src/app/newSettings/Sections/Account/Billing/BillingAccountSection.tsx
@@ -11,7 +11,7 @@ import BillingPaymentMethodCard from '../../../components/BillingPaymentMethodCa
 import Invoices from '../../../containers/InvoicesContainer';
 import CancelSubscription from './components/CancelSubscription';
 import BillingAccountOverview from './containers/BillingAccountOverview';
-import { UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import { getCurrentUsage, getPlanInfo, getPlanName } from '../Plans/utils/planUtils';
 
 interface BillingAccountSectionProps {

--- a/src/app/newSettings/Sections/Account/Billing/components/CancelSubscription.tsx
+++ b/src/app/newSettings/Sections/Account/Billing/components/CancelSubscription.tsx
@@ -1,7 +1,7 @@
 import { t } from 'i18next';
 import { Button } from '@internxt/ui';
 import CancelSubscriptionModal from '../../../Workspace/Billing/CancelSubscriptionModal';
-import { UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 
 interface CancelSubscriptionProps {
   isCancelSubscriptionModalOpen: boolean;

--- a/src/app/newSettings/Sections/Account/Plans/PlansSection.tsx
+++ b/src/app/newSettings/Sections/Account/Plans/PlansSection.tsx
@@ -1,4 +1,4 @@
-import { DisplayPrice, UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { DisplayPrice, UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import { AppView } from 'app/core/types';
 import Section from 'app/newSettings/components/Section';

--- a/src/app/newSettings/Sections/Account/Plans/api/plansApi.ts
+++ b/src/app/newSettings/Sections/Account/Plans/api/plansApi.ts
@@ -2,7 +2,7 @@ import { Stripe, loadStripe } from '@stripe/stripe-js';
 import envService from '../../../../../core/services/env.service';
 import errorService from '../../../../../core/services/error.service';
 import paymentService from '../../../../../payment/services/payment.service';
-import { UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 
 const COUNTRY_API = process.env.REACT_APP_COUNTRY_API_URL;
 const productValue = {

--- a/src/app/newSettings/Sections/Account/Plans/components/ChangePlanDialog.tsx
+++ b/src/app/newSettings/Sections/Account/Plans/components/ChangePlanDialog.tsx
@@ -1,4 +1,4 @@
-import { DisplayPrice, UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { DisplayPrice, UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import { ArrowRight } from '@phosphor-icons/react';
 import { useSelector } from 'react-redux';
 import { bytesToString } from '../../../../../drive/services/size.service';

--- a/src/app/newSettings/Sections/Account/Plans/components/PlanSelection/InfoCardComponent.tsx
+++ b/src/app/newSettings/Sections/Account/Plans/components/PlanSelection/InfoCardComponent.tsx
@@ -1,4 +1,4 @@
-import { DisplayPrice } from '@internxt/sdk/dist/drive/payments/types';
+import { DisplayPrice } from '@internxt/sdk/dist/drive/payments/types/types';
 import PlanCard, { ChangePlanType } from '../PlanCard';
 import { bytesToString } from 'app/drive/services/size.service';
 import currencyService from 'app/payment/services/currency.service';

--- a/src/app/newSettings/Sections/Account/Plans/components/PlanSelection/PlanSelectionComponent.tsx
+++ b/src/app/newSettings/Sections/Account/Plans/components/PlanSelection/PlanSelectionComponent.tsx
@@ -1,4 +1,4 @@
-import { DisplayPrice, UserSubscription } from '@internxt/sdk/dist/drive/payments/types';
+import { DisplayPrice, UserSubscription } from '@internxt/sdk/dist/drive/payments/types/types';
 import PlanSelectionCard from './PlanSelectionCard';
 import { bytesToString } from 'app/drive/services/size.service';
 import { displayAmount } from '../../utils/planUtils';

--- a/src/app/newSettings/Sections/Account/Plans/utils/planUtils.ts
+++ b/src/app/newSettings/Sections/Account/Plans/utils/planUtils.ts
@@ -1,4 +1,9 @@
-import { DisplayPrice, RenewalPeriod, StoragePlan, UserSubscription } from '@internxt/sdk/dist/drive/payments/types';
+import {
+  DisplayPrice,
+  RenewalPeriod,
+  StoragePlan,
+  UserSubscription,
+} from '@internxt/sdk/dist/drive/payments/types/types';
 import { UsageResponse } from '@internxt/sdk/dist/drive/storage/types';
 import { bytesToString } from 'app/drive/services/size.service';
 import { t } from 'i18next';

--- a/src/app/newSettings/Sections/Workspace/Billing/BillingWorkspaceSection.tsx
+++ b/src/app/newSettings/Sections/Workspace/Billing/BillingWorkspaceSection.tsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from 'app/store';
 import { PlanState, planThunks } from 'app/store/slices/plan';
 
-import { CustomerBillingInfo, UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { CustomerBillingInfo, UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
 import Section from 'app/newSettings/components/Section';
 import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';

--- a/src/app/newSettings/Sections/Workspace/Billing/CancelSubscriptionModal.tsx
+++ b/src/app/newSettings/Sections/Workspace/Billing/CancelSubscriptionModal.tsx
@@ -1,4 +1,4 @@
-import { UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import { ArrowRight } from '@phosphor-icons/react';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import sizeService from '../../../../drive/services/size.service';

--- a/src/app/newSettings/Sections/Workspace/Billing/components/EditBillingDetailsModal.tsx
+++ b/src/app/newSettings/Sections/Workspace/Billing/components/EditBillingDetailsModal.tsx
@@ -1,7 +1,7 @@
 import { t } from 'i18next';
 import { useState } from 'react';
 
-import { CustomerBillingInfo } from '@internxt/sdk/dist/drive/payments/types';
+import { CustomerBillingInfo } from '@internxt/sdk/dist/drive/payments/types/types';
 import { Button, Modal } from '@internxt/ui';
 
 import { PhoneInput } from 'react-international-phone';

--- a/src/app/newSettings/Sections/Workspace/Billing/components/EditPaymentMethodModal.tsx
+++ b/src/app/newSettings/Sections/Workspace/Billing/components/EditPaymentMethodModal.tsx
@@ -7,7 +7,7 @@ import paymentService from 'app/payment/services/payment.service';
 import useEffectAsync from 'app/core/hooks/useEffectAsync';
 
 import EditPaymentMethodForm from './EditPaymentMethodForm';
-import { UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import { Loader, Modal } from '@internxt/ui';
 
 interface EditPaymentMethodModalProps {

--- a/src/app/newSettings/Sections/Workspace/Billing/components/UpdateMembers/ConfirmUpdatedMembersModal.tsx
+++ b/src/app/newSettings/Sections/Workspace/Billing/components/UpdateMembers/ConfirmUpdatedMembersModal.tsx
@@ -1,5 +1,5 @@
 import { Button, Modal } from '@internxt/ui';
-import { StoragePlan } from '@internxt/sdk/dist/drive/payments/types';
+import { StoragePlan } from '@internxt/sdk/dist/drive/payments/types/types';
 import { ArrowRight } from '@phosphor-icons/react';
 import { bytesToString } from 'app/drive/services/size.service';
 import { Translate } from 'app/i18n/types';

--- a/src/app/newSettings/Sections/Workspace/Billing/components/UpdateMembers/SelectNewMembersModal.tsx
+++ b/src/app/newSettings/Sections/Workspace/Billing/components/UpdateMembers/SelectNewMembersModal.tsx
@@ -1,7 +1,7 @@
 import { Button, RangeSlider, Modal } from '@internxt/ui';
 import { X } from '@phosphor-icons/react';
 import { Translate } from '../../../../../../i18n/types';
-import { StoragePlan } from '@internxt/sdk/dist/drive/payments/types';
+import { StoragePlan } from '@internxt/sdk/dist/drive/payments/types/types';
 
 interface SeatsProps {
   minimumAllowedSeats: number;

--- a/src/app/newSettings/Sections/Workspace/Billing/containers/BillingWorkspaceOverview.tsx
+++ b/src/app/newSettings/Sections/Workspace/Billing/containers/BillingWorkspaceOverview.tsx
@@ -5,7 +5,7 @@ import { bytesToString } from '../../../../../drive/services/size.service';
 
 import Card from 'app/shared/components/Card';
 
-import { UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import { PlanState } from 'app/store/slices/plan';
 import { getNextBillingDate, getSubscriptionData } from '../../../../utils/suscriptionUtils';
 

--- a/src/app/newSettings/Sections/Workspace/Overview/OverviewSection.tsx
+++ b/src/app/newSettings/Sections/Workspace/Overview/OverviewSection.tsx
@@ -1,4 +1,4 @@
-import { UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import { WorkspaceTeam, WorkspaceUser } from '@internxt/sdk/dist/workspaces';
 import { PencilSimple } from '@phosphor-icons/react';
 import { t } from 'i18next';

--- a/src/app/newSettings/components/BillingPaymentMethodCard.tsx
+++ b/src/app/newSettings/components/BillingPaymentMethodCard.tsx
@@ -1,4 +1,4 @@
-import { PaymentMethod, UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { PaymentMethod, UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import { Button, Loader } from '@internxt/ui';
 import Card from 'app/shared/components/Card';
 import { t } from 'i18next';

--- a/src/app/newSettings/components/Invoices/InvoicesList.tsx
+++ b/src/app/newSettings/components/Invoices/InvoicesList.tsx
@@ -1,4 +1,4 @@
-import { Invoice } from '@internxt/sdk/dist/drive/payments/types';
+import { Invoice } from '@internxt/sdk/dist/drive/payments/types/types';
 import { DownloadSimple } from '@phosphor-icons/react';
 import { useState } from 'react';
 import dateService from '../../../core/services/date.service';

--- a/src/app/newSettings/containers/InvoicesContainer.tsx
+++ b/src/app/newSettings/containers/InvoicesContainer.tsx
@@ -1,4 +1,4 @@
-import { Invoice, UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { Invoice, UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import { useTranslationContext } from '../../i18n/provider/TranslationProvider';
 import Section from '../Sections/General/components/Section';
 import Card from '../../shared/components/Card';

--- a/src/app/newSettings/hooks/useDefaultPaymentMethod.tsx
+++ b/src/app/newSettings/hooks/useDefaultPaymentMethod.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { PaymentMethod, UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { PaymentMethod, UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import { Source } from '@stripe/stripe-js';
 
 import paymentService from 'app/payment/services/payment.service';

--- a/src/app/newSettings/utils/suscriptionUtils.ts
+++ b/src/app/newSettings/utils/suscriptionUtils.ts
@@ -1,4 +1,4 @@
-import { StoragePlan, UserSubscription, UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { StoragePlan, UserSubscription, UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import dateService from 'app/core/services/date.service';
 import { t } from 'i18next';
 import moneyService from '../../payment/services/currency.service';

--- a/src/app/payment/components/checkout/CheckoutProductCard.tsx
+++ b/src/app/payment/components/checkout/CheckoutProductCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Switch, Transition } from '@headlessui/react';
-import { UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import { Check, SealPercent, X } from '@phosphor-icons/react';
 
 import { bytesToString } from '../../../drive/services/size.service';

--- a/src/app/payment/services/checkout.service.ts
+++ b/src/app/payment/services/checkout.service.ts
@@ -1,4 +1,4 @@
-import { DisplayPrice, UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { DisplayPrice, UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import { StripeElementsOptions } from '@stripe/stripe-js';
 import paymentService from '../../payment/services/payment.service';
 import { ClientSecretData, CouponCodeData, PlanData, RequestedPlanData } from '../types';

--- a/src/app/payment/services/payment.service.ts
+++ b/src/app/payment/services/payment.service.ts
@@ -9,7 +9,7 @@ import {
   RedeemCodePayload,
   UserSubscription,
   UserType,
-} from '@internxt/sdk/dist/drive/payments/types';
+} from '@internxt/sdk/dist/drive/payments/types/types';
 import { RedirectToCheckoutServerOptions, Source, Stripe, StripeError } from '@stripe/stripe-js';
 import { loadStripe } from '@stripe/stripe-js/pure';
 import axios from 'axios';

--- a/src/app/payment/store/types.ts
+++ b/src/app/payment/store/types.ts
@@ -1,4 +1,4 @@
-import { DisplayPrice } from '@internxt/sdk/dist/drive/payments/types';
+import { DisplayPrice } from '@internxt/sdk/dist/drive/payments/types/types';
 import { AuthMethodTypes, CouponCodeData, PartialErrorState, PlanData, RequestedPlanData } from '../types';
 import { StripeElementsOptions } from '@stripe/stripe-js';
 

--- a/src/app/payment/types.ts
+++ b/src/app/payment/types.ts
@@ -1,4 +1,4 @@
-import { DisplayPrice, UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { DisplayPrice, UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 
 export enum Currency {
   'eur' = '€',

--- a/src/app/payment/utils/getProductAmount.ts
+++ b/src/app/payment/utils/getProductAmount.ts
@@ -1,4 +1,4 @@
-import { DisplayPrice } from '@internxt/sdk/dist/drive/payments/types';
+import { DisplayPrice } from '@internxt/sdk/dist/drive/payments/types/types';
 import { CouponCodeData } from '../types';
 
 export const getProductAmount = (

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutView.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutView.tsx
@@ -12,7 +12,7 @@ import { CheckoutViewManager, UpsellManagerProps, UserInfoProps } from './Checko
 import { State } from 'app/payment/store/types';
 import { LegacyRef } from 'react';
 import { OptionalB2BDropdown } from 'app/payment/components/checkout/OptionalB2BDropdown';
-import { UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 
 export const PAYMENT_ELEMENT_OPTIONS: StripePaymentElementOptions = {
   wallets: {

--- a/src/app/store/slices/plan/index.ts
+++ b/src/app/store/slices/plan/index.ts
@@ -1,6 +1,6 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { StoragePlan, UserSubscription, UserType } from '@internxt/sdk/dist/drive/payments/types';
+import { StoragePlan, UserSubscription, UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import { UsageResponse } from '@internxt/sdk/dist/drive/storage/types';
 import { GetMemberUsageResponse } from '@internxt/sdk/dist/workspaces';
 import workspacesService from 'app/core/services/workspace.service';

--- a/src/hooks/checkout/useCheckout.ts
+++ b/src/hooks/checkout/useCheckout.ts
@@ -2,7 +2,7 @@ import { Dispatch } from 'react';
 import { Action } from 'app/payment/store/types';
 import { AuthMethodTypes, CouponCodeData, ErrorType, PlanData } from 'app/payment/types';
 import { StripeElementsOptions } from '@stripe/stripe-js';
-import { DisplayPrice } from '@internxt/sdk/dist/drive/payments/types';
+import { DisplayPrice } from '@internxt/sdk/dist/drive/payments/types/types';
 
 export const useCheckout = (dispatchReducer: Dispatch<Action>) => {
   const setUserNameFromElementAddress = (userName: string) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2750,10 +2750,10 @@
   resolved "https://npm.pkg.github.com/download/@internxt/prettier-config/1.0.2/5bd220b8de76734448db5475b3e0c01f9d22c19b#5bd220b8de76734448db5475b3e0c01f9d22c19b"
   integrity sha512-t4HiqvCbC7XgQepwWlIaFJe3iwW7HCf6xOSU9nKTV0tiGqOPz7xMtIgLEloQrDA34Cx4PkOYBXrvFPV6RxSFAA==
 
-"@internxt/sdk@=1.9.15":
-  version "1.9.15"
-  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.9.15/2532058881950181e231417a7f6f8612b9b89958#2532058881950181e231417a7f6f8612b9b89958"
-  integrity sha512-XmR4vYuQk8CKCHdjP92qkAhlSHA0BZNDtFGSeYD+UIDnNdGEgs2pV8h1txmUiO9rlTbA5pGlbU0RFo8jxyLRHw==
+"@internxt/sdk@=1.9.18":
+  version "1.9.18"
+  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.9.18/80e44cbc5f99b048787276afbb1b497a3c5d8bf6#80e44cbc5f99b048787276afbb1b497a3c5d8bf6"
+  integrity sha512-KCDq+2jrtedtdlce7MITlAfHAdu+V/ElqSNV7mZx5djWaQ0F1JtXnE/c6sT429J2e+Dt8C+nQgCzVVHgvNmmlQ==
   dependencies:
     axios "^0.24.0"
     query-string "^7.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2750,10 +2750,10 @@
   resolved "https://npm.pkg.github.com/download/@internxt/prettier-config/1.0.2/5bd220b8de76734448db5475b3e0c01f9d22c19b#5bd220b8de76734448db5475b3e0c01f9d22c19b"
   integrity sha512-t4HiqvCbC7XgQepwWlIaFJe3iwW7HCf6xOSU9nKTV0tiGqOPz7xMtIgLEloQrDA34Cx4PkOYBXrvFPV6RxSFAA==
 
-"@internxt/sdk@=1.9.9":
-  version "1.9.9"
-  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.9.9/41aaf713bfa85688a09bcfce35814b831389b9be#41aaf713bfa85688a09bcfce35814b831389b9be"
-  integrity sha512-3bhC/WBunAeGLpexEOj84xgZbznwDdTripoLj/fmnPEKW4PpCGP0tS7f58IMDSMkpPMhB6wTSMAXXLW9LfQNNg==
+"@internxt/sdk@=1.9.15":
+  version "1.9.15"
+  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.9.15/2532058881950181e231417a7f6f8612b9b89958#2532058881950181e231417a7f6f8612b9b89958"
+  integrity sha512-XmR4vYuQk8CKCHdjP92qkAhlSHA0BZNDtFGSeYD+UIDnNdGEgs2pV8h1txmUiO9rlTbA5pGlbU0RFo8jxyLRHw==
   dependencies:
     axios "^0.24.0"
     query-string "^7.1.0"


### PR DESCRIPTION
## Description

Migrate the create thumbnail endpoint to use the new endpoint exposed in drive-server-wip

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

#internxt/sdk/pull/286
#internxt/drive-server-wip/pull/543

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## How Has This Been Tested?

Uploaded various images and pdfs in both a personal drive and business workspace and verified the thumbnails were being successfully created.

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
