### PR TITLE
[_]: feat/send gclid for Google Ads conversion tracking

### DIFF
--- a/src/app/analytics/impact.service.ts
+++ b/src/app/analytics/impact.service.ts
@@ -43,6 +43,7 @@ export async function trackPaymentConversion() {
     const priceId = localStorageService.get('priceId');
     const currency = localStorageService.get('currency');
     const amount = parseFloat(localStorageService.get('amountPaid') ?? '0');
+    const gclid = getCookie('gclid');
 
     try {
       window.gtag('event', 'purchase', {
@@ -57,6 +58,7 @@ export async function trackPaymentConversion() {
             price: amount,
           },
         ],
+        ...(gclid ? { gclid } : {}),
       });
     } catch (error) {
       //

--- a/src/app/payment/utils/checkStarWarsCode.test.ts
+++ b/src/app/payment/utils/checkStarWarsCode.test.ts
@@ -43,7 +43,12 @@ describe('isStarWarsThemeAvailable', () => {
   it('returns true and sets localStorage if coupon is used for subscription', async () => {
     (localStorageService.get as Mock).mockReturnValue(undefined);
     (paymentService.isCouponUsedByUser as any).mockResolvedValue({ couponUsed: true });
-    const plan = { ...planBase, individualSubscription: { type: 'subscription' } };
+
+    const plan = {
+      individualSubscription: { type: 'subscription' },
+      businessSubscription: null,
+    };
+
     const onSuccess = vi.fn().mockResolvedValue(() => Promise.resolve());
 
     const result = await isStarWarsThemeAvailable(plan as any, onSuccess);
@@ -56,7 +61,11 @@ describe('isStarWarsThemeAvailable', () => {
   it('returns false if coupon is not used for subscription', async () => {
     (localStorageService.get as Mock).mockReturnValue(undefined);
     (paymentService.isCouponUsedByUser as any).mockResolvedValue({ couponUsed: false });
-    const plan = { ...planBase, businessSubscription: { type: 'subscription' } };
+
+    const plan = {
+      individualSubscription: null,
+      businessSubscription: { type: 'subscription' },
+    };
 
     const result = await isStarWarsThemeAvailable(plan as any);
 
@@ -67,7 +76,12 @@ describe('isStarWarsThemeAvailable', () => {
   it('returns true and sets localStorage if coupon is used for lifetime', async () => {
     (localStorageService.get as Mock).mockReturnValue(undefined);
     (paymentService.isCouponUsedByUser as any).mockResolvedValue({ couponUsed: true });
-    const plan = { ...planBase, individualSubscription: { type: 'lifetime' } };
+
+    const plan = {
+      individualSubscription: { type: 'lifetime' },
+      businessSubscription: null,
+    };
+
     const onSuccess = vi.fn().mockResolvedValue(() => Promise.resolve());
 
     const result = await isStarWarsThemeAvailable(plan as any, onSuccess);
@@ -80,7 +94,11 @@ describe('isStarWarsThemeAvailable', () => {
   it('returns false if coupon is not used for lifetime', async () => {
     (localStorageService.get as Mock).mockReturnValue(undefined);
     (paymentService.isCouponUsedByUser as any).mockResolvedValue({ couponUsed: false });
-    const plan = { ...planBase, businessSubscription: { type: 'lifetime' } };
+
+    const plan = {
+      individualSubscription: null,
+      businessSubscription: { type: 'lifetime' },
+    };
 
     const result = await isStarWarsThemeAvailable(plan as any);
 
@@ -91,7 +109,11 @@ describe('isStarWarsThemeAvailable', () => {
   it('calls errorService.reportError and returns false on error', async () => {
     (localStorageService.get as Mock).mockReturnValue(undefined);
     (paymentService.isCouponUsedByUser as any).mockRejectedValue(new Error('fail'));
-    const plan = { ...planBase, individualSubscription: { type: 'subscription' } };
+
+    const plan = {
+      individualSubscription: { type: 'subscription' },
+      businessSubscription: null,
+    };
 
     const result = await isStarWarsThemeAvailable(plan as any);
 
@@ -101,7 +123,11 @@ describe('isStarWarsThemeAvailable', () => {
 
   it('returns false if no subscription or lifetime', async () => {
     (localStorageService.get as Mock).mockReturnValue(undefined);
-    const plan = { ...planBase };
+
+    const plan = {
+      individualSubscription: null,
+      businessSubscription: null,
+    };
 
     const result = await isStarWarsThemeAvailable(plan as any);
 

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutView.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutView.tsx
@@ -10,7 +10,7 @@ import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
 import { StripePaymentElementOptions } from '@stripe/stripe-js';
 import { CheckoutViewManager, UpsellManagerProps, UserInfoProps } from './CheckoutViewWrapper';
 import { State } from 'app/payment/store/types';
-import { LegacyRef } from 'react';
+import { LegacyRef, useEffect } from 'react';
 import { OptionalB2BDropdown } from 'app/payment/components/checkout/OptionalB2BDropdown';
 import { UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 
@@ -85,6 +85,16 @@ const CheckoutView = ({
     checkoutViewManager.onCheckoutButtonClicked(formData, event, stripeSDK, elements);
   };
 
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const gclid = params.get('gclid');
+
+    if (gclid) {
+      const expiryDate = new Date();
+      expiryDate.setTime(expiryDate.getTime() + 90 * 24 * 60 * 60 * 1000);
+      document.cookie = `gclid=${gclid}; expires=${expiryDate.toUTCString()}; path=/`;
+    }
+  }, []);
   return (
     <form
       className="flex h-full overflow-y-scroll bg-gray-1 lg:w-screen xl:px-16"

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutView.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutView.tsx
@@ -42,6 +42,9 @@ const AUTH_METHOD_VALUES = {
   IS_SIGNED_IN: 'userIsSignedIn',
 };
 
+const GCLID_COOKIE_LIFESPAN_DAYS = 90;
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
 const CheckoutView = ({
   userInfo,
   isUserAuthenticated,
@@ -91,7 +94,7 @@ const CheckoutView = ({
 
     if (gclid) {
       const expiryDate = new Date();
-      expiryDate.setTime(expiryDate.getTime() + 90 * 24 * 60 * 60 * 1000);
+      expiryDate.setTime(expiryDate.getTime() + GCLID_COOKIE_LIFESPAN_DAYS * MILLISECONDS_PER_DAY);
       document.cookie = `gclid=${gclid}; expires=${expiryDate.toUTCString()}; path=/`;
     }
   }, []);


### PR DESCRIPTION
## Description
This PR introduces improvements in analytics tracking 

Analytics Improvement:

The trackPaymentConversion function in impact.service.ts now includes the gclid (Google Click Identifier) value from cookies, if available, when sending the purchase event to Google Analytics via gtag.

<!-- Provide a clear and concise summary of the changes. Include the reason and context, if applicable. -->

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests
https://github.com/internxt/website/pull/1429

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->
A user clicks on a Google Ads ad, and the website automatically appends a parameter called gclid to the URL, storing it in a cookie along with a 90-day expiration date. When we reach the checkout, the goal is to retrieve that gclid so we can include it in the conversion event. I haven’t been able to test it with Google Ads yet because I’m still waiting for some things to be set up. However, I have confirmed that the cookie is being stored correctly by checking it through the browser’s DevTools.
## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
