### PR TITLE
[PB-4238]: fix/add loading state while fetching workspace limit and usage

### DIFF
--- a/src/app/core/components/Sidenav/Sidenav.tsx
+++ b/src/app/core/components/Sidenav/Sidenav.tsx
@@ -113,6 +113,9 @@ const Sidenav = ({
   const dispatch = useAppDispatch();
   const isB2BWorkspace = !!useSelector(workspacesSelectors.getSelectedWorkspace);
   const isLoadingCredentials = useAppSelector((state: RootState) => state.workspaces.isLoadingCredentials);
+  const isLoadingBusinessLimitAndUsage = useAppSelector(
+    (state: RootState) => state.plan.isLoadingBusinessLimitAndUsage,
+  );
   const pendingInvitations = useAppSelector((state: RootState) => state.shared.pendingInvitations);
   const selectedWorkspace = useAppSelector(workspacesSelectors.getSelectedWorkspace);
   const workspaceUuid = selectedWorkspace?.workspaceUser.workspaceId;
@@ -208,7 +211,7 @@ const Sidenav = ({
             limit={planLimit}
             usage={planUsage}
             isUpgradeAvailable={isUpgradeAvailable}
-            isLoading={isLoadingPlanUsage || isLoadingPlanLimit}
+            isLoading={isLoadingPlanUsage || isLoadingPlanLimit || isLoadingBusinessLimitAndUsage}
           />
         </div>
       </div>

--- a/src/app/store/slices/plan/index.ts
+++ b/src/app/store/slices/plan/index.ts
@@ -15,6 +15,7 @@ export interface PlanState {
   isLoadingPlans: boolean;
   isLoadingPlanLimit: boolean;
   isLoadingPlanUsage: boolean;
+  isLoadingBusinessLimitAndUsage: boolean;
   individualPlan: StoragePlan | null;
   businessPlan: StoragePlan | null;
   teamPlan: StoragePlan | null;
@@ -32,6 +33,7 @@ const initialState: PlanState = {
   isLoadingPlans: false,
   isLoadingPlanLimit: false,
   isLoadingPlanUsage: false,
+  isLoadingBusinessLimitAndUsage: false,
   individualPlan: null,
   businessPlan: null,
   teamPlan: null,
@@ -192,7 +194,9 @@ export const planSlice = createSlice({
     });
 
     builder
-      .addCase(fetchBusinessLimitUsageThunk.pending, () => undefined)
+      .addCase(fetchBusinessLimitUsageThunk.pending, (state) => {
+        state.isLoadingBusinessLimitAndUsage = true;
+      })
       .addCase(fetchBusinessLimitUsageThunk.fulfilled, (state, action) => {
         const spaceLimit = Number(action.payload?.spaceLimit) || 0;
         const driveUsage = Number(action.payload?.driveUsage) || 0;
@@ -205,8 +209,11 @@ export const planSlice = createSlice({
           backups: backupsUsage,
           total: driveUsage + backupsUsage,
         };
+        state.isLoadingBusinessLimitAndUsage = false;
       })
-      .addCase(fetchBusinessLimitUsageThunk.rejected, () => undefined);
+      .addCase(fetchBusinessLimitUsageThunk.rejected, (state) => {
+        state.isLoadingBusinessLimitAndUsage = false;
+      });
   },
 });
 


### PR DESCRIPTION
## Description

This PR implements a loading state for the Storage/Limit component while fetching the workspace's usage and limit data. This prevents displaying misleading information like 0 of ... before the actual values are loaded.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process
- Open an existing account with at least one Workspace.
- Switch from a personal account to a workspace account.
- Observe that the Storage/Limit component shows a loading state until the data is fetched, then displays the correct usage and limit.

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
