### PR TITLE
[PB-4474]: feat/migrate-thumbnail-endpoint

### DIFF
--- a/src/app/core/factory/sdk/index.ts
+++ b/src/app/core/factory/sdk/index.ts
@@ -63,7 +63,7 @@ export class SdkFactory {
   public createStorageClient(): Storage {
     const apiUrl = this.getApiUrl();
     const appDetails = SdkFactory.getAppDetails();
-    const apiSecurity = this.getApiSecurity();
+    const apiSecurity = this.getNewApiSecurity();
     return Storage.client(apiUrl, appDetails, apiSecurity);
   }
 

--- a/src/app/core/factory/sdk/index.ts
+++ b/src/app/core/factory/sdk/index.ts
@@ -63,7 +63,7 @@ export class SdkFactory {
   public createStorageClient(): Storage {
     const apiUrl = this.getApiUrl();
     const appDetails = SdkFactory.getAppDetails();
-    const apiSecurity = this.getNewApiSecurity();
+    const apiSecurity = this.getApiSecurity();
     return Storage.client(apiUrl, appDetails, apiSecurity);
   }
 

--- a/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
+++ b/src/app/drive/components/FileViewer/FileViewerWrapper.tsx
@@ -270,7 +270,7 @@ const FileViewerWrapper = ({
 
     if (isDifferentThumbnailOrNotExists && thumbnailGenerated.file) {
       const thumbnailToUpload: ThumbnailToUpload = {
-        fileId: driveFile.id,
+        fileId: driveFile.uuid,
         size: thumbnailGenerated.file.size,
         max_width: thumbnailGenerated.max_width,
         max_height: thumbnailGenerated.max_height,

--- a/src/app/drive/services/file.service/uploadFile.ts
+++ b/src/app/drive/services/file.service/uploadFile.ts
@@ -112,7 +112,7 @@ export async function uploadFile(
     };
   }
 
-  const generatedThumbnail = await generateThumbnailFromFile(file, response.id, userEmail, options.isTeam);
+  const generatedThumbnail = await generateThumbnailFromFile(file, response.uuid, userEmail, options.isTeam);
   if (generatedThumbnail?.thumbnail) {
     response.thumbnails.push(generatedThumbnail.thumbnail);
     if (generatedThumbnail.thumbnailFile) {

--- a/src/app/drive/services/thumbnail.service.ts
+++ b/src/app/drive/services/thumbnail.service.ts
@@ -23,7 +23,7 @@ import { getEnvironmentConfig } from './network.service';
 import { FileToUpload } from './file.service/types';
 
 export interface ThumbnailToUpload {
-  fileId: number;
+  fileId: string;
   size: number;
   max_width: number;
   max_height: number;
@@ -130,19 +130,19 @@ export const uploadThumbnail = async (
     abortController,
   });
 
-  const storageClient = SdkFactory.getInstance().createStorageClient();
-  const thumbnailEntry: StorageTypes.ThumbnailEntry = {
-    file_id: thumbnailToUpload.fileId,
-    max_width: thumbnailToUpload.max_width,
-    max_height: thumbnailToUpload.max_height,
-    type: thumbnailToUpload.type,
+  const storageClient = SdkFactory.getNewApiInstance().createStorageClient();
+  const thumbnailEntry: StorageTypes.CreateThumbnailEntryPayload = {
+    bucketFile,
+    bucketId,
+    encryptVersion: StorageTypes.EncryptionVersion.Aes03,
+    fileUuid: thumbnailToUpload.fileId,
+    maxHeight: thumbnailToUpload.max_height,
+    maxWidth: thumbnailToUpload.max_width,
     size: thumbnailToUpload.size,
-    bucket_id: bucketId,
-    bucket_file: bucketFile,
-    encrypt_version: StorageTypes.EncryptionVersion.Aes03,
+    type: thumbnailToUpload.type,
   };
 
-  return await storageClient.createThumbnailEntry(thumbnailEntry);
+  return await storageClient.createThumbnailEntryWithUUID(thumbnailEntry);
 };
 
 /**
@@ -176,7 +176,7 @@ export const getThumbnailFrom = async (fileToUpload: FileToUpload): Promise<Thum
 
 export const generateThumbnailFromFile = async (
   fileToUpload: FileToUpload,
-  fileId: number,
+  fileId: string,
   userEmail: string,
   isTeam: boolean,
 ): Promise<{ thumbnail: Thumbnail; thumbnailFile: File } | null> => {

--- a/src/app/drive/services/thumbnail.service.ts
+++ b/src/app/drive/services/thumbnail.service.ts
@@ -130,7 +130,7 @@ export const uploadThumbnail = async (
     abortController,
   });
 
-  const storageClient = SdkFactory.getNewApiInstance().createStorageClient();
+  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
   const thumbnailEntry: StorageTypes.CreateThumbnailEntryPayload = {
     bucketFile,
     bucketId,


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise summary of the changes. Include the reason and context, if applicable. -->
Migrates thumbnail creation endpoint from drive-old to drive-new

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [X] Changes have been tested locally.
- [X] Unit tests have been written or updated as necessary.
- [X] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [X] No new warnings or errors have been introduced.
- [X] SonarCloud issues have been reviewed and addressed.
- [x] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->
Verify using the network tab from a browser that the thumbnail creation endpoint uses the drive-new backend when uploading an image

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
