### PR TITLE
[PB-4554] Remove mocks for types and mock reset

### DIFF
--- a/src/app/auth/components/SignUp/WorkspaceGuestSignUp.test.tsx
+++ b/src/app/auth/components/SignUp/WorkspaceGuestSignUp.test.tsx
@@ -110,13 +110,6 @@ describe('onSubmit', () => {
       },
     }));
 
-    vi.mock('app/core/types', () => ({
-      AppView: {
-        Drive: vi.fn(),
-        Signup: vi.fn(),
-      },
-    }));
-
     vi.mock('app/i18n/provider/TranslationProvider', () => ({
       useTranslationContext: vi.fn().mockReturnValue({
         translate: vi.fn().mockImplementation((value: string) => {

--- a/src/app/auth/components/SignUp/useSignUp.test.ts
+++ b/src/app/auth/components/SignUp/useSignUp.test.ts
@@ -11,15 +11,6 @@ vi.mock('@internxt/lib', () => ({
   },
 }));
 
-vi.mock('@internxt/sdk', () => ({
-  Keys: vi.fn(),
-  RegisterDetails: vi.fn(),
-}));
-
-vi.mock('@internxt/sdk/dist/shared/types/userSettings', () => ({
-  UserSettings: vi.fn(),
-}));
-
 vi.mock('bip39', () => ({
   generateMnemonic: vi.fn().mockReturnValue('mock-mnemonic'),
 }));

--- a/src/app/auth/services/auth.service.test.ts
+++ b/src/app/auth/services/auth.service.test.ts
@@ -36,12 +36,6 @@ beforeAll(() => {
   vi.mock('app/analytics/impact.service', () => ({
     trackSignUp: vi.fn(),
   }));
-  vi.mock('app/core/types', () => ({
-    default: {
-      AppError: vi.fn(),
-    },
-    AppView: vi.fn(),
-  }));
   vi.mock('app/database/services/database.service', () => ({
     default: {
       clear: vi.fn(),
@@ -63,9 +57,6 @@ beforeAll(() => {
         })),
       })),
     },
-  }));
-  vi.mock('app/payment/types', () => ({
-    AuthMethodTypes: vi.fn(),
   }));
   vi.mock('app/store', () => ({
     AppDispatch: vi.fn(),

--- a/src/app/share/views/SharedGuestSignUp/ShareGuestSignUpView.test.tsx
+++ b/src/app/share/views/SharedGuestSignUp/ShareGuestSignUpView.test.tsx
@@ -126,14 +126,6 @@ describe('onSubmit', () => {
       },
     }));
 
-    vi.mock('app/core/types', () => ({
-      AppView: {
-        Drive: vi.fn(),
-        Signup: vi.fn(),
-      },
-      IFormValues: vi.fn(),
-    }));
-
     vi.mock('app/i18n/provider/TranslationProvider', () => ({
       useTranslationContext: vi.fn().mockReturnValue({
         translate: vi.fn().mockImplementation((value: string) => {

--- a/src/app/store/slices/sharedLinks/index.test.ts
+++ b/src/app/store/slices/sharedLinks/index.test.ts
@@ -18,9 +18,6 @@ import shareService from 'app/share/services/share.service';
 
 describe('Encryption and Decryption', () => {
   beforeAll(() => {
-    vi.mock('app/core/types', () => ({
-      AppView: vi.fn(),
-    }));
     vi.mock('app/core/services/navigation.service', () => ({
       default: { push: vi.fn() },
     }));

--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.test.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 import { uploadItemsParallelThunk, uploadItemsThunk, uploadItemsThunkExtraReducers } from './uploadItemsThunk';
 import { RootState } from '../../..';
 import { useDispatch } from 'react-redux';
@@ -69,11 +69,6 @@ describe('uploadItemsThunk', () => {
   beforeEach(() => {
     (useDispatch as Mock).mockReturnValue(dispatch);
 
-    vi.clearAllMocks();
-    vi.restoreAllMocks();
-  });
-
-  afterEach(() => {
     vi.clearAllMocks();
   });
 
@@ -155,7 +150,6 @@ describe('uploadItemsThunkExtraReducers', () => {
     RetryManager.clearTasks();
 
     vi.clearAllMocks();
-    vi.restoreAllMocks();
   });
 
   it('should handle rejected case and call RetryManager and notificationsService', () => {


### PR DESCRIPTION
## Description

Remove mocks for types and vi.resetAllMocks()

## Related Pull Requests

[Switch to envService PR](https://github.com/internxt/drive-web/pull/1576)

## Checklist

- [ ] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

unit tests
