### PR TITLE
[PB-4586] feagure/Ignore hidden files when upload folders

### DIFF
--- a/src/app/network/UploadFolderManager.ts
+++ b/src/app/network/UploadFolderManager.ts
@@ -1,23 +1,23 @@
-import { TaskData, TaskEvent, TaskStatus, TaskType, UploadFolderTask } from '../tasks/types';
-import { DriveFolderData, DriveItemData } from '../drive/types';
-import { IRoot } from '../store/slices/storage/types';
-import tasksService from '../tasks/services/tasks.service';
-import errorService from '../core/services/error.service';
+import { WorkspaceData } from '@internxt/sdk/dist/workspaces';
+import { AnyAction, ThunkDispatch } from '@reduxjs/toolkit';
 import { queue, QueueObject } from 'async';
 import { t } from 'i18next';
-import { AnyAction, ThunkDispatch } from '@reduxjs/toolkit';
+import errorService from '../core/services/error.service';
+import newStorageService from '../drive/services/new-storage.service';
+import { DriveFolderData, DriveItemData } from '../drive/types';
 import { RootState } from '../store';
-import { WorkspaceData } from '@internxt/sdk/dist/workspaces';
 import { planThunks } from '../store/slices/plan';
-import { uploadItemsParallelThunk } from '../store/slices/storage/storage.thunks/uploadItemsThunk';
-import { createFolder } from '../store/slices/storage/folderUtils/createFolder';
-import { deleteItemsThunk } from '../store/slices/storage/storage.thunks/deleteItemsThunk';
 import { checkFolderDuplicated } from '../store/slices/storage/folderUtils/checkFolderDuplicated';
+import { createFolder } from '../store/slices/storage/folderUtils/createFolder';
 import { getUniqueFolderName } from '../store/slices/storage/folderUtils/getUniqueFolderName';
-import { ConnectionLostError } from './requests';
+import { deleteItemsThunk } from '../store/slices/storage/storage.thunks/deleteItemsThunk';
+import { uploadItemsParallelThunk } from '../store/slices/storage/storage.thunks/uploadItemsThunk';
+import { IRoot } from '../store/slices/storage/types';
+import tasksService from '../tasks/services/tasks.service';
+import { TaskData, TaskEvent, TaskStatus, TaskType, UploadFolderTask } from '../tasks/types';
 import { QueueUtilsService } from '../utils/queueUtils';
 import { wait } from '../utils/timeUtils';
-import newStorageService from '../drive/services/new-storage.service';
+import { ConnectionLostError } from './requests';
 
 interface UploadFolderPayload {
   root: IRoot;
@@ -251,6 +251,7 @@ export class UploadFoldersManager {
             disableDuplicatedNamesCheck: true,
             disableExistenceCheck: true,
             isUploadedFromFolder: true,
+            notUploadHiddenFiles: true,
           },
           onFileUploadCallback: () => {
             this.tasksInfo[taskId].progress.itemsUploaded += 1;

--- a/src/app/store/slices/storage/fileUtils/prepareFilesToUpload.test.ts
+++ b/src/app/store/slices/storage/fileUtils/prepareFilesToUpload.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { prepareFilesToUpload } from './prepareFilesToUpload';
-import { checkDuplicatedFiles } from './checkDuplicatedFiles';
-import { processDuplicateFiles } from './processDuplicateFiles';
 import { DriveFileData } from 'app/drive/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { checkDuplicatedFiles } from './checkDuplicatedFiles';
+import { prepareFilesToUpload } from './prepareFilesToUpload';
+import { processDuplicateFiles } from './processDuplicateFiles';
 
 const BATCH_SIZE = 200;
 
@@ -255,5 +255,133 @@ describe('prepareFilesToUpload', () => {
         fileType,
       }),
     );
+  });
+
+  it('should filter hidden files when notUploadHiddenFiles is true', async () => {
+    const mockFilesWithHidden = [
+      new File(['content'], 'file1.txt', { type: 'text/plain' }),
+      new File(['content'], '.hidden-file', { type: 'text/plain' }),
+      new File(['content'], '.DS_Store', { type: 'text/plain' }),
+      new File(['content'], 'normal-file.txt', { type: 'text/plain' }),
+    ];
+
+    const visibleFiles = [mockFilesWithHidden[0], mockFilesWithHidden[3]];
+
+    vi.mocked(checkDuplicatedFiles).mockResolvedValue({
+      duplicatedFilesResponse: [],
+      filesWithoutDuplicates: visibleFiles,
+      filesWithDuplicates: [],
+    });
+
+    vi.mocked(processDuplicateFiles).mockResolvedValue({
+      zeroLengthFiles: 0,
+      newFilesToUpload: visibleFiles.map((file) => ({
+        name: file.name,
+        size: file.size,
+        type: file.type,
+        parentFolderId,
+        content: file,
+      })),
+    });
+
+    const result = await prepareFilesToUpload({
+      files: mockFilesWithHidden,
+      parentFolderId,
+      notUploadHiddenFiles: true,
+    });
+
+    expect(result.filesToUpload).toHaveLength(2);
+    expect(result.filesToUpload[0].name).toBe('file1.txt');
+    expect(result.filesToUpload[1].name).toBe('normal-file.txt');
+
+    expect(checkDuplicatedFiles).toHaveBeenCalledWith(visibleFiles, parentFolderId);
+  });
+
+  it('should not filter hidden files when notUploadHiddenFiles is false', async () => {
+    const mockFilesWithHidden = [
+      new File(['content'], 'file1.txt', { type: 'text/plain' }),
+      new File(['content'], '.hidden-file', { type: 'text/plain' }),
+      new File(['content'], '.DS_Store', { type: 'text/plain' }),
+    ];
+
+    vi.mocked(checkDuplicatedFiles).mockResolvedValue({
+      duplicatedFilesResponse: [],
+      filesWithoutDuplicates: mockFilesWithHidden,
+      filesWithDuplicates: [],
+    });
+
+    vi.mocked(processDuplicateFiles).mockResolvedValue({
+      zeroLengthFiles: 0,
+      newFilesToUpload: mockFilesWithHidden.map((file) => ({
+        name: file.name,
+        size: file.size,
+        type: file.type,
+        parentFolderId,
+        content: file,
+      })),
+    });
+
+    const result = await prepareFilesToUpload({
+      files: mockFilesWithHidden,
+      parentFolderId,
+      notUploadHiddenFiles: false,
+    });
+
+    expect(result.filesToUpload).toHaveLength(3);
+    expect(result.filesToUpload.map((f) => f.name)).toEqual(['file1.txt', '.hidden-file', '.DS_Store']);
+
+    expect(checkDuplicatedFiles).toHaveBeenCalledWith(mockFilesWithHidden, parentFolderId);
+  });
+
+  it('should not filter hidden files when notUploadHiddenFiles is undefined', async () => {
+    const mockFilesWithHidden = [
+      new File(['content'], 'file1.txt', { type: 'text/plain' }),
+      new File(['content'], '.hidden-file', { type: 'text/plain' }),
+    ];
+
+    vi.mocked(checkDuplicatedFiles).mockResolvedValue({
+      duplicatedFilesResponse: [],
+      filesWithoutDuplicates: mockFilesWithHidden,
+      filesWithDuplicates: [],
+    });
+
+    vi.mocked(processDuplicateFiles).mockResolvedValue({
+      zeroLengthFiles: 0,
+      newFilesToUpload: mockFilesWithHidden.map((file) => ({
+        name: file.name,
+        size: file.size,
+        type: file.type,
+        parentFolderId,
+        content: file,
+      })),
+    });
+
+    const result = await prepareFilesToUpload({
+      files: mockFilesWithHidden,
+      parentFolderId,
+    });
+
+    expect(result.filesToUpload).toHaveLength(2);
+    expect(result.filesToUpload.map((f) => f.name)).toEqual(['file1.txt', '.hidden-file']);
+
+    expect(checkDuplicatedFiles).toHaveBeenCalledWith(mockFilesWithHidden, parentFolderId);
+  });
+
+  it('should handle empty array when all files are hidden and notUploadHiddenFiles is true', async () => {
+    const mockHiddenFiles = [
+      new File(['content'], '.hidden1', { type: 'text/plain' }),
+      new File(['content'], '.hidden2', { type: 'text/plain' }),
+    ];
+
+    const result = await prepareFilesToUpload({
+      files: mockHiddenFiles,
+      parentFolderId,
+      notUploadHiddenFiles: true,
+    });
+
+    expect(result.filesToUpload).toHaveLength(0);
+    expect(result.zeroLengthFilesNumber).toBe(0);
+    expect(checkDuplicatedFiles).not.toHaveBeenCalled();
+    expect(processDuplicateFiles).not.toHaveBeenCalled();
   });
 });

--- a/src/app/store/slices/storage/fileUtils/prepareFilesToUpload.ts
+++ b/src/app/store/slices/storage/fileUtils/prepareFilesToUpload.ts
@@ -1,9 +1,14 @@
 import { DriveFileData } from '@internxt/sdk/dist/drive/storage/types';
+import { FileToUpload } from '../../../../drive/services/file.service/types';
 import { checkDuplicatedFiles } from './checkDuplicatedFiles';
 import { processDuplicateFiles } from './processDuplicateFiles';
-import { FileToUpload } from '../../../../drive/services/file.service/types';
 
 const BATCH_SIZE = 200;
+
+const isHiddenFile = (fileName: string): boolean => {
+  if (fileName.startsWith('.')) console.log('isHiddenFile', fileName);
+  return fileName.startsWith('.');
+};
 
 export const prepareFilesToUpload = async ({
   files,
@@ -11,13 +16,17 @@ export const prepareFilesToUpload = async ({
   disableDuplicatedNamesCheck = false,
   fileType,
   disableExistenceCheck = false,
+  notUploadHiddenFiles = false,
 }: {
   files: File[];
   parentFolderId: string;
   disableDuplicatedNamesCheck?: boolean;
   fileType?: string;
   disableExistenceCheck?: boolean;
+  notUploadHiddenFiles?: boolean;
 }): Promise<{ filesToUpload: FileToUpload[]; zeroLengthFilesNumber: number }> => {
+  const filteredFiles = notUploadHiddenFiles ? files.filter((file) => !isHiddenFile(file.name)) : files;
+
   let filesToUpload: FileToUpload[] = [];
   let zeroLengthFilesNumber = 0;
 
@@ -34,7 +43,6 @@ export const prepareFilesToUpload = async ({
       disableDuplicatedNamesCheck: disableDuplicatedNamesCheckOverride,
       duplicatedFiles,
     });
-
     filesToUpload = newFilesToUpload;
     zeroLengthFilesNumber += zeroLengthFiles;
   };
@@ -53,8 +61,8 @@ export const prepareFilesToUpload = async ({
     }
   };
 
-  for (let i = 0; i < files.length; i += BATCH_SIZE) {
-    const batch = files.slice(i, i + BATCH_SIZE);
+  for (let i = 0; i < filteredFiles.length; i += BATCH_SIZE) {
+    const batch = filteredFiles.slice(i, i + BATCH_SIZE);
     await processFilesBatch(batch);
   }
 

--- a/src/app/store/slices/storage/fileUtils/prepareFilesToUpload.ts
+++ b/src/app/store/slices/storage/fileUtils/prepareFilesToUpload.ts
@@ -6,7 +6,6 @@ import { processDuplicateFiles } from './processDuplicateFiles';
 const BATCH_SIZE = 200;
 
 const isHiddenFile = (fileName: string): boolean => {
-  if (fileName.startsWith('.')) console.log('isHiddenFile', fileName);
   return fileName.startsWith('.');
 };
 

--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
@@ -22,10 +22,10 @@ import { planThunks } from '../../plan';
 import { uiActions } from '../../ui';
 import workspacesSelectors from '../../workspaces/workspaces.selectors';
 
+import RetryManager from 'app/network/RetryManager';
+import { FileToUpload } from '../../../../drive/services/file.service/types';
 import { prepareFilesToUpload } from '../fileUtils/prepareFilesToUpload';
 import { StorageState } from '../storage.model';
-import { FileToUpload } from '../../../../drive/services/file.service/types';
-import RetryManager from 'app/network/RetryManager';
 
 interface UploadItemsThunkOptions {
   relatedTaskId: string;
@@ -37,6 +37,7 @@ interface UploadItemsThunkOptions {
   disableDuplicatedNamesCheck?: boolean;
   disableExistenceCheck?: boolean;
   isUploadedFromFolder?: boolean;
+  notUploadHiddenFiles?: boolean;
 }
 
 interface UploadItemsPayload {
@@ -117,7 +118,6 @@ export const uploadItemsThunk = createAsyncThunk<void, UploadItemsPayload, { sta
   ) => {
     const user = getState().user.user as UserSettings;
     const errors: Error[] = [];
-
     const options = { ...DEFAULT_OPTIONS, ...payloadOptions };
 
     const state = getState();
@@ -431,6 +431,7 @@ export const uploadItemsParallelThunk = createAsyncThunk<void, UploadItemsPayloa
       parentFolderId,
       disableDuplicatedNamesCheck: options.disableDuplicatedNamesCheck,
       disableExistenceCheck: options.disableExistenceCheck,
+      notUploadHiddenFiles: options.notUploadHiddenFiles,
     });
 
     showEmptyFilesNotification(zeroLengthFilesNumber);


### PR DESCRIPTION
## Description

Refactor upload folder management and file preparation to include opion for not uploading system hidden files

## Related Issues


## Related Pull Requests


## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [x] QA Passed

## Testing Process

- Upload folder (from drag and drop or upload folders button) and check that system hidden files are not upload

## Additional Notes
