### PR TITLE
[PB-4499]: feat/captcha validation for log in

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@internxt/css-config": "^1.0.3",
     "@internxt/inxt-js": "=1.2.21",
     "@internxt/lib": "^1.2.0",
-    "@internxt/sdk": "=1.10.3",
+    "@internxt/sdk": "=1.10.7",
     "@internxt/ui": "^0.0.23",
     "@phosphor-icons/react": "^2.1.7",
     "@popperjs/core": "^2.11.6",

--- a/src/app/auth/components/LogIn/LogIn.tsx
+++ b/src/app/auth/components/LogIn/LogIn.tsx
@@ -17,7 +17,7 @@ import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import { WarningCircle } from '@phosphor-icons/react';
 import errorService from 'app/core/services/error.service';
 import navigationService from 'app/core/services/navigation.service';
-import AppError, { AppView, IFormValues } from 'app/core/types';
+import { AppView, IFormValues } from 'app/core/types';
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
 import { Button } from '@internxt/ui';
 import workspacesService from '../../../core/services/workspace.service';
@@ -178,7 +178,7 @@ export default function LogIn(): JSX.Element {
 
       setLoginError([castedError.message]);
       setShowErrors(true);
-      if ((err as AppError)?.status === 403) {
+      if (castedError?.status === 403 && castedError?.code !== 'CaptchaRequired') {
         await sendUnblockAccountEmail(email);
         navigationService.history.push({
           pathname: AppView.BlockedAccount,

--- a/src/app/auth/components/LogIn/LogIn.tsx
+++ b/src/app/auth/components/LogIn/LogIn.tsx
@@ -31,6 +31,8 @@ import vpnAuthService from 'app/auth/services/vpnAuth.service';
 import envService from 'app/core/services/env.service';
 import { generateCaptchaToken } from 'app/auth/utils';
 
+const CAPTCHA_FLOW_ERROR_CODES = ['WebLoginRequired', 'CaptchaRequired'];
+
 const showNotification = ({ text, isError }: { text: string; isError: boolean }) => {
   notificationsService.show({
     text,
@@ -178,7 +180,7 @@ export default function LogIn(): JSX.Element {
 
       setLoginError([castedError.message]);
       setShowErrors(true);
-      if (castedError?.status === 403 && castedError?.code !== 'CaptchaRequired') {
+      if (castedError?.status === 403 && castedError?.code && !CAPTCHA_FLOW_ERROR_CODES.includes(castedError?.code)) {
         await sendUnblockAccountEmail(email);
         navigationService.history.push({
           pathname: AppView.BlockedAccount,

--- a/src/app/auth/components/LogIn/LogIn.tsx
+++ b/src/app/auth/components/LogIn/LogIn.tsx
@@ -139,14 +139,12 @@ export default function LogIn(): JSX.Element {
       const captchaToken = await generateCaptchaToken();
 
       if (!isTfaEnabled || showTwoFactor) {
-        const loginType: 'desktop' | 'web' = isUniversalLinkMode ? 'desktop' : 'web';
         const authParams = {
           email,
           password,
           authMethod: 'signIn' as AuthMethodTypes,
           twoFactorCode,
           dispatch,
-          loginType,
           captchaToken,
         };
 

--- a/src/app/auth/components/LogIn/LogIn.tsx
+++ b/src/app/auth/components/LogIn/LogIn.tsx
@@ -29,6 +29,7 @@ import TextInput from '../TextInput/TextInput';
 import { AuthMethodTypes } from 'app/payment/types';
 import vpnAuthService from 'app/auth/services/vpnAuth.service';
 import envService from 'app/core/services/env.service';
+import { generateCaptchaToken } from 'app/auth/utils';
 
 const showNotification = ({ text, isError }: { text: string; isError: boolean }) => {
   notificationsService.show({
@@ -133,6 +134,8 @@ export default function LogIn(): JSX.Element {
     try {
       const isTfaEnabled = await is2FANeeded(email);
 
+      const captchaToken = await generateCaptchaToken();
+
       if (!isTfaEnabled || showTwoFactor) {
         const loginType: 'desktop' | 'web' = isUniversalLinkMode ? 'desktop' : 'web';
         const authParams = {
@@ -142,6 +145,7 @@ export default function LogIn(): JSX.Element {
           twoFactorCode,
           dispatch,
           loginType,
+          captchaToken,
         };
 
         const { token, user, mnemonic } = await authenticateUser(authParams);

--- a/src/app/auth/services/auth.service.test.ts
+++ b/src/app/auth/services/auth.service.test.ts
@@ -322,6 +322,72 @@ describe('logIn', () => {
       mnemonic: mockMnemonic,
     });
   });
+
+  it('When the user tries to log in, then the captcha token is sent', async () => {
+    const mockedCaptchaToken = 'captcha-token';
+    const mockToken = 'test-token';
+    const mockNewToken = 'test-new-token';
+    const mockLoginType = 'web';
+
+    const mockPassword = 'password123';
+    const mockMnemonic =
+      'until bonus summer risk chunk oyster census ability frown win pull steel measure employ rigid improve riot remind system earn inch broken chalk clip';
+    const keys = await keysService.getKeys(mockPassword);
+    const encryptedMnemonic = encryptTextWithKey(mockMnemonic, mockPassword);
+
+    const mockOlsUser: Partial<UserSettings> = {
+      uuid: 'mock-uuid',
+      email: 'mock@email.com',
+      privateKey: keys.ecc.privateKeyEncrypted,
+      mnemonic: encryptedMnemonic,
+      userId: 'mock-userId',
+      name: 'mock-name',
+      lastname: 'mock-lastname',
+      username: 'mock-username',
+      bridgeUser: 'mock-bridgeUser',
+      bucket: 'mock-bucket',
+      backupsBucket: null,
+      root_folder_id: 0,
+      rootFolderId: 'mock-rootFolderId',
+      rootFolderUuid: undefined,
+      sharedWorkspace: false,
+      credit: 0,
+      publicKey: keys.ecc.publicKey,
+      revocationKey: keys.revocationCertificate,
+      appSumoDetails: null,
+      registerCompleted: false,
+      hasReferralsProgram: false,
+      createdAt: new Date(),
+      avatar: null,
+      emailVerified: false,
+    };
+    const mockTwoFactorCode = '123456';
+
+    const mockUser = mockOlsUser as UserSettings;
+
+    const createAuthClientSpy = vi.fn().mockReturnValue({
+      login: vi.fn().mockResolvedValue({
+        user: mockUser,
+        token: mockToken,
+        newToken: mockNewToken,
+      }),
+    });
+
+    vi.spyOn(SdkFactory, 'getNewApiInstance').mockReturnValue({
+      createAuthClient: createAuthClientSpy,
+      createDesktopAuthClient: vi.fn().mockReturnValue({
+        login: vi.fn().mockResolvedValue({
+          user: mockUser,
+          token: mockToken,
+          newToken: mockNewToken,
+        }),
+      }),
+    } as any);
+
+    await authService.doLogin(mockUser.email, mockPassword, mockTwoFactorCode, mockLoginType, mockedCaptchaToken);
+
+    expect(createAuthClientSpy).toHaveBeenCalledWith(mockedCaptchaToken);
+  });
 });
 
 describe('signUp', () => {
@@ -645,219 +711,3 @@ describe('Change password', () => {
     expect(mockSendDeactivationEmail).toHaveBeenCalledWith('token');
   });
 });
-
-/*
-import * as authService from './auth.service';
-import { userActions } from 'app/store/slices/user';
-import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
-import localStorageService from 'app/core/services/local-storage.service';
-import * as keysService from 'app/crypto/services/keys.service';
-import { AuthenticateUserParams } from './auth.service';
-import { AuthMethodTypes } from 'app/payment/types';
-import { vi, describe, it, beforeEach, afterEach, expect } from 'vitest';
-
-vi.mock('../../../WebWorker');
-vi.mock('app/store/slices/user');
-vi.mock('app/core/services/local-storage.service');
-vi.mock('app/core/services/error.service');
-
-const mockDispatch = vi.fn();
-const mockToken = 'test-token';
-const mockMnemonic = 'test-mnemonic';
-const mockUuid = 'test-uuid';
-const mockEmail = 'test@test.com';
-const mockUserId = 'user-id';
-const mockPassword = 'password123';
-const mockTwoFactorCode = '123456';
-const mockLoginType = 'web';
-const mockPrivateKey = 'mockPrivateKey';
-const mockPrivateKeyDecript = 'mockPrivateKeyDecript';
-const mockSignUpToken = 'signup-token';
-const mockNewToken = 'new-token';
-const mockUser: UserSettings = {
-  uuid: mockUuid,
-  email: mockEmail,
-  privateKey: mockPrivateKey,
-  mnemonic: mockMnemonic,
-  userId: mockUserId,
-  name: '',
-  lastname: '',
-  username: '',
-  bridgeUser: '',
-  bucket: '',
-  backupsBucket: null,
-  root_folder_id: 0,
-  rootFolderId: '',
-  rootFolderUuid: undefined,
-  sharedWorkspace: false,
-  credit: 0,
-  publicKey: '',
-  revocationKey: '',
-  appSumoDetails: null,
-  registerCompleted: false,
-  hasReferralsProgram: false,
-  createdAt: new Date(),
-  avatar: null,
-  emailVerified: false,
-};
-const mockSignUpFunction = vi.fn();
-
-beforeEach(() => {
-  window.gtag = vi.fn();
-
-  mockSignUpFunction.mockResolvedValue({
-    xUser: { ...mockUser, privateKey: mockPrivateKey },
-    xToken: mockToken,
-    mnemonic: mockMnemonic,
-  });
-});
-
-afterEach(() => {
-  vi.clearAllMocks();
-});
-
-describe('logIn', () => {
-  it('should log in and dispatch necessary actions', async () => {
-    const doLoginSpy = vi.spyOn(authService, 'doLogin').mockResolvedValue({
-      user: mockUser,
-      token: mockToken,
-      mnemonic: mockMnemonic,
-    });
-
-    const result = await authService.logIn({
-      email: mockEmail,
-      password: mockPassword,
-      twoFactorCode: mockTwoFactorCode,
-      dispatch: mockDispatch,
-      loginType: mockLoginType,
-    });
-
-    expect(doLoginSpy).toHaveBeenCalledWith(mockEmail, mockPassword, mockTwoFactorCode, mockLoginType);
-    expect(mockDispatch).toHaveBeenCalledWith(userActions.setUser(mockUser));
-    expect(mockDispatch).toHaveBeenCalledTimes(7);
-
-    expect(result).toEqual({
-      token: mockToken,
-      user: mockUser,
-      mnemonic: mockMnemonic,
-    });
-  });
-});
-
-describe('signIn', () => {
-  it('should sign up a new user and set user details', async () => {
-    vi.spyOn(authService, 'getNewToken').mockResolvedValueOnce(mockNewToken);
-    vi.spyOn(keysService, 'decryptPrivateKey').mockImplementation(() => mockPrivateKeyDecript);
-
-    const mockParams = {
-      doSignUp: mockSignUpFunction,
-      email: mockEmail,
-      password: mockPassword,
-      token: mockSignUpToken,
-      isNewUser: true,
-      redeemCodeObject: false,
-      dispatch: mockDispatch,
-    };
-
-    const result = await authService.signUp(mockParams);
-
-    expect(mockSignUpFunction).toHaveBeenCalledWith(mockEmail, mockPassword, mockSignUpToken);
-    expect(localStorageService.set).toHaveBeenCalledWith('xToken', mockToken);
-    expect(localStorageService.set).toHaveBeenCalledWith('xMnemonic', mockMnemonic);
-    expect(localStorageService.set).toHaveBeenCalledWith('xNewToken', mockNewToken);
-    expect(mockDispatch).toHaveBeenCalledWith(userActions.setUser(expect.any(Object)));
-
-    const expectedResult = {
-      token: mockToken,
-      user: mockUser,
-      mnemonic: mockMnemonic,
-    };
-
-    expect(result).toEqual(expectedResult);
-  });
-
-  it('should handle error during sign up', async () => {
-    mockSignUpFunction.mockRejectedValueOnce(new Error('Signup failed'));
-
-    const mockParams = {
-      doSignUp: mockSignUpFunction,
-      email: mockEmail,
-      password: mockPassword,
-      token: mockSignUpToken,
-      isNewUser: true,
-      redeemCodeObject: false,
-      dispatch: mockDispatch,
-    };
-    await expect(authService.signUp(mockParams)).rejects.toThrow('Signup failed');
-  });
-});
-
-describe('authMethod', () => {
-  it('should log in the user when authMethod is signIn', async () => {
-    vi.spyOn(authService, 'logIn');
-
-    const mockParams: AuthenticateUserParams = {
-      email: mockEmail,
-      password: mockPassword,
-      authMethod: 'signIn',
-      twoFactorCode: mockTwoFactorCode,
-      dispatch: mockDispatch,
-      loginType: mockLoginType,
-      isNewUser: false,
-    };
-
-    const result = await authService.authenticateUser(mockParams);
-
-    expect(authService.logIn).toHaveBeenCalledWith({
-      email: mockEmail,
-      password: mockPassword,
-      twoFactorCode: mockTwoFactorCode,
-      dispatch: mockDispatch,
-      loginType: mockLoginType,
-    });
-    expect(result).toEqual({ token: mockToken, user: mockUser, mnemonic: mockMnemonic });
-  });
-
-  it('should sign up the user when authMethod is signUp', async () => {
-    vi.spyOn(authService, 'signUp');
-    vi.spyOn(authService, 'getNewToken').mockResolvedValueOnce(mockNewToken);
-
-    const mockParams: AuthenticateUserParams = {
-      email: mockEmail,
-      password: mockPassword,
-      authMethod: 'signUp',
-      twoFactorCode: mockTwoFactorCode,
-      dispatch: mockDispatch,
-      loginType: mockLoginType,
-      isNewUser: false,
-      doSignUp: mockSignUpFunction,
-    };
-
-    const result = await authService.authenticateUser(mockParams);
-
-    const expectedResult = {
-      token: mockToken,
-      user: mockUser,
-      mnemonic: mockMnemonic,
-    };
-
-    expect(authService.signUp).toHaveBeenCalledWith(expect.any(Object));
-    expect(result).toEqual(expectedResult);
-  });
-
-  it('should throw an error for invalidMethod authMethod', async () => {
-    const mockParams: AuthenticateUserParams = {
-      email: mockEmail,
-      password: mockPassword,
-      authMethod: 'invalidMethod' as unknown as AuthMethodTypes,
-      twoFactorCode: mockTwoFactorCode,
-      dispatch: mockDispatch,
-      loginType: mockLoginType,
-      isNewUser: false,
-      doSignUp: mockSignUpFunction,
-    };
-
-    await expect(authService.authenticateUser(mockParams)).rejects.toThrow('Unknown authMethod: invalidMethod');
-  });
-});
-*/

--- a/src/app/auth/services/auth.service.test.ts
+++ b/src/app/auth/services/auth.service.test.ts
@@ -43,9 +43,6 @@ beforeAll(() => {
         createAuthClient: vi.fn(() => ({
           login: vi.fn(),
         })),
-        createDesktopAuthClient: vi.fn(() => ({
-          login: vi.fn(),
-        })),
       })),
     },
   }));
@@ -196,13 +193,6 @@ describe('logIn', () => {
           newToken: mockNewToken,
         }),
       }),
-      createDesktopAuthClient: vi.fn().mockReturnValue({
-        login: vi.fn().mockResolvedValue({
-          user: mockUser,
-          token: mockToken,
-          newToken: mockNewToken,
-        }),
-      }),
     } as any);
 
     const result = await authService.doLogin(mockUser.email, mockPassword, mockTwoFactorCode, mockLoginType);
@@ -285,13 +275,6 @@ describe('logIn', () => {
           newToken: mockNewToken,
         }),
       }),
-      createDesktopAuthClient: vi.fn().mockReturnValue({
-        login: vi.fn().mockResolvedValue({
-          user: mockUser,
-          token: mockToken,
-          newToken: mockNewToken,
-        }),
-      }),
     } as any);
 
     const result = await authService.doLogin(mockUser.email, mockPassword, mockTwoFactorCode, mockLoginType);
@@ -328,8 +311,6 @@ describe('logIn', () => {
     const mockedCaptchaToken = 'captcha-token';
     const mockToken = 'test-token';
     const mockNewToken = 'test-new-token';
-    const mockLoginType = 'web';
-
     const mockPassword = 'password123';
     const mockMnemonic =
       'until bonus summer risk chunk oyster census ability frown win pull steel measure employ rigid improve riot remind system earn inch broken chalk clip';
@@ -363,7 +344,6 @@ describe('logIn', () => {
       emailVerified: false,
     };
     const mockTwoFactorCode = '123456';
-
     const mockUser = mockOlsUser as UserSettings;
 
     const createAuthClientSpy = vi.fn().mockReturnValue({
@@ -376,16 +356,9 @@ describe('logIn', () => {
 
     vi.spyOn(SdkFactory, 'getNewApiInstance').mockReturnValue({
       createAuthClient: createAuthClientSpy,
-      createDesktopAuthClient: vi.fn().mockReturnValue({
-        login: vi.fn().mockResolvedValue({
-          user: mockUser,
-          token: mockToken,
-          newToken: mockNewToken,
-        }),
-      }),
     } as any);
 
-    await authService.doLogin(mockUser.email, mockPassword, mockTwoFactorCode, mockLoginType, mockedCaptchaToken);
+    await authService.doLogin(mockUser.email, mockPassword, mockTwoFactorCode, mockedCaptchaToken);
 
     expect(createAuthClientSpy).toHaveBeenCalledWith(mockedCaptchaToken);
   });
@@ -625,10 +598,6 @@ describe('Change password', () => {
         changePassword: changePasswordMock,
         securityDetails: vi.fn().mockReturnValue({ encryptedSalt }),
       }),
-      createDesktopAuthClient: vi.fn().mockReturnValue({
-        changePassword: changePasswordMock,
-        securityDetails: vi.fn().mockReturnValue({ encryptedSalt }),
-      }),
       createUsersClient: vi.fn().mockReturnValue({
         changePassword: changePasswordMock,
       }),
@@ -674,10 +643,6 @@ describe('Change password', () => {
       .mockReturnValue(Promise.resolve({ newToken: 'newMockToken', token: 'mockToken' }));
     vi.spyOn(SdkFactory, 'getNewApiInstance').mockReturnValue({
       createAuthClient: vi.fn().mockReturnValue({
-        changePassword: changePasswordMock,
-        securityDetails: vi.fn().mockReturnValue({ encryptedSalt }),
-      }),
-      createDesktopAuthClient: vi.fn().mockReturnValue({
         changePassword: changePasswordMock,
         securityDetails: vi.fn().mockReturnValue({ encryptedSalt }),
       }),

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -125,7 +125,7 @@ export const is2FANeeded = async (email: string): Promise<boolean> => {
 const getAuthClient = (authType: 'web' | 'desktop', captchaToken?: string) => {
   const AUTH_CLIENT = {
     web: SdkFactory.getNewApiInstance().createAuthClient(captchaToken),
-    desktop: SdkFactory.getNewApiInstance().createDesktopAuthClient(),
+    desktop: SdkFactory.getNewApiInstance().createDesktopAuthClient(captchaToken),
   };
 
   return AUTH_CLIENT[authType];

--- a/src/app/auth/utils.ts
+++ b/src/app/auth/utils.ts
@@ -1,6 +1,7 @@
 import testPasswordStrength from '@internxt/lib/dist/src/auth/testPasswordStrength';
 import { t } from 'i18next';
 import { MAX_PASSWORD_LENGTH } from '../shared/components/ValidPassword';
+import envConfig from 'app/core/services/env.service';
 
 const onChangePasswordHandler = ({
   password,
@@ -37,4 +38,11 @@ const onChangePasswordHandler = ({
   }
 };
 
-export { onChangePasswordHandler };
+const generateCaptchaToken = async (): Promise<string> => {
+  await new Promise<void>((r) => window.grecaptcha.ready(r));
+  return window.grecaptcha.execute(envConfig.getVariable('recaptchaV3'), {
+    action: 'authentication',
+  });
+};
+
+export { onChangePasswordHandler, generateCaptchaToken };

--- a/src/app/core/factory/sdk/index.ts
+++ b/src/app/core/factory/sdk/index.ts
@@ -51,19 +51,6 @@ export class SdkFactory {
     return Auth.client(apiUrl, appDetails, apiSecurity);
   }
 
-  public createDesktopAuthClient(captchaToken?: string): Auth {
-    const customHeaders: Record<string, string> = {};
-
-    if (captchaToken) {
-      customHeaders['x-internxt-captcha'] = captchaToken;
-    }
-
-    const apiUrl = this.getApiUrl();
-    const appDetails = SdkFactory.getDesktopAppDetails(customHeaders);
-    const apiSecurity = this.getNewApiSecurity();
-    return Auth.client(apiUrl, appDetails, apiSecurity);
-  }
-
   public createNewStorageClient(): Storage {
     const apiUrl = this.getApiUrl();
     const appDetails = SdkFactory.getAppDetails();
@@ -149,22 +136,6 @@ export class SdkFactory {
       clientVersion: packageJson.version,
       customHeaders,
     };
-  }
-
-  private static getDesktopAppDetails(customHeaders?: Record<string, string>): AppDetails {
-    return {
-      clientName: 'drive-desktop',
-      clientVersion: packageJson.version,
-      customHeaders,
-    };
-  }
-
-  private getToken(workspace: string): Token {
-    const tokenByWorkspace: { [key in Workspace]: string } = {
-      [Workspace.Individuals]: SdkFactory.sdk.localStorage.get('xToken') || '',
-      [Workspace.Business]: SdkFactory.sdk.localStorage.get('xTokenTeam') || '',
-    };
-    return tokenByWorkspace[workspace];
   }
 
   private getNewToken(workspace: string): Token {

--- a/src/app/core/factory/sdk/index.ts
+++ b/src/app/core/factory/sdk/index.ts
@@ -51,9 +51,15 @@ export class SdkFactory {
     return Auth.client(apiUrl, appDetails, apiSecurity);
   }
 
-  public createDesktopAuthClient(): Auth {
+  public createDesktopAuthClient(captchaToken?: string): Auth {
+    const customHeaders: Record<string, string> = {};
+
+    if (captchaToken) {
+      customHeaders['x-internxt-captcha'] = captchaToken;
+    }
+
     const apiUrl = this.getApiUrl();
-    const appDetails = SdkFactory.getDesktopAppDetails();
+    const appDetails = SdkFactory.getDesktopAppDetails(customHeaders);
     const apiSecurity = this.getNewApiSecurity();
     return Auth.client(apiUrl, appDetails, apiSecurity);
   }
@@ -145,10 +151,11 @@ export class SdkFactory {
     };
   }
 
-  private static getDesktopAppDetails(): AppDetails {
+  private static getDesktopAppDetails(customHeaders?: Record<string, string>): AppDetails {
     return {
       clientName: 'drive-desktop',
       clientVersion: packageJson.version,
+      customHeaders,
     };
   }
 

--- a/src/app/core/factory/sdk/index.ts
+++ b/src/app/core/factory/sdk/index.ts
@@ -38,9 +38,15 @@ export class SdkFactory {
     return this.sdk.newApiInstance;
   }
 
-  public createAuthClient(): Auth {
+  public createAuthClient(captchaToken?: string): Auth {
+    const customHeaders: Record<string, string> = {};
+
+    if (captchaToken) {
+      customHeaders['x-internxt-captcha'] = captchaToken;
+    }
+
     const apiUrl = this.getApiUrl();
-    const appDetails = SdkFactory.getAppDetails();
+    const appDetails = SdkFactory.getAppDetails({ ...customHeaders });
     const apiSecurity = this.getNewApiSecurity();
     return Auth.client(apiUrl, appDetails, apiSecurity);
   }
@@ -131,10 +137,11 @@ export class SdkFactory {
     return this.apiUrl;
   }
 
-  private static getAppDetails(): AppDetails {
+  private static getAppDetails(customHeaders?: Record<string, string>): AppDetails {
     return {
       clientName: packageJson.name,
       clientVersion: packageJson.version,
+      customHeaders,
     };
   }
 

--- a/src/app/core/services/error.service.ts
+++ b/src/app/core/services/error.service.ts
@@ -9,8 +9,9 @@ interface AxiosErrorResponse {
   message?: string;
 }
 
-interface ErrorWithStatus extends Error {
+interface ErrorWithStatusAndCode extends Error {
   status?: number;
+  code?: string;
 }
 
 const errorService = {
@@ -41,11 +42,16 @@ const errorService = {
       castedError = new AppError(
         responseData?.error || responseData?.message || 'Unknown error',
         axiosError.response?.status,
+        axiosError.code,
       );
     } else if (typeof err === 'string') {
       castedError = new AppError(err);
     } else if (err instanceof Error) {
-      castedError = new AppError(err.message || 'Unknown error', (err as ErrorWithStatus).status);
+      castedError = new AppError(
+        err.message || 'Unknown error',
+        (err as ErrorWithStatusAndCode).status,
+        (err as ErrorWithStatusAndCode).code,
+      );
     } else {
       const map = err as Record<string, unknown>;
       castedError = map.message ? new AppError(map.message as string, map.status as number) : castedError;

--- a/src/app/core/types.ts
+++ b/src/app/core/types.ts
@@ -69,11 +69,13 @@ export interface AppViewConfig {
 
 export default class AppError extends Error {
   readonly status?: number;
+  readonly code?: string;
 
-  constructor(message: string, status?: number) {
+  constructor(message: string, status?: number, code?: string) {
     super(message);
 
     this.status = status;
+    this.code = code;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1919,12 +1919,13 @@
   resolved "https://npm.pkg.github.com/download/@internxt/prettier-config/1.0.2/5bd220b8de76734448db5475b3e0c01f9d22c19b#5bd220b8de76734448db5475b3e0c01f9d22c19b"
   integrity sha512-t4HiqvCbC7XgQepwWlIaFJe3iwW7HCf6xOSU9nKTV0tiGqOPz7xMtIgLEloQrDA34Cx4PkOYBXrvFPV6RxSFAA==
 
-"@internxt/sdk@=1.10.3":
-  version "1.10.3"
-  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.10.3/4903964fb3db71d20921f421e9f2f0eb51ddddeb#4903964fb3db71d20921f421e9f2f0eb51ddddeb"
-  integrity sha512-ouZM3jJMZf/1izTksQ9t6lwAG2ISooIZIjLE51nR0Z41xE3DlnjvEb7itAzcRTIT7z5cX6ZpHPlY0uhsLbJ3Bw==
+"@internxt/sdk@=1.10.7":
+  version "1.10.7"
+  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.10.7/1c2a7860143aea7b089c1cf2a3d45207f2986d42#1c2a7860143aea7b089c1cf2a3d45207f2986d42"
+  integrity sha512-FINOzAaKqEmcmyCCO3M++BGW+j5f8eadwhlIz+mMNpXFbt8rPcERGkOletIz28ewoSd5qX5WLqa1Ya5To5cx7Q==
   dependencies:
     axios "1.10.0"
+    uuid "11.1.0"
 
 "@internxt/ui@^0.0.23":
   version "0.0.23"
@@ -9655,6 +9656,11 @@ util@^0.12.4, util@^0.12.5:
     is-generator-function "^1.0.7"
     is-typed-array "^1.1.3"
     which-typed-array "^1.1.2"
+
+uuid@11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
 uuid@=8.3.2, uuid@^8.3.0:
   version "8.3.2"


### PR DESCRIPTION
## Description

This PR adds support for sending the reCaptcha token during the login attempt. This allows the backend to validate that the login request comes from a human user and helps prevent automated attacks (e.g., credential stuffing or brute-force login attempts).

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

- [SDK/feat/PB-4499-captcha-token-for-login-endpoint](https://github.com/internxt/sdk/pull/304)
- [Drive Server WIP/feature/PB-4499-add-recaptcha-for-log-in](https://github.com/internxt/drive-server-wip/pull/593)

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
