### PR TITLE
[_]: fix/impact radius tracks

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,3 +5,4 @@
 /src/app/core/services/stream.service.ts @internxt/cryptography
 /src/app/crypto/services/pgp.service.ts @internxt/cryptography
 /src/upload.worker.ts @internxt/cryptography
+/src/app/analytics/impact.service.ts @internxt/marketing

--- a/src/app/analytics/impact.service.test.ts
+++ b/src/app/analytics/impact.service.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import { savePaymentDataInLocalStorage, trackPaymentConversion } from './impact.service';
+import { PriceWithTax } from '@internxt/sdk/dist/payments/types';
+import { getProductAmount } from 'app/payment/utils/getProductAmount';
+import axios from 'axios';
+import localStorageService from 'app/core/services/local-storage.service';
+import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
+
+vi.mock('./utils', () => ({
+  getCookie: vi.fn((key: string) => {
+    if (key === 'impactAnonymousId') return 'anon_id';
+    if (key === 'impactSource') return 'ads';
+    return '';
+  }),
+}));
+
+const subId = 'sub_123';
+const paymentIntentId = 'py_123';
+
+const promoCode = {
+  amountOff: undefined,
+  codeId: 'promo_123',
+  percentOff: 99,
+  codeName: 'PROMO',
+};
+
+const product = {
+  price: {
+    id: 'price_123',
+    currency: 'eur',
+    amount: 11988,
+    bytes: 1099511627776,
+    interval: 'year',
+    decimalAmount: 119.88,
+    type: 'individual',
+    product: 'prod_1234',
+  },
+  taxes: {
+    tax: 25,
+    decimalTax: 0.25,
+    amountWithTax: 145,
+    decimalAmountWithTax: 1.45,
+  },
+};
+const expectedAmount = getProductAmount(product.price.decimalAmount, 1, promoCode);
+
+describe('Testing Impact Service', () => {
+  describe('Store necessary data to track it later', () => {
+    it('When wants to store the data, then the price to convert is the correct one', () => {
+      const setToLocalStorageSpy = vi.spyOn(Storage.prototype, 'setItem');
+      savePaymentDataInLocalStorage(subId, paymentIntentId, product as PriceWithTax, 1, promoCode);
+
+      expect(setToLocalStorageSpy).toHaveBeenCalledWith('amountPaid', expectedAmount);
+    });
+  });
+
+  describe('Send the track with the correct data', () => {
+    it('When the track is requested, then the necessary data is sent', async () => {
+      const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
+      vi.spyOn(localStorageService, 'getUser').mockReturnValue({
+        uuid: 'user_uuid',
+      } as unknown as UserSettings);
+
+      await trackPaymentConversion();
+
+      expect(axiosSpy).toHaveBeenCalledTimes(1);
+
+      const callArgs = axiosSpy.mock.calls[0][1];
+      expect(callArgs).toMatchObject({
+        anonymousId: 'anon_id',
+        properties: {
+          impact_value: parseFloat(expectedAmount),
+          subscription_id: subId,
+        },
+        userId: 'user_uuid',
+        type: 'track',
+        event: 'Payment Conversion',
+      });
+    });
+  });
+});

--- a/src/app/analytics/impact.service.ts
+++ b/src/app/analytics/impact.service.ts
@@ -5,13 +5,60 @@ import { getCookie } from './utils';
 import errorService from 'app/core/services/error.service';
 import localStorageService from 'app/core/services/local-storage.service';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
+import { PriceWithTax } from '@internxt/sdk/dist/payments/types';
+import { CouponCodeData } from 'app/payment/types';
+import { bytesToString } from 'app/drive/services/size.service';
+import { getProductAmount } from 'app/payment/utils/getProductAmount';
 
 const IMPACT_API = process.env.REACT_APP_IMPACT_API as string;
 
 const anonymousID = getCookie('impactAnonymousId');
 const source = getCookie('impactSource');
 
-export async function trackSignUp(uuid, email) {
+/**
+ * Stores relevant payment data in local storage to be retrieved later,
+ * particularly after a successful checkout (e.g., in CheckoutSuccessView).
+ * This enables tracking and analytics with accurate purchase context.
+ *
+ * Depending on the type of plan (subscription vs lifetime), the function stores:
+ * - `subscriptionId` for subscription-based plans (non-lifetime)
+ * - `paymentIntentId` for lifetime plans
+ *
+ * Additionally, it stores metadata such as product name, amount paid, price ID, and currency.
+ * The `amountPaid` value is computed based on:
+ * - The raw price (pre-tax and before any discounts)
+ * - Number of users
+ * - Coupon code data (if any)
+ *
+ * @param subscriptionId - Stripe subscription ID (only for recurring plans)
+ * @param paymentIntentId - Stripe payment intent ID (only for lifetime plans)
+ * @param selectedPlan - The pricing plan selected by the user
+ * @param users - Number of users for the purchase (1 for individual, >1 for B2B)
+ * @param couponCodeData - Optional coupon code information applied to the purchase
+ */
+export function savePaymentDataInLocalStorage(
+  subscriptionId: string | undefined,
+  paymentIntentId: string | undefined,
+  selectedPlan: PriceWithTax | undefined,
+  users: number,
+  couponCodeData: CouponCodeData | undefined,
+) {
+  if (subscriptionId && selectedPlan?.price.interval !== 'lifetime')
+    localStorageService.set('subscriptionId', subscriptionId);
+  if (paymentIntentId && selectedPlan?.price.interval === 'lifetime')
+    localStorageService.set('paymentIntentId', paymentIntentId);
+  if (selectedPlan) {
+    const planName = bytesToString(selectedPlan.price.bytes) + selectedPlan.price.interval;
+    const amountToPay = getProductAmount(selectedPlan.price.decimalAmount, users, couponCodeData);
+
+    localStorageService.set('productName', planName);
+    localStorageService.set('amountPaid', amountToPay);
+    localStorageService.set('priceId', selectedPlan.price.id);
+    localStorageService.set('currency', selectedPlan.price.currency);
+  }
+}
+
+export async function trackSignUp(uuid: string, email: string) {
   try {
     window.rudderanalytics.identify(uuid, { email, uuid: uuid });
     window.rudderanalytics.track('User Signup', { email });

--- a/src/app/core/services/local-storage.service.test.ts
+++ b/src/app/core/services/local-storage.service.test.ts
@@ -4,7 +4,7 @@ import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import { Workspace } from '../types';
 import { WorkspaceCredentialsDetails, WorkspaceData } from '@internxt/sdk/dist/workspaces';
 
-const mockUserSettings: UserSettings = {
+export const mockUserSettings: UserSettings = {
   userId: 'user_123',
   uuid: 'uuid-1234-5678',
   email: 'test.user@example.com',

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
@@ -93,26 +93,6 @@ const STATUS_CODE_ERROR = {
   INTERNAL_SERVER_ERROR: 500,
 };
 
-function savePaymentDataInLocalStorage(
-  subscriptionId: string | undefined,
-  paymentIntentId: string | undefined,
-  selectedPlan: PriceWithTax | undefined,
-  users: number,
-  couponCodeData: CouponCodeData | undefined,
-) {
-  if (subscriptionId) localStorageService.set('subscriptionId', subscriptionId);
-  if (paymentIntentId) localStorageService.set('paymentIntentId', paymentIntentId);
-  if (selectedPlan) {
-    const planName = bytesToString(selectedPlan.price.bytes) + selectedPlan.price.interval;
-    const amountToPay = getProductAmount(selectedPlan.price.decimalAmount, users, couponCodeData);
-
-    localStorageService.set('productName', planName);
-    localStorageService.set('amountPaid', amountToPay);
-    localStorageService.set('priceId', selectedPlan.price.id);
-    localStorageService.set('currency', selectedPlan.price.currency);
-  }
-}
-
 let stripeSdk: Stripe;
 
 const CheckoutViewWrapper = () => {
@@ -459,7 +439,7 @@ const CheckoutViewWrapper = () => {
             seatsForBusinessSubscription,
           });
 
-        // Store subscriptionId, paymentIntentId, and amountPaid to send to IMPACT API
+        // Store subscriptionId, paymentIntentId, and amountPaid to send to IMPACT API once the payment is done
         savePaymentDataInLocalStorage(
           subscriptionId,
           paymentIntentId,

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
@@ -32,6 +32,7 @@ import CheckoutView from './CheckoutView';
 import { PriceWithTax } from '@internxt/sdk/dist/payments/types';
 import { userLocation } from 'app/utils/userLocation';
 import { UserLocation } from '@internxt/sdk';
+import { savePaymentDataInLocalStorage } from 'app/analytics/impact.service';
 
 export const THEME_STYLES = {
   dark: {

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
@@ -104,7 +104,7 @@ function savePaymentDataInLocalStorage(
   if (paymentIntentId) localStorageService.set('paymentIntentId', paymentIntentId);
   if (selectedPlan) {
     const planName = bytesToString(selectedPlan.price.bytes) + selectedPlan.price.interval;
-    const amountToPay = getProductAmount(selectedPlan.taxes.decimalAmountWithTax, users, couponCodeData);
+    const amountToPay = getProductAmount(selectedPlan.price.decimalAmount, users, couponCodeData);
 
     localStorageService.set('productName', planName);
     localStorageService.set('amountPaid', amountToPay);

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
@@ -5,8 +5,6 @@ import { BaseSyntheticEvent, useCallback, useEffect, useReducer, useRef, useStat
 import { useSelector } from 'react-redux';
 
 import { Loader } from '@internxt/ui';
-import { bytesToString } from 'app/drive/services/size.service';
-import { getProductAmount } from 'app/payment/utils/getProductAmount';
 import { useCheckout } from 'hooks/checkout/useCheckout';
 import { useSignUp } from '../../../auth/components/SignUp/useSignUp';
 import envService from '../../../core/services/env.service';
@@ -29,7 +27,7 @@ import { planThunks } from '../../../store/slices/plan';
 import { useThemeContext } from '../../../theme/ThemeProvider';
 import authCheckoutService from '../../services/auth-checkout.service';
 import { checkoutReducer, initialStateForCheckout } from '../../store/checkoutReducer';
-import { AuthMethodTypes, CouponCodeData } from '../../types';
+import { AuthMethodTypes } from '../../types';
 import CheckoutView from './CheckoutView';
 import { PriceWithTax } from '@internxt/sdk/dist/payments/types';
 import { userLocation } from 'app/utils/userLocation';


### PR DESCRIPTION
## Description

This PR fixes the incorrect calculation of the amount sent to Impact Radius. Previously, the discount was applied twice — once in the priceWithTax, which already includes the discount, and again when we manually applied the coupon logic.

To resolve this, we now use the gross price (excluding tax and discounts) and apply the coupon code ourselves, ensuring the discount is applied only once. This results in accurate tracking data being sent to Impact Radius.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [ ] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

To test this, some payments have been made using an affiliate test link to see that the conversion reaches Impact correctly.

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
