### PR TITLE
[_]:fix/ Add logic to handle closing of banner for free users

### DIFF
--- a/src/app/banners/BannerManager.ts
+++ b/src/app/banners/BannerManager.ts
@@ -67,11 +67,9 @@ export class BannerManager {
     };
   }
 
-  public onCloseBanner(): void {
-    localStorageService.set(BANNER_NAME_IN_LOCAL_STORAGE, this.todayDate);
-  }
+  public onCloseBanner(type: 'free' | 'subscription'): void {
+    const key = type === 'free' ? BANNER_NAME_FOR_FREE_USERS : BANNER_NAME_IN_LOCAL_STORAGE;
 
-  public onCloseFreeBanner(): void {
-    localStorageService.set(BANNER_NAME_FOR_FREE_USERS, this.todayDate);
+    localStorageService.set(key, this.todayDate);
   }
 }

--- a/src/app/banners/BannerManager.ts
+++ b/src/app/banners/BannerManager.ts
@@ -70,4 +70,8 @@ export class BannerManager {
   public onCloseBanner(): void {
     localStorageService.set(BANNER_NAME_IN_LOCAL_STORAGE, this.todayDate);
   }
+
+  public onCloseFreeBanner(): void {
+    localStorageService.set(BANNER_NAME_FOR_FREE_USERS, this.todayDate);
+  }
 }

--- a/src/app/banners/BannerWrapper.tsx
+++ b/src/app/banners/BannerWrapper.tsx
@@ -34,9 +34,16 @@ const BannerWrapper = (): JSX.Element => {
     setBannersToShow((prev) => ({ ...prev, [bannerKey]: false }));
   };
 
+  const onCloseFreeBanner = (bannerKey: keyof typeof bannersToShow) => {
+    bannerManager.onCloseFreeBanner();
+    setBannersToShow((prev) => ({ ...prev, [bannerKey]: false }));
+  };
+
   return (
     <>
-      {bannersToShow.showFreeBanner && <FeaturesBanner showBanner onClose={() => onCloseBanner('showFreeBanner')} />}
+      {bannersToShow.showFreeBanner && (
+        <FeaturesBanner showBanner onClose={() => onCloseFreeBanner('showFreeBanner')} />
+      )}
       {bannersToShow.showSubscriptionBanner && (
         <SubscriptionBanner
           showBanner

--- a/src/app/banners/BannerWrapper.tsx
+++ b/src/app/banners/BannerWrapper.tsx
@@ -30,20 +30,14 @@ const BannerWrapper = (): JSX.Element => {
   }, [bannerManager]);
 
   const onCloseBanner = (bannerKey: keyof typeof bannersToShow) => {
-    bannerManager.onCloseBanner();
-    setBannersToShow((prev) => ({ ...prev, [bannerKey]: false }));
-  };
-
-  const onCloseFreeBanner = (bannerKey: keyof typeof bannersToShow) => {
-    bannerManager.onCloseFreeBanner();
+    const type = bannerKey === 'showFreeBanner' ? 'free' : 'subscription';
+    bannerManager.onCloseBanner(type);
     setBannersToShow((prev) => ({ ...prev, [bannerKey]: false }));
   };
 
   return (
     <>
-      {bannersToShow.showFreeBanner && (
-        <FeaturesBanner showBanner onClose={() => onCloseFreeBanner('showFreeBanner')} />
-      )}
+      {bannersToShow.showFreeBanner && <FeaturesBanner showBanner onClose={() => onCloseBanner('showFreeBanner')} />}
       {bannersToShow.showSubscriptionBanner && (
         <SubscriptionBanner
           showBanner

--- a/src/app/banners/BannerWrapper.tsx
+++ b/src/app/banners/BannerWrapper.tsx
@@ -19,7 +19,15 @@ const BannerWrapper = (): JSX.Element => {
 
   const bannerManager = useMemo(() => new BannerManager(user, plan, OFFER_END_DAY), [user, plan, isNewAccount]);
 
-  const [bannersToShow, setBannersToShow] = useState({ showFreeBanner: false, showSubscriptionBanner: false });
+  const [bannersToShow, setBannersToShow] = useState({
+    showFreeBanner: false,
+    showSubscriptionBanner: false,
+  });
+
+  const bannerKeyMap: Record<keyof typeof bannersToShow, string> = {
+    showFreeBanner: 'show_free_users_banner',
+    showSubscriptionBanner: 'show_banner',
+  };
 
   useEffect(() => {
     const newBanners = bannerManager.getBannersToShow();
@@ -30,8 +38,8 @@ const BannerWrapper = (): JSX.Element => {
   }, [bannerManager]);
 
   const onCloseBanner = (bannerKey: keyof typeof bannersToShow) => {
-    const type = bannerKey === 'showFreeBanner' ? 'free' : 'subscription';
-    bannerManager.onCloseBanner(type);
+    const localStorageKey = bannerKeyMap[bannerKey];
+    bannerManager.onCloseBannerByKey(localStorageKey);
     setBannersToShow((prev) => ({ ...prev, [bannerKey]: false }));
   };
 

--- a/src/app/payment/utils/checkStarWarsCode.test.ts
+++ b/src/app/payment/utils/checkStarWarsCode.test.ts
@@ -4,6 +4,7 @@ import localStorageService from 'app/core/services/local-storage.service';
 import paymentService from '../services/payment.service';
 import errorService from 'app/core/services/error.service';
 
+// Mocks reforzados
 vi.mock('app/core/services/local-storage.service', async () => {
   const actual = await vi.importActual<typeof import('app/core/services/local-storage.service')>(
     'app/core/services/local-storage.service',
@@ -43,7 +44,12 @@ describe('isStarWarsThemeAvailable', () => {
   it('returns true and sets localStorage if coupon is used for subscription', async () => {
     (localStorageService.get as Mock).mockReturnValue(undefined);
     (paymentService.isCouponUsedByUser as any).mockResolvedValue({ couponUsed: true });
-    const plan = { ...planBase, individualSubscription: { type: 'subscription' } };
+
+    const plan = {
+      individualSubscription: { type: 'subscription' },
+      businessSubscription: null,
+    };
+
     const onSuccess = vi.fn().mockResolvedValue(() => Promise.resolve());
 
     const result = await isStarWarsThemeAvailable(plan as any, onSuccess);
@@ -56,7 +62,11 @@ describe('isStarWarsThemeAvailable', () => {
   it('returns false if coupon is not used for subscription', async () => {
     (localStorageService.get as Mock).mockReturnValue(undefined);
     (paymentService.isCouponUsedByUser as any).mockResolvedValue({ couponUsed: false });
-    const plan = { ...planBase, businessSubscription: { type: 'subscription' } };
+
+    const plan = {
+      individualSubscription: null,
+      businessSubscription: { type: 'subscription' },
+    };
 
     const result = await isStarWarsThemeAvailable(plan as any);
 
@@ -67,7 +77,12 @@ describe('isStarWarsThemeAvailable', () => {
   it('returns true and sets localStorage if coupon is used for lifetime', async () => {
     (localStorageService.get as Mock).mockReturnValue(undefined);
     (paymentService.isCouponUsedByUser as any).mockResolvedValue({ couponUsed: true });
-    const plan = { ...planBase, individualSubscription: { type: 'lifetime' } };
+
+    const plan = {
+      individualSubscription: { type: 'lifetime' },
+      businessSubscription: null,
+    };
+
     const onSuccess = vi.fn().mockResolvedValue(() => Promise.resolve());
 
     const result = await isStarWarsThemeAvailable(plan as any, onSuccess);
@@ -80,7 +95,11 @@ describe('isStarWarsThemeAvailable', () => {
   it('returns false if coupon is not used for lifetime', async () => {
     (localStorageService.get as Mock).mockReturnValue(undefined);
     (paymentService.isCouponUsedByUser as any).mockResolvedValue({ couponUsed: false });
-    const plan = { ...planBase, businessSubscription: { type: 'lifetime' } };
+
+    const plan = {
+      individualSubscription: null,
+      businessSubscription: { type: 'lifetime' },
+    };
 
     const result = await isStarWarsThemeAvailable(plan as any);
 
@@ -91,7 +110,11 @@ describe('isStarWarsThemeAvailable', () => {
   it('calls errorService.reportError and returns false on error', async () => {
     (localStorageService.get as Mock).mockReturnValue(undefined);
     (paymentService.isCouponUsedByUser as any).mockRejectedValue(new Error('fail'));
-    const plan = { ...planBase, individualSubscription: { type: 'subscription' } };
+
+    const plan = {
+      individualSubscription: { type: 'subscription' },
+      businessSubscription: null,
+    };
 
     const result = await isStarWarsThemeAvailable(plan as any);
 
@@ -101,7 +124,11 @@ describe('isStarWarsThemeAvailable', () => {
 
   it('returns false if no subscription or lifetime', async () => {
     (localStorageService.get as Mock).mockReturnValue(undefined);
-    const plan = { ...planBase };
+
+    const plan = {
+      individualSubscription: null,
+      businessSubscription: null,
+    };
 
     const result = await isStarWarsThemeAvailable(plan as any);
 


### PR DESCRIPTION
## Description
- Added `onCloseFreeBanner` method to `BannerManager` to store close date for free user banners.
- Updated `BannerWrapper` to support `onCloseFreeBanner` as separate handler.

This enables better control and tracking of banners shown to free users.
## Related Issues
Addressing customer complaints regarding excessive banner frequency
<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [ ] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
