### PR TITLE
[PB-4483]: fix/"Security" preferences menu closes immediately when "Show Password" (Eye Icon) is clicked

### DIFF
--- a/src/app/newSettings/Sections/Account/Security/components/EnterPassword.tsx
+++ b/src/app/newSettings/Sections/Account/Security/components/EnterPassword.tsx
@@ -43,7 +43,13 @@ const EnterPassword = ({
   };
 
   return (
-    <div className="flex w-full justify-center" title={translate('views.account.tabs.security.label')}>
+    <div
+      className="flex w-full justify-center"
+      title={translate('views.account.tabs.security.label')}
+      onMouseDown={(e) => {
+        e.stopPropagation();
+      }}
+    >
       <Card className="w-2/3 space-y-3">
         <h1 className="text-lg font-medium text-gray-80">{translate('views.account.tabs.security.lock.title')}</h1>
         <p className="text-gray-80">{translate('views.account.tabs.security.lock.description')}</p>

--- a/src/app/share/components/SharePasswordInputDialog/SharePasswordInputDialog.tsx
+++ b/src/app/share/components/SharePasswordInputDialog/SharePasswordInputDialog.tsx
@@ -32,7 +32,13 @@ export const SharePasswordInputDialog = ({
 
   return (
     <Modal maxWidth="max-w-sm" isOpen={isOpen} onClose={onClose}>
-      <form onSubmit={handleConfirm} className="space-y-5 p-5">
+      <form
+        onSubmit={handleConfirm}
+        className="space-y-5 p-5"
+        onMouseDown={(e) => {
+          e.stopPropagation();
+        }}
+      >
         <p className="text-2xl font-medium">
           {!isAlreadyProtected
             ? translate('modals.shareModal.protectSharingModal.protect')


### PR DESCRIPTION
## Description

This PR prevents the Security dialog from closing when the user clicks the "eye" icon to toggle password visibility.

Why:
Previously, clicking the `Eye` icon unintentionally triggered the dialog to close. This happened because the `Modal` component listens to the `mouseDown` event to detect outside clicks. Since the `Eye` icon is rendered outside the dialog boundary, it was treated as an external click.

This fix improves the user experience by allowing users to toggle password visibility without accidentally closing the dialog.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
