### PR TITLE
[PB-4563]: fix/drive Web B2B workspace not displaying used storage correctly

### DIFF
--- a/src/app/newSettings/Sections/Workspace/Overview/OverviewSection.tsx
+++ b/src/app/newSettings/Sections/Workspace/Overview/OverviewSection.tsx
@@ -181,6 +181,7 @@ const OverviewSection = ({ onClosePreferences, changeSection }: OverviewSectionP
       <WorkspaceOverviewDetails
         members={members?.length || 0}
         teams={teams?.length || 0}
+        planUsage={plan.businessPlanUsage}
         planLimit={plan.businessPlanLimit}
         products={products}
         isOwner={isOwner}
@@ -216,7 +217,7 @@ const EditWorkspaceDetailsModal = ({
   onSave: (editedCompanyName: string, editedAbout: string) => void;
   isLoading: boolean;
 }) => {
-  const MAX_NAME_LENGHT = 50;
+  const MAX_NAME_LENGTH = 50;
   const MAX_ABOUT_NAME = 150;
   const [editedCompanyName, setEditedCompanyName] = useState(companyName);
   const [aboutCompany, setAboutCompany] = useState(aboutText);
@@ -232,7 +233,7 @@ const EditWorkspaceDetailsModal = ({
             label="Name"
             textValue={editedCompanyName}
             onChangeTextValue={setEditedCompanyName}
-            maxLength={MAX_NAME_LENGHT}
+            maxLength={MAX_NAME_LENGTH}
             disabled={isLoading}
           />
           <div>
@@ -269,6 +270,7 @@ const EditWorkspaceDetailsModal = ({
 interface WorkspaceOverviewDetailsProps {
   members: number;
   teams: number;
+  planUsage: number;
   planLimit: number;
   products: Parameters<typeof UsageContainer>[0]['products'] | null;
   isOwner: boolean;
@@ -281,6 +283,7 @@ interface WorkspaceOverviewDetailsProps {
 const WorkspaceOverviewDetails = ({
   members,
   teams,
+  planUsage,
   planLimit,
   products,
   isOwner,
@@ -333,7 +336,7 @@ const WorkspaceOverviewDetails = ({
         <div className="flex flex-row">
           <Card className="flex grow">
             {products && planLimit ? (
-              <UsageContainer planLimitInBytes={planLimit} products={products} />
+              <UsageContainer planUsage={planUsage} planLimitInBytes={planLimit} products={products} />
             ) : (
               <div className="flex h-36 w-full items-center justify-center">
                 <Loader classNameLoader="h-7 w-7 text-primary" />

--- a/src/app/newSettings/containers/UsageContainer.tsx
+++ b/src/app/newSettings/containers/UsageContainer.tsx
@@ -1,20 +1,18 @@
-import { RootState } from 'app/store';
-import { useAppSelector } from 'app/store/hooks';
 import { DriveProduct } from '../types/types';
 import Usage from '../components/Usage/Usage';
 import { Loader } from '@internxt/ui';
 
 const UsageContainer = ({
   className = '',
+  planUsage,
   planLimitInBytes,
   products,
 }: Readonly<{
   className?: string;
+  planUsage: number;
   planLimitInBytes: number;
   products: DriveProduct[];
 }>): JSX.Element => {
-  const planUsage = useAppSelector((state: RootState) => state.plan.planUsage);
-
   const driveProduct = products.find((product) => product.name === 'Drive');
   const backupsProduct = products.find((product) => product.name === 'Backups');
   const driveUsage = driveProduct ? driveProduct?.usageInBytes : 0;


### PR DESCRIPTION
## Description

This PR fixes the displayed storage usage in Settings for B2B workspaces.

**Issue:**
Previously, the component was adding the individual account's space internally, leading to incorrect storage information being shown for workspace accounts.

**Fix:**
We now use the correct workspace usage and limit data, ensuring accurate information is shown in the UI.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

- Log in using an account that has a B2B workspace.
- Switch to the B2B workspace.
- Go to Settings.
- In the Overview tab (Workspace section), verify that the storage usage and limit are displayed correctly.
- Click on the Account tab (Account section).
- Confirm that the storage usage shown is also correct.

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
