### PR TITLE
[PB-4381]: feat/use the avatar blob from the local DB or fetch it again

### DIFF
--- a/src/app/auth/services/user.service.test.ts
+++ b/src/app/auth/services/user.service.test.ts
@@ -8,7 +8,6 @@ const testEmail = 'test@initnxt.com';
 const usersClientMock = {
   getUserData: vi.fn(),
   updateUserProfile: vi.fn(),
-  //updateUserAvatar: vi.fn(),
   deleteUserAvatar: vi.fn(),
   sendVerificationEmail: vi.fn(),
   getPublicKeyByEmail: vi.fn(),
@@ -72,13 +71,6 @@ describe('userService', () => {
     );
   });
 
-  /*it('should update user avatar', async () => {
-    usersClientMock.updateUserAvatar.mockResolvedValue({ avatar: 'avatar-url' });
-    const result = await userService.updateUserAvatar({ avatar: new Blob() });
-    expect(result).toEqual({ avatar: 'avatar-url' });
-    expect(usersClientMock.updateUserAvatar).toHaveBeenCalled();
-  });*/
-
   it('should delete user avatar', async () => {
     usersClientMock.deleteUserAvatar.mockResolvedValue({ success: true });
     await userService.deleteUserAvatar();
@@ -113,5 +105,14 @@ describe('userService', () => {
     usersClientMock.checkChangeEmailExpiration.mockResolvedValue('mockExpirationResponse');
     const response = await userService.checkChangeEmailLinkExpiration('verifyToken');
     expect(response).toBe('mockExpirationResponse');
+  });
+
+  it('should download the avatar', async () => {
+    const downloadAvatarSpy = vi.spyOn(userService, 'downloadAvatar');
+    const abortController = new AbortController();
+
+    await userService.downloadAvatar('testSrcURL', abortController.signal);
+
+    expect(downloadAvatarSpy).toHaveBeenCalledWith('testSrcURL', expect.any(AbortSignal));
   });
 });

--- a/src/app/auth/services/user.service.ts
+++ b/src/app/auth/services/user.service.ts
@@ -74,8 +74,8 @@ const checkChangeEmailLinkExpiration = (verifyToken: string): Promise<CheckChang
   return authClient.checkChangeEmailExpiration(verifyToken);
 };
 
-const downloadAvatar = async (url: string): Promise<Blob> => {
-  const response = await fetch(url);
+const downloadAvatar = async (url: string, signal?: AbortSignal): Promise<Blob> => {
+  const response = await fetch(url, { signal });
   const data = await response.blob();
   return data;
 };

--- a/src/app/core/components/Sidenav/Sidenav.tsx
+++ b/src/app/core/components/Sidenav/Sidenav.tsx
@@ -26,6 +26,13 @@ import { STORAGE_KEYS } from '../../../core/services/storage-keys';
 import { HUNDRED_TB } from '../../../core/constants';
 import { useEffect } from 'react';
 import { sharedThunks } from 'app/store/slices/sharedLinks';
+import { useAvatar } from 'hooks/useAvatar';
+import { deleteDatabaseProfileAvatar, getDatabaseProfileAvatar } from 'app/drive/services/database.service';
+import userService from 'app/auth/services/user.service';
+import {
+  saveAvatarToDatabase,
+  showUpdateAvatarErrorToast,
+} from 'app/newSettings/Sections/Account/Account/components/AvatarWrapper';
 
 interface SidenavProps {
   user: UserSettings | undefined;
@@ -119,6 +126,14 @@ const Sidenav = ({
   const pendingInvitations = useAppSelector((state: RootState) => state.shared.pendingInvitations);
   const selectedWorkspace = useAppSelector(workspacesSelectors.getSelectedWorkspace);
   const workspaceUuid = selectedWorkspace?.workspaceUser.workspaceId;
+  const { avatarBlob } = useAvatar({
+    avatarSrcURL: user?.avatar || null,
+    deleteDatabaseAvatar: deleteDatabaseProfileAvatar,
+    downloadAvatar: userService.downloadAvatar,
+    getDatabaseAvatar: getDatabaseProfileAvatar,
+    saveAvatarToDatabase: saveAvatarToDatabase,
+    onError: showUpdateAvatarErrorToast,
+  });
 
   useEffect(() => {
     dispatch(sharedThunks.getPendingInvitations());
@@ -200,7 +215,14 @@ const Sidenav = ({
       </button>
       <div className="flex grow flex-col overflow-x-auto border-r border-gray-5 px-2">
         <div className="mt-2 flex w-full flex-col">
-          {user && <WorkspaceSelectorContainer user={user} />}
+          {user && (
+            <WorkspaceSelectorContainer
+              user={{
+                ...user,
+                avatar: avatarBlob ? URL.createObjectURL(avatarBlob) : user.avatar,
+              }}
+            />
+          )}
           <SideNavItems sideNavItems={itemsNavigation} />
         </div>
 

--- a/src/app/core/components/Sidenav/WorkspaceSelector.tsx
+++ b/src/app/core/components/Sidenav/WorkspaceSelector.tsx
@@ -107,8 +107,6 @@ const WorkspaceSelector: React.FC<WorkspaceSelectorProps> = ({
     };
   });
 
-  console.log(selectedWorkspace);
-
   return (
     <div className="relative mb-2 inline-block w-full" ref={dropdownRef}>
       {/* TOGGLE BUTTON */}

--- a/src/app/core/components/Sidenav/WorkspaceSelector.tsx
+++ b/src/app/core/components/Sidenav/WorkspaceSelector.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 
 import { useTranslationContext } from '../../../i18n/provider/TranslationProvider';
 import WorkspaceAvatarWrapper from '../../../newSettings/Sections/Workspace/Overview/components/WorkspaceAvatarWrapper';
+import AvatarWrapper from 'app/newSettings/Sections/Account/Account/components/AvatarWrapper';
 
 export interface Workspace {
   uuid: string;
@@ -44,12 +45,16 @@ const WorkspaceCard = ({
   return (
     <button className="w-full px-2 py-3 text-left hover:bg-gray-5 dark:hover:bg-gray-10" onClick={handleOnClick}>
       <div className="flex w-full flex-row items-center justify-between space-x-2">
-        <WorkspaceAvatarWrapper
-          diameter={28}
-          workspaceId={workspace.uuid}
-          fullName={workspace?.name ?? ''}
-          avatarSrcURL={workspace.avatar}
-        />
+        {workspace && workspace?.type === 'Personal' ? (
+          <AvatarWrapper avatarSrcURL={workspace.avatar ?? null} fullName={workspace.name ?? ''} diameter={28} />
+        ) : (
+          <WorkspaceAvatarWrapper
+            diameter={28}
+            workspaceId={workspace?.uuid ?? ''}
+            fullName={workspace?.name ?? ''}
+            avatarSrcURL={workspace?.avatar ?? null}
+          />
+        )}
         <div className="flex grow flex-col truncate">
           <p className="truncate text-sm font-medium leading-4 text-gray-100">{workspace.name}</p>
           <p className="truncate text-xs font-medium leading-3 text-gray-60">
@@ -102,6 +107,8 @@ const WorkspaceSelector: React.FC<WorkspaceSelectorProps> = ({
     };
   });
 
+  console.log(selectedWorkspace);
+
   return (
     <div className="relative mb-2 inline-block w-full" ref={dropdownRef}>
       {/* TOGGLE BUTTON */}
@@ -112,12 +119,20 @@ const WorkspaceSelector: React.FC<WorkspaceSelectorProps> = ({
         onClick={toggleDropdown}
       >
         <div className="flex w-full flex-row items-center justify-between space-x-2">
-          <WorkspaceAvatarWrapper
-            diameter={28}
-            workspaceId={selectedWorkspace?.uuid ?? ''}
-            fullName={selectedWorkspace?.name ?? ''}
-            avatarSrcURL={selectedWorkspace?.avatar ?? null}
-          />
+          {selectedWorkspace?.type === 'Personal' ? (
+            <AvatarWrapper
+              avatarSrcURL={userWorkspace.avatar ?? null}
+              fullName={userWorkspace.name ?? ''}
+              diameter={28}
+            />
+          ) : (
+            <WorkspaceAvatarWrapper
+              diameter={28}
+              workspaceId={selectedWorkspace?.uuid ?? ''}
+              fullName={selectedWorkspace?.name ?? ''}
+              avatarSrcURL={selectedWorkspace?.avatar ?? null}
+            />
+          )}
           <div className="flex grow flex-col truncate">
             <p className="truncate text-sm font-medium leading-4 text-gray-100">{selectedWorkspace?.name}</p>
             <p className="truncate text-xs font-medium leading-3 text-gray-60">

--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -150,6 +150,7 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
   const [openPasswordInput, setOpenPasswordInput] = useState(false);
   const [openPasswordDisableDialog, setOpenPasswordDisableDialog] = useState(false);
   const [sharingMeta, setSharingMeta] = useState<SharingMeta | null>(null);
+  const [avatarBlob, setAvatarBlob] = useState<Blob | null>(null);
 
   const [accessRequests, setAccessRequests] = useState<RequestProps[]>([]);
   const [userOptionsEmail, setUserOptionsEmail] = useState<InvitedUserProps>();
@@ -180,8 +181,6 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
     onCloseDialog?.();
   };
 
-  const [avatarBlob, setAvatarBlob] = useState<Blob | null>(null);
-
   const downloadAndSaveAvatar = async (url: string) => {
     const avatar = await userService.downloadAvatar(url);
     setAvatarBlob(avatar);
@@ -192,8 +191,7 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
     const databaseAvatarData = await getDatabaseProfileAvatar();
 
     if (!databaseAvatarData) {
-      downloadAndSaveAvatar(url);
-      return;
+      return downloadAndSaveAvatar(url);
     }
 
     const existsNewAvatar = databaseAvatarData.uuid !== extractAvatarURLID(url);

--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -45,40 +45,16 @@ import { useAvatar } from 'hooks/useAvatar';
 import { deleteDatabaseProfileAvatar, getDatabaseProfileAvatar } from 'app/drive/services/database.service';
 import userService from 'app/auth/services/user.service';
 import { saveAvatarToDatabase } from 'app/newSettings/Sections/Account/Account/components/AvatarWrapper';
-
-type AccessMode = 'public' | 'restricted';
-type UserRole = 'owner' | 'editor' | 'reader';
-type Views = 'general' | 'invite' | 'requests';
-type RequestStatus = 'pending' | 'accepted' | 'denied';
-
-const REQUEST_STATUS = {
-  PENDING: 'pending' as RequestStatus,
-  ACCEPTED: 'accepted' as RequestStatus,
-  DENIED: 'denied' as RequestStatus,
-};
-
-export interface InvitedUserProps {
-  avatar: string | null;
-  name: string;
-  lastname: string;
-  email: string;
-  roleName: UserRole;
-  uuid: string;
-  sharingId: string;
-}
-
-interface RequestProps {
-  avatar: string;
-  name: string;
-  lastname: string;
-  email: string;
-  message?: string;
-  status: RequestStatus;
-}
-
-interface ViewProps {
-  view: Views;
-}
+import {
+  AccessMode,
+  InvitedUserProps,
+  REQUEST_STATUS,
+  RequestProps,
+  RequestStatus,
+  UserRole,
+  ViewProps,
+  Views,
+} from './types';
 
 const isRequestPending = (status: RequestStatus): boolean =>
   status !== REQUEST_STATUS.DENIED && status !== REQUEST_STATUS.ACCEPTED;

--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -82,14 +82,14 @@ const isAdvancedShareItem = (item: DriveItemData | AdvancedSharedItem): item is 
   return item['encryptionKey'];
 };
 
-const getLocalUserData = (avatarBlob?: string) => {
+const getLocalUserData = (avatarSrc?: string) => {
   const user = localStorageService.getUser() as UserSettings;
   const ownerData = {
     name: user.name,
     lastname: user.lastname,
     email: user.email,
     sharingId: '',
-    avatar: avatarBlob ?? user.avatar,
+    avatar: avatarSrc ?? user.avatar,
     uuid: user.uuid,
     role: {
       id: 'NONE',

--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -39,6 +39,14 @@ import ShareInviteDialog from '../ShareInviteDialog/ShareInviteDialog';
 import StopSharingItemDialog from '../StopSharingItemDialog/StopSharingItemDialog';
 import './ShareDialog.scss';
 import envService from 'app/core/services/env.service';
+import { getDatabaseProfileAvatar } from 'app/drive/services/database.service';
+import {
+  extractAvatarURLID,
+  saveAvatarToDatabase,
+} from 'app/newSettings/Sections/Account/Account/components/AvatarWrapper';
+import userService from 'app/auth/services/user.service';
+import { User } from './components/User';
+import { InvitedUsersSkeletonLoader } from './components/InvitedUsersSkeletonLoader';
 
 type AccessMode = 'public' | 'restricted';
 type UserRole = 'owner' | 'editor' | 'reader';
@@ -51,7 +59,7 @@ const REQUEST_STATUS = {
   DENIED: 'denied' as RequestStatus,
 };
 
-interface InvitedUserProps {
+export interface InvitedUserProps {
   avatar: string | null;
   name: string;
   lastname: string;
@@ -171,6 +179,35 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
     setSharingMeta(null);
     onCloseDialog?.();
   };
+
+  const [avatarBlob, setAvatarBlob] = useState<Blob | null>(null);
+
+  const downloadAndSaveAvatar = async (url: string) => {
+    const avatar = await userService.downloadAvatar(url);
+    setAvatarBlob(avatar);
+    await saveAvatarToDatabase(url, avatar);
+  };
+
+  const handleDownload = useCallback(async (url: string) => {
+    const databaseAvatarData = await getDatabaseProfileAvatar();
+
+    if (!databaseAvatarData) {
+      downloadAndSaveAvatar(url);
+      return;
+    }
+
+    const existsNewAvatar = databaseAvatarData.uuid !== extractAvatarURLID(url);
+
+    if (existsNewAvatar) {
+      return downloadAndSaveAvatar(url);
+    }
+
+    setAvatarBlob(databaseAvatarData.avatarBlob);
+  }, []);
+
+  useEffect(() => {
+    if (props.user.avatar) handleDownload(props.user.avatar);
+  }, [props.user.avatar, handleDownload]);
 
   useEffect(() => {
     const OWNER_ROLE = { id: 'NONE', name: 'owner' };
@@ -581,6 +618,7 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
                     <User
                       user={user}
                       key={user.email}
+                      avatarSrc={avatarBlob ? URL.createObjectURL(avatarBlob) : user.avatar}
                       listPosition={index}
                       translate={translate}
                       openUserOptions={openUserOptions}
@@ -890,197 +928,3 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
 export default connect((state: RootState) => ({
   user: state.user.user as UserSettings,
 }))(ShareDialog);
-
-export const UserOptions = ({
-  listPosition,
-  selectedUserListIndex,
-  userOptionsY,
-  translate,
-  onRemoveUser,
-  userOptionsEmail,
-  selectedRole,
-  onChangeRole,
-  disableRoleChange,
-}): JSX.Element => {
-  const isUserSelected = selectedUserListIndex === listPosition;
-
-  return isUserSelected ? (
-    <Popover
-      className="absolute z-10 h-0 max-h-0 w-full"
-      style={{
-        top: `${userOptionsY}px`,
-        right: 0,
-        minWidth: '160px',
-      }}
-    >
-      <Popover.Panel
-        className={`absolute right-0 z-10 origin-top-right whitespace-nowrap rounded-lg border border-gray-10 bg-surface p-1 shadow-subtle transition-all duration-50 ease-out dark:bg-gray-5 ${
-          isUserSelected ? 'scale-100 opacity-100' : 'pointer-events-none scale-95 opacity-0'
-        }`}
-        style={{
-          top: '44px',
-          minWidth: '160px',
-        }}
-        static
-      >
-        {disableRoleChange ? (
-          <></>
-        ) : (
-          <>
-            {/* Editor */}
-            <button
-              className="flex h-9 w-full cursor-pointer items-center justify-start space-x-3 rounded-lg px-3 hover:bg-gray-5 dark:hover:bg-gray-10"
-              onClick={() => {
-                onChangeRole('editor');
-              }}
-            >
-              <p className="w-full text-left text-base font-medium leading-none">
-                {translate('modals.shareModal.list.userItem.roles.editor')}
-              </p>
-              {selectedRole === 'editor' && <Check size={20} />}
-            </button>
-
-            {/* Reader */}
-            <button
-              className="flex h-9 w-full cursor-pointer items-center justify-start space-x-3 rounded-lg px-3 hover:bg-gray-5 dark:hover:bg-gray-10"
-              onClick={() => {
-                onChangeRole('reader');
-              }}
-            >
-              <p className="w-full text-left text-base font-medium leading-none">
-                {translate('modals.shareModal.list.userItem.roles.reader')}
-              </p>
-              {selectedRole === 'reader' && <Check size={20} />}
-            </button>
-
-            <div className="mx-3 my-0.5 flex h-px bg-gray-10" />
-          </>
-        )}
-        {/* Remove */}
-        <button
-          className="flex h-9 w-full cursor-pointer items-center justify-start space-x-3 rounded-lg px-3 hover:bg-gray-5 dark:hover:bg-gray-10"
-          onClick={() => {
-            onRemoveUser(userOptionsEmail);
-          }}
-        >
-          <p className="w-full text-left text-base font-medium leading-none">
-            {translate('modals.shareModal.list.userItem.remove')}
-          </p>
-        </button>
-      </Popover.Panel>
-    </Popover>
-  ) : (
-    <></>
-  );
-};
-
-const User = ({
-  user,
-  listPosition,
-  translate,
-  openUserOptions,
-  selectedUserListIndex,
-  userOptionsY,
-  onRemoveUser,
-  userOptionsEmail,
-  onChangeRole,
-  disableUserOptionsPanel,
-  disableRoleChange,
-}: {
-  user: InvitedUserProps;
-  listPosition: number | null;
-  translate: (key: string, props?: Record<string, unknown>) => string;
-  openUserOptions: (
-    event: MouseEvent<HTMLDivElement, globalThis.MouseEvent>,
-    user: InvitedUserProps,
-    listPosition: number | null,
-  ) => void;
-  selectedUserListIndex;
-  userOptionsY;
-  onRemoveUser;
-  userOptionsEmail;
-  onChangeRole: (email: string, roleName: string) => void;
-  disableUserOptionsPanel: boolean;
-  disableRoleChange: boolean;
-}) => (
-  <div
-    className={`group flex h-14 shrink-0 items-center space-x-2.5 border-t ${
-      user.roleName === 'owner' ? 'border-transparent' : 'border-gray-5'
-    }`}
-  >
-    <Avatar src={user.avatar} fullName={`${user.name} ${user.lastname}`} diameter={40} />
-
-    <div className="flex flex-1 flex-col overflow-hidden">
-      <p className="w-full overflow-hidden text-ellipsis whitespace-nowrap font-medium leading-tight">
-        {user.name}&nbsp;{user.lastname}
-      </p>
-      <p className="w-full overflow-hidden text-ellipsis whitespace-nowrap text-sm leading-none text-gray-50">
-        {user.email}
-      </p>
-    </div>
-
-    {user.roleName === 'owner' || disableUserOptionsPanel ? (
-      <div className="px-3 text-gray-50">{translate(`modals.shareModal.list.userItem.roles.${user.roleName}`)}</div>
-    ) : (
-      <>
-        <div
-          className="relative flex h-9 cursor-pointer select-none flex-row items-center justify-center space-x-2 whitespace-nowrap rounded-lg border border-gray-10 bg-surface px-3 text-base font-medium text-gray-80 outline-none ring-2 ring-primary/0 ring-offset-2 ring-offset-transparent transition-all duration-100 ease-in-out hover:border-gray-20 focus-visible:shadow-sm focus-visible:ring-primary/50 active:bg-gray-1 group-hover:border-gray-20 group-hover:shadow-sm dark:bg-gray-5 dark:active:bg-gray-10"
-          onMouseUpCapture={(event) => openUserOptions(event, user, listPosition)}
-          tabIndex={-1}
-        >
-          <span className="pointer-events-none">
-            {translate(`modals.shareModal.list.userItem.roles.${user.roleName}`)}
-          </span>
-          <CaretDown size={16} weight="bold" className="pointer-events-none" />
-        </div>
-        <UserOptions
-          listPosition={listPosition}
-          selectedUserListIndex={selectedUserListIndex}
-          userOptionsY={userOptionsY}
-          translate={translate}
-          onRemoveUser={onRemoveUser}
-          userOptionsEmail={userOptionsEmail}
-          selectedRole={user.roleName}
-          onChangeRole={(roleName) => onChangeRole(user.email, roleName)}
-          disableRoleChange={disableRoleChange}
-        />
-      </>
-    )}
-  </div>
-);
-
-const InvitedUsersSkeletonLoader = () => {
-  const skinSkeleton = [
-    <div className="flex flex-row items-center space-x-4">
-      <div className="h-9 w-9 rounded-md bg-gray-5" />
-    </div>,
-    <div className="h-4 w-72 rounded bg-gray-5" />,
-    <div className="ml-3 h-4 w-24 rounded bg-gray-5" />,
-  ];
-
-  const columnsWidth = [
-    {
-      width: 'flex w-1/12 cursor-pointer items-center',
-    },
-    {
-      width: 'flex grow cursor-pointer items-center pl-4',
-    },
-    {
-      width: 'hidden w-3/12 lg:flex pl-4',
-    },
-  ].map((column) => column.width);
-
-  return (
-    <div className="group relative flex h-14 w-full shrink-0 animate-pulse flex-row items-center pl-2 pr-2">
-      {new Array(5).fill(0).map((col, i) => (
-        <div
-          key={`${col}-${i}`}
-          className={`relative flex h-full shrink-0 flex-row items-center overflow-hidden whitespace-nowrap border-b border-gray-5 ${columnsWidth[i]}`}
-        >
-          {skinSkeleton?.[i]}
-        </div>
-      ))}
-      <div className="h-full w-12" />
-    </div>
-  );
-};

--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -82,14 +82,14 @@ const isAdvancedShareItem = (item: DriveItemData | AdvancedSharedItem): item is 
   return item['encryptionKey'];
 };
 
-const getLocalUserData = () => {
+const getLocalUserData = (avatarBlob?: string) => {
   const user = localStorageService.getUser() as UserSettings;
-  const onwerData = {
+  const ownerData = {
     name: user.name,
     lastname: user.lastname,
     email: user.email,
     sharingId: '',
-    avatar: user.avatar,
+    avatar: avatarBlob ?? user.avatar,
     uuid: user.uuid,
     role: {
       id: 'NONE',
@@ -98,7 +98,7 @@ const getLocalUserData = () => {
       updatedAt: '',
     },
   };
-  return onwerData;
+  return ownerData;
 };
 
 // TODO: THIS IS TEMPORARY, REMOVE WHEN NEED TO SHOW OTHER ROLES
@@ -220,8 +220,9 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
       // the server throws an error when there are no users with shared item,
       // that means that the local user is the owner as there is nobody else with this shared file.
       if (isUserOwner) {
-        const onwerData = getLocalUserData();
-        setInvitedUsers([{ ...onwerData, roleName: 'owner' }]);
+        const ownerAvatar = avatarBlob ? URL.createObjectURL(avatarBlob) : undefined;
+        const ownerData = getLocalUserData(ownerAvatar);
+        setInvitedUsers([{ ...ownerData, roleName: 'owner' }]);
       }
     }
   }, [itemToShare, roles]);
@@ -575,7 +576,6 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
                     <User
                       user={user}
                       key={user.email}
-                      avatarSrc={avatarBlob ? URL.createObjectURL(avatarBlob) : user.avatar}
                       listPosition={index}
                       translate={translate}
                       openUserOptions={openUserOptions}

--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -44,7 +44,10 @@ import { InvitedUsersSkeletonLoader } from './components/InvitedUsersSkeletonLoa
 import { useAvatar } from 'hooks/useAvatar';
 import { deleteDatabaseProfileAvatar, getDatabaseProfileAvatar } from 'app/drive/services/database.service';
 import userService from 'app/auth/services/user.service';
-import { saveAvatarToDatabase } from 'app/newSettings/Sections/Account/Account/components/AvatarWrapper';
+import {
+  saveAvatarToDatabase,
+  showUpdateAvatarErrorToast,
+} from 'app/newSettings/Sections/Account/Account/components/AvatarWrapper';
 import {
   AccessMode,
   InvitedUserProps,
@@ -117,6 +120,7 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
     downloadAvatar: userService.downloadAvatar,
     getDatabaseAvatar: getDatabaseProfileAvatar,
     saveAvatarToDatabase: saveAvatarToDatabase,
+    onError: showUpdateAvatarErrorToast,
   });
 
   const [roles, setRoles] = useState<Role[]>([]);

--- a/src/app/drive/components/ShareDialog/components/InvitedUsersSkeletonLoader.tsx
+++ b/src/app/drive/components/ShareDialog/components/InvitedUsersSkeletonLoader.tsx
@@ -1,0 +1,35 @@
+export const InvitedUsersSkeletonLoader = () => {
+  const skinSkeleton = [
+    <div className="flex flex-row items-center space-x-4">
+      <div className="h-9 w-9 rounded-md bg-gray-5" />
+    </div>,
+    <div className="h-4 w-72 rounded bg-gray-5" />,
+    <div className="ml-3 h-4 w-24 rounded bg-gray-5" />,
+  ];
+
+  const columnsWidth = [
+    {
+      width: 'flex w-1/12 cursor-pointer items-center',
+    },
+    {
+      width: 'flex grow cursor-pointer items-center pl-4',
+    },
+    {
+      width: 'hidden w-3/12 lg:flex pl-4',
+    },
+  ].map((column) => column.width);
+
+  return (
+    <div className="group relative flex h-14 w-full shrink-0 animate-pulse flex-row items-center pl-2 pr-2">
+      {new Array(5).fill(0).map((col, i) => (
+        <div
+          key={`${col}-${i}`}
+          className={`relative flex h-full shrink-0 flex-row items-center overflow-hidden whitespace-nowrap border-b border-gray-5 ${columnsWidth[i]}`}
+        >
+          {skinSkeleton?.[i]}
+        </div>
+      ))}
+      <div className="h-full w-12" />
+    </div>
+  );
+};

--- a/src/app/drive/components/ShareDialog/components/InvitedUsersSkeletonLoader.tsx
+++ b/src/app/drive/components/ShareDialog/components/InvitedUsersSkeletonLoader.tsx
@@ -1,10 +1,10 @@
 export const InvitedUsersSkeletonLoader = () => {
   const skinSkeleton = [
-    <div className="flex flex-row items-center space-x-4">
+    <div key={'skin-skeleton-1'} className="flex flex-row items-center space-x-4">
       <div className="h-9 w-9 rounded-md bg-gray-5" />
     </div>,
-    <div className="h-4 w-72 rounded bg-gray-5" />,
-    <div className="ml-3 h-4 w-24 rounded bg-gray-5" />,
+    <div key={'skin-skeleton-2'} className="h-4 w-72 rounded bg-gray-5" />,
+    <div key={'skin-skeleton-3'} className="ml-3 h-4 w-24 rounded bg-gray-5" />,
   ];
 
   const columnsWidth = [
@@ -20,7 +20,10 @@ export const InvitedUsersSkeletonLoader = () => {
   ].map((column) => column.width);
 
   return (
-    <div className="group relative flex h-14 w-full shrink-0 animate-pulse flex-row items-center pl-2 pr-2">
+    <div
+      data-testid="invited-users-skeleton-loader"
+      className="group relative flex h-14 w-full shrink-0 animate-pulse flex-row items-center pl-2 pr-2"
+    >
       {new Array(5).fill(0).map((col, i) => (
         <div
           key={`${col}-${i}`}

--- a/src/app/drive/components/ShareDialog/components/User.tsx
+++ b/src/app/drive/components/ShareDialog/components/User.tsx
@@ -1,0 +1,82 @@
+import { CaretDown } from '@phosphor-icons/react';
+import { InvitedUserProps } from '../ShareDialog';
+import { Avatar } from '@internxt/ui';
+import { MouseEvent } from 'react';
+import { UserOptions } from './UserOptions';
+
+export const User = ({
+  user,
+  listPosition,
+  translate,
+  openUserOptions,
+  avatarSrc,
+  selectedUserListIndex,
+  userOptionsY,
+  onRemoveUser,
+  userOptionsEmail,
+  onChangeRole,
+  disableUserOptionsPanel,
+  disableRoleChange,
+}: {
+  user: InvitedUserProps;
+  listPosition: number | null;
+  avatarSrc: string | null;
+  translate: (key: string, props?: Record<string, unknown>) => string;
+  openUserOptions: (
+    event: MouseEvent<HTMLDivElement, globalThis.MouseEvent>,
+    user: InvitedUserProps,
+    listPosition: number | null,
+  ) => void;
+  selectedUserListIndex;
+  userOptionsY;
+  onRemoveUser;
+  userOptionsEmail;
+  onChangeRole: (email: string, roleName: string) => void;
+  disableUserOptionsPanel: boolean;
+  disableRoleChange: boolean;
+}) => (
+  <div
+    className={`group flex h-14 shrink-0 items-center space-x-2.5 border-t ${
+      user.roleName === 'owner' ? 'border-transparent' : 'border-gray-5'
+    }`}
+  >
+    <Avatar src={avatarSrc} fullName={`${user.name} ${user.lastname}`} diameter={40} />
+
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <p className="w-full overflow-hidden text-ellipsis whitespace-nowrap font-medium leading-tight">
+        {user.name}&nbsp;{user.lastname}
+      </p>
+      <p className="w-full overflow-hidden text-ellipsis whitespace-nowrap text-sm leading-none text-gray-50">
+        {user.email}
+      </p>
+    </div>
+
+    {user.roleName === 'owner' || disableUserOptionsPanel ? (
+      <div className="px-3 text-gray-50">{translate(`modals.shareModal.list.userItem.roles.${user.roleName}`)}</div>
+    ) : (
+      <>
+        <div
+          className="relative flex h-9 cursor-pointer select-none flex-row items-center justify-center space-x-2 whitespace-nowrap rounded-lg border border-gray-10 bg-surface px-3 text-base font-medium text-gray-80 outline-none ring-2 ring-primary/0 ring-offset-2 ring-offset-transparent transition-all duration-100 ease-in-out hover:border-gray-20 focus-visible:shadow-sm focus-visible:ring-primary/50 active:bg-gray-1 group-hover:border-gray-20 group-hover:shadow-sm dark:bg-gray-5 dark:active:bg-gray-10"
+          onMouseUpCapture={(event) => openUserOptions(event, user, listPosition)}
+          tabIndex={-1}
+        >
+          <span className="pointer-events-none">
+            {translate(`modals.shareModal.list.userItem.roles.${user.roleName}`)}
+          </span>
+          <CaretDown size={16} weight="bold" className="pointer-events-none" />
+        </div>
+        <UserOptions
+          listPosition={listPosition}
+          selectedUserListIndex={selectedUserListIndex}
+          userOptionsY={userOptionsY}
+          translate={translate}
+          onRemoveUser={onRemoveUser}
+          userOptionsEmail={userOptionsEmail}
+          selectedRole={user.roleName}
+          onChangeRole={(roleName) => onChangeRole(user.email, roleName)}
+          disableRoleChange={disableRoleChange}
+        />
+      </>
+    )}
+  </div>
+);

--- a/src/app/drive/components/ShareDialog/components/User.tsx
+++ b/src/app/drive/components/ShareDialog/components/User.tsx
@@ -1,8 +1,8 @@
 import { CaretDown } from '@phosphor-icons/react';
-import { InvitedUserProps } from '../ShareDialog';
 import { Avatar } from '@internxt/ui';
 import { MouseEvent } from 'react';
 import { UserOptions } from './UserOptions';
+import { InvitedUserProps } from '../types';
 
 export const User = ({
   user,

--- a/src/app/drive/components/ShareDialog/components/User.tsx
+++ b/src/app/drive/components/ShareDialog/components/User.tsx
@@ -9,7 +9,6 @@ export const User = ({
   listPosition,
   translate,
   openUserOptions,
-  avatarSrc,
   selectedUserListIndex,
   userOptionsY,
   onRemoveUser,
@@ -20,7 +19,6 @@ export const User = ({
 }: {
   user: InvitedUserProps;
   listPosition: number | null;
-  avatarSrc: string | null;
   translate: (key: string, props?: Record<string, unknown>) => string;
   openUserOptions: (
     event: MouseEvent<HTMLDivElement, globalThis.MouseEvent>,
@@ -40,7 +38,7 @@ export const User = ({
       user.roleName === 'owner' ? 'border-transparent' : 'border-gray-5'
     }`}
   >
-    <Avatar src={avatarSrc} fullName={`${user.name} ${user.lastname}`} diameter={40} />
+    <Avatar src={user.avatar} fullName={`${user.name} ${user.lastname}`} diameter={40} />
 
     <div className="flex flex-1 flex-col overflow-hidden">
       <p className="w-full overflow-hidden text-ellipsis whitespace-nowrap font-medium leading-tight">

--- a/src/app/drive/components/ShareDialog/components/UserOptions.tsx
+++ b/src/app/drive/components/ShareDialog/components/UserOptions.tsx
@@ -1,0 +1,85 @@
+import { Popover } from '@headlessui/react';
+import { Check } from '@phosphor-icons/react';
+
+export const UserOptions = ({
+  listPosition,
+  selectedUserListIndex,
+  userOptionsY,
+  translate,
+  onRemoveUser,
+  userOptionsEmail,
+  selectedRole,
+  onChangeRole,
+  disableRoleChange,
+}): JSX.Element => {
+  const isUserSelected = selectedUserListIndex === listPosition;
+
+  return isUserSelected ? (
+    <Popover
+      className="absolute z-10 h-0 max-h-0 w-full"
+      style={{
+        top: `${userOptionsY}px`,
+        right: 0,
+        minWidth: '160px',
+      }}
+    >
+      <Popover.Panel
+        className={`absolute right-0 z-10 origin-top-right whitespace-nowrap rounded-lg border border-gray-10 bg-surface p-1 shadow-subtle transition-all duration-50 ease-out dark:bg-gray-5 ${
+          isUserSelected ? 'scale-100 opacity-100' : 'pointer-events-none scale-95 opacity-0'
+        }`}
+        style={{
+          top: '44px',
+          minWidth: '160px',
+        }}
+        static
+      >
+        {disableRoleChange ? (
+          <></>
+        ) : (
+          <>
+            {/* Editor */}
+            <button
+              className="flex h-9 w-full cursor-pointer items-center justify-start space-x-3 rounded-lg px-3 hover:bg-gray-5 dark:hover:bg-gray-10"
+              onClick={() => {
+                onChangeRole('editor');
+              }}
+            >
+              <p className="w-full text-left text-base font-medium leading-none">
+                {translate('modals.shareModal.list.userItem.roles.editor')}
+              </p>
+              {selectedRole === 'editor' && <Check size={20} />}
+            </button>
+
+            {/* Reader */}
+            <button
+              className="flex h-9 w-full cursor-pointer items-center justify-start space-x-3 rounded-lg px-3 hover:bg-gray-5 dark:hover:bg-gray-10"
+              onClick={() => {
+                onChangeRole('reader');
+              }}
+            >
+              <p className="w-full text-left text-base font-medium leading-none">
+                {translate('modals.shareModal.list.userItem.roles.reader')}
+              </p>
+              {selectedRole === 'reader' && <Check size={20} />}
+            </button>
+
+            <div className="mx-3 my-0.5 flex h-px bg-gray-10" />
+          </>
+        )}
+        {/* Remove */}
+        <button
+          className="flex h-9 w-full cursor-pointer items-center justify-start space-x-3 rounded-lg px-3 hover:bg-gray-5 dark:hover:bg-gray-10"
+          onClick={() => {
+            onRemoveUser(userOptionsEmail);
+          }}
+        >
+          <p className="w-full text-left text-base font-medium leading-none">
+            {translate('modals.shareModal.list.userItem.remove')}
+          </p>
+        </button>
+      </Popover.Panel>
+    </Popover>
+  ) : (
+    <></>
+  );
+};

--- a/src/app/drive/components/ShareDialog/types.ts
+++ b/src/app/drive/components/ShareDialog/types.ts
@@ -1,0 +1,33 @@
+export type AccessMode = 'public' | 'restricted';
+export type UserRole = 'owner' | 'editor' | 'reader';
+export type Views = 'general' | 'invite' | 'requests';
+export type RequestStatus = 'pending' | 'accepted' | 'denied';
+
+export const REQUEST_STATUS = {
+  PENDING: 'pending' as RequestStatus,
+  ACCEPTED: 'accepted' as RequestStatus,
+  DENIED: 'denied' as RequestStatus,
+};
+
+export interface InvitedUserProps {
+  avatar: string | null;
+  name: string;
+  lastname: string;
+  email: string;
+  roleName: UserRole;
+  uuid: string;
+  sharingId: string;
+}
+
+export interface RequestProps {
+  avatar: string;
+  name: string;
+  lastname: string;
+  email: string;
+  message?: string;
+  status: RequestStatus;
+}
+
+export interface ViewProps {
+  view: Views;
+}

--- a/src/app/i18n/locales/de.json
+++ b/src/app/i18n/locales/de.json
@@ -1000,7 +1000,8 @@
     "errorMovingToTrash": "Beim Verschieben der Elemente in den Papierkorb ist ein Fehler aufgetreten.",
     "errorDeletingFromTrash": "Beim Löschen der Elemente aus dem Papierkorb ist ein Fehler aufgetreten.",
     "maxSizeUploadLimitError": "Datei zu groß (größer als 40 GB)",
-    "braveNotSupportMultiplePhotosDowload": "Brave unterstützt nicht das Herunterladen mehrerer Fotos."
+    "braveNotSupportMultiplePhotosDowload": "Brave unterstützt nicht das Herunterladen mehrerer Fotos.",
+    "updateAvatarError": "Fehler beim Aktualisieren des Avatars"
   },
   "backups": {
     "backups-from": "Backups von {{deviceName}}",

--- a/src/app/i18n/locales/en.json
+++ b/src/app/i18n/locales/en.json
@@ -6,10 +6,10 @@
   "featuresBanner": {
     "label": "Save 80%",
     "title": "Annual and lifetime plans!",
-    "upperTitle":"Hot summer savings",
+    "upperTitle": "Hot summer savings",
     "cta": "Claim deal",
     "guarantee": "30-day money-back guarantee",
-    "specialOfferGift":"Chance to win an Internxt backpack",
+    "specialOfferGift": "Chance to win an Internxt backpack",
     "lastCta": "*Offer is for free accounts or new customers",
     "features": [
       "Drive, VPN, and Antivirus",
@@ -1050,7 +1050,8 @@
     "errorDeletingFromTrash": "An error occurred while deleting the items from trash.",
     "maxSizeUploadLimitError": "File too large (greater than 40GB)",
     "connectionLostError": "Internet connection lost",
-    "errorLoadingTrashItems": "Error loading trash items"
+    "errorLoadingTrashItems": "Error loading trash items",
+    "updateAvatarError": "Error updating avatar"
   },
   "backups": {
     "backups-from": "Backups from {{deviceName}}",

--- a/src/app/i18n/locales/es.json
+++ b/src/app/i18n/locales/es.json
@@ -4,13 +4,13 @@
     "logOut": "Cerrar sesión"
   },
 
- "featuresBanner": {
+  "featuresBanner": {
     "label": "Ahorra 80%",
     "title": "Descuento en todos los planes",
-    "upperTitle":"Oferta de verano",
+    "upperTitle": "Oferta de verano",
     "cta": "Obtener oferta",
     "guarantee": "Garantía de devolución de 30 días",
-    "specialOfferGift":"Sorteo de una mochila Internxt x Swiss Peak",
+    "specialOfferGift": "Sorteo de una mochila Internxt x Swiss Peak",
     "lastCta": "*La oferta es para cuentas gratuitas o nuevos clientes",
     "features": [
       "Drive, VPN, y Antivirus ",
@@ -18,7 +18,7 @@
       "Cifrado post-cuántico",
       "Transferencias cifradas de extremo a extremo",
       "Sin accesos no autorizados",
-      "Tema de verano gratis"      
+      "Tema de verano gratis"
     ]
   },
   "susbcriptionsBanner": {
@@ -1030,7 +1030,8 @@
     "errorDeletingFromTrash": "Ha ocurrido un error mientras se eliminaban los items de la basura.",
     "maxSizeUploadLimitError": "File too large (greater than 40GB)",
     "connectionLostError": "Conexión a internet perdida",
-    "errorLoadingTrashItems": "Error al cargar items de la papelera"
+    "errorLoadingTrashItems": "Error al cargar items de la papelera",
+    "updateAvatarError": "Error al actualizar el avatar"
   },
   "backups": {
     "backups-from": "Copias de seguridad de {{deviceName}}",

--- a/src/app/i18n/locales/fr.json
+++ b/src/app/i18n/locales/fr.json
@@ -1009,7 +1009,8 @@
     "errorMovingToTrash": "Error lors du déplacement des éléments.",
     "maxSizeUploadLimitError": "Fichier trop volumineux (plus de 40GB)",
     "connectionLostError": "Lost Internet connection",
-    "errorLoadingTrashItems": "Erreur de chargement des éléments de la corbeille"
+    "errorLoadingTrashItems": "Erreur de chargement des éléments de la corbeille",
+    "updateAvatarError": "Erreur lors de la mise à jour de l'avatar"
   },
   "backups": {
     "backups-from": "Sauvagardes de {{deviceName}}",

--- a/src/app/i18n/locales/it.json
+++ b/src/app/i18n/locales/it.json
@@ -1117,7 +1117,8 @@
     "errorDeletingFromTrash": "Si è verificato un errore durante l'eliminazione degli elementi dal cestino.",
     "maxSizeUploadLimitError": "File troppo grande (superiore a 40GB)",
     "connectionLostError": "Connessione Internet persa",
-    "errorLoadingTrashItems": "Errore nel caricamento degli elementi del cestino"
+    "errorLoadingTrashItems": "Errore nel caricamento degli elementi del cestino",
+    "updateAvatarError": "Errore nell'aggiornamento dell'avatar"
   },
   "backups": {
     "backups-from": "Backup da {{deviceName}}",

--- a/src/app/i18n/locales/ru.json
+++ b/src/app/i18n/locales/ru.json
@@ -1022,7 +1022,8 @@
     "errorDeletingFromTrash": "При удалении элементов из корзины произошла ошибка.",
     "maxSizeUploadLimitError": "Слишком большой файл (более 40 ГБ)",
     "connectionLostError": "Потеряно подключение к Интернету",
-    "errorLoadingTrashItems": "Ошибка при загрузке элементов корзины"
+    "errorLoadingTrashItems": "Ошибка при загрузке элементов корзины",
+    "updateAvatarError": "Ошибка при обновлении аватара"
   },
   "backups": {
     "backups-from": "Резервные копии с {{deviceName}}",

--- a/src/app/i18n/locales/tw.json
+++ b/src/app/i18n/locales/tw.json
@@ -1011,7 +1011,8 @@
     "errorDeletingFromTrash": "從垃圾桶中刪除項目時出錯。",
     "maxSizeUploadLimitError": "文件過大（大於40GB）",
     "connectionLostError": "網絡連接已丟失",
-    "errorLoadingTrashItems": "加載垃圾桶項目時出錯"
+    "errorLoadingTrashItems": "加載垃圾桶項目時出錯",
+    "updateAvatarError": "更新頭像時發生錯誤"
   },
   "backups": {
     "backups-from": "來自{{deviceName}}的備份",

--- a/src/app/i18n/locales/zh.json
+++ b/src/app/i18n/locales/zh.json
@@ -1046,7 +1046,8 @@
     "errorDeletingFromTrash": "从垃圾箱中删除项目时出错。",
     "maxSizeUploadLimitError": "文件太大（大于40GB）",
     "connectionLostError": "互联网连接丢失",
-    "errorLoadingTrashItems": "加载垃圾箱内的项目时出错"
+    "errorLoadingTrashItems": "加载垃圾箱内的项目时出错",
+    "updateAvatarError": "更新头像时出错"
   },
   "backups": {
     "backups-from": "来自 {{deviceName}} 的备份",

--- a/src/app/newSettings/Sections/Account/Account/components/AvatarWrapper.tsx
+++ b/src/app/newSettings/Sections/Account/Account/components/AvatarWrapper.tsx
@@ -1,13 +1,13 @@
-import { memo, useEffect, useState } from 'react';
+import { memo } from 'react';
 import {
   deleteDatabaseProfileAvatar,
   getDatabaseProfileAvatar,
   updateDatabaseProfileAvatar,
 } from '../../../../../drive/services/database.service';
-import * as Sentry from '@sentry/react';
 import notificationsService, { ToastType } from '../../../../../notifications/services/notifications.service';
 import { Avatar } from '@internxt/ui';
 import userService from 'app/auth/services/user.service';
+import { useAvatar } from 'hooks/useAvatar';
 
 export const extractAvatarURLID = (url: string): string | null => {
   const regex = /internxt\.com\/(.*?)[?&]/;
@@ -42,53 +42,13 @@ const AvatarWrapper = memo(
     diameter: number;
     style?: Record<string, string | number>;
   }): JSX.Element => {
-    const [avatarBlob, setAvatarBlob] = useState<Blob | null>(null);
-
-    useEffect(() => {
-      const handleAvatarData = async () => {
-        try {
-          if (avatarSrcURL) {
-            await handleDownload(avatarSrcURL);
-            return;
-          }
-          deleteDatabaseProfileAvatar();
-          setAvatarBlob(null);
-        } catch (error) {
-          Sentry.captureException(error, {
-            extra: {
-              avatarURL: avatarSrcURL,
-            },
-          });
-          showUpdateProfilePhotoErrorToast();
-          setAvatarBlob(null);
-        }
-      };
-
-      handleAvatarData();
-    }, [avatarSrcURL]);
-
-    const downloadAndSaveAvatar = async (url: string) => {
-      const avatar = await userService.downloadAvatar(url);
-      setAvatarBlob(avatar);
-      await saveAvatarToDatabase(url, avatar);
-    };
-
-    const handleDownload = async (url: string) => {
-      const databaseAvatarData = await getDatabaseProfileAvatar();
-
-      if (!databaseAvatarData) {
-        downloadAndSaveAvatar(url);
-        return;
-      }
-
-      const existsNewAvatar = databaseAvatarData.uuid !== extractAvatarURLID(url);
-
-      if (existsNewAvatar) {
-        return downloadAndSaveAvatar(url);
-      }
-
-      setAvatarBlob(databaseAvatarData.avatarBlob);
-    };
+    const { avatarBlob } = useAvatar({
+      avatarSrcURL,
+      deleteDatabaseAvatar: deleteDatabaseProfileAvatar,
+      downloadAvatar: userService.downloadAvatar,
+      getDatabaseAvatar: getDatabaseProfileAvatar,
+      saveAvatarToDatabase: saveAvatarToDatabase,
+    });
 
     return (
       <Avatar

--- a/src/app/newSettings/Sections/Account/Account/components/AvatarWrapper.tsx
+++ b/src/app/newSettings/Sections/Account/Account/components/AvatarWrapper.tsx
@@ -4,22 +4,23 @@ import {
   getDatabaseProfileAvatar,
   updateDatabaseProfileAvatar,
 } from '../../../../../drive/services/database.service';
-import notificationsService, { ToastType } from '../../../../../notifications/services/notifications.service';
 import { Avatar } from '@internxt/ui';
 import userService from 'app/auth/services/user.service';
 import { useAvatar } from 'hooks/useAvatar';
+import { t } from 'i18next';
+import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
+
+export const showUpdateAvatarErrorToast = () =>
+  notificationsService.show({
+    text: t('error.updateAvatarError'),
+    type: ToastType.Error,
+  });
 
 export const extractAvatarURLID = (url: string): string | null => {
   const regex = /internxt\.com\/(.*?)[?&]/;
   const match = url.match(regex);
   return match ? match[1] : null;
 };
-
-const showUpdateProfilePhotoErrorToast = () =>
-  notificationsService.show({
-    text: 'Error updating profile photo',
-    type: ToastType.Error,
-  });
 
 export const saveAvatarToDatabase = async (url: string, avatar: Blob): Promise<void> => {
   const uuid = extractAvatarURLID(url);
@@ -48,6 +49,7 @@ const AvatarWrapper = memo(
       downloadAvatar: userService.downloadAvatar,
       getDatabaseAvatar: getDatabaseProfileAvatar,
       saveAvatarToDatabase: saveAvatarToDatabase,
+      onError: showUpdateAvatarErrorToast,
     });
 
     return (

--- a/src/app/newSettings/Sections/Workspace/Overview/OverviewSection.tsx
+++ b/src/app/newSettings/Sections/Workspace/Overview/OverviewSection.tsx
@@ -383,7 +383,7 @@ const WorkspaceProfileCard: React.FC<WorkspaceProfileCardProps> = ({
     <div className="flex w-full flex-col items-center justify-center space-y-4">
       <div className="flex flex-col justify-center">
         {isOwner ? (
-          <>
+          <div className="relative flex z-50">
             <Dropdown
               options={isOwner ? dropdownOptions : undefined}
               classMenuItems={'-left-6 mt-1 w-max rounded-md border border-gray-10 bg-surface dark:bg-gray-5'}
@@ -412,7 +412,7 @@ const WorkspaceProfileCard: React.FC<WorkspaceProfileCardProps> = ({
               }
               onSavingAvatarError={errorService.reportError}
             />
-          </>
+          </div>
         ) : (
           <WorkspaceAvatarWrapper
             diameter={128}

--- a/src/app/newSettings/Sections/Workspace/Overview/OverviewSection.tsx
+++ b/src/app/newSettings/Sections/Workspace/Overview/OverviewSection.tsx
@@ -383,26 +383,28 @@ const WorkspaceProfileCard: React.FC<WorkspaceProfileCardProps> = ({
     <div className="flex w-full flex-col items-center justify-center space-y-4">
       <div className="flex flex-col justify-center">
         {isOwner ? (
-          <div className="relative flex z-50">
-            <Dropdown
-              options={isOwner ? dropdownOptions : undefined}
-              classMenuItems={'-left-6 mt-1 w-max rounded-md border border-gray-10 bg-surface dark:bg-gray-5'}
-              openDirection={'right'}
-            >
-              <div className="relative">
-                <WorkspaceAvatarWrapper
-                  diameter={128}
-                  workspaceId={workspaceId}
-                  fullName={companyName ?? ''}
-                  avatarSrcURL={avatarSrcURL}
-                />
-                {
-                  <div className="absolute -bottom-1.5 -right-0.5 flex h-8 w-8 items-center justify-center rounded-full border-3 border-surface bg-gray-5 text-gray-60 dark:bg-gray-10">
-                    <PencilSimple size={16} />
-                  </div>
-                }
-              </div>
-            </Dropdown>
+          <>
+            <div className="relative flex z-50">
+              <Dropdown
+                options={isOwner ? dropdownOptions : undefined}
+                classMenuItems={'-left-6 mt-1 w-max rounded-md border border-gray-10 bg-surface dark:bg-gray-5'}
+                openDirection={'right'}
+              >
+                <div className="relative">
+                  <WorkspaceAvatarWrapper
+                    diameter={128}
+                    workspaceId={workspaceId}
+                    fullName={companyName ?? ''}
+                    avatarSrcURL={avatarSrcURL}
+                  />
+                  {
+                    <div className="absolute -bottom-1.5 -right-0.5 flex h-8 w-8 items-center justify-center rounded-full border-3 border-surface bg-gray-5 text-gray-60 dark:bg-gray-10">
+                      <PencilSimple size={16} />
+                    </div>
+                  }
+                </div>
+              </Dropdown>
+            </div>
             <UploadAvatarModal
               isOpen={openEditAvatarModal}
               onClose={() => setOpenEditAvatarModal(false)}
@@ -412,7 +414,7 @@ const WorkspaceProfileCard: React.FC<WorkspaceProfileCardProps> = ({
               }
               onSavingAvatarError={errorService.reportError}
             />
-          </div>
+          </>
         ) : (
           <WorkspaceAvatarWrapper
             diameter={128}

--- a/src/app/newSettings/Sections/Workspace/Overview/components/WorkspaceAvatarWrapper.tsx
+++ b/src/app/newSettings/Sections/Workspace/Overview/components/WorkspaceAvatarWrapper.tsx
@@ -1,6 +1,5 @@
 import { Avatar } from '@internxt/ui';
 import userService from 'app/auth/services/user.service';
-import { memo } from 'react';
 import {
   deleteDatabaseWorkspaceAvatar,
   getDatabaseWorkspaceAvatar,
@@ -28,38 +27,36 @@ export const deleteWorkspaceAvatarFromDatabase = async (workspaceId: string): Pr
   return await deleteDatabaseWorkspaceAvatar(workspaceId);
 };
 
-const WorkspaceAvatarWrapper = memo(
-  ({
-    workspaceId,
+const WorkspaceAvatarWrapper = ({
+  workspaceId,
+  avatarSrcURL,
+  fullName,
+  diameter,
+  style,
+}: {
+  workspaceId: string;
+  avatarSrcURL: string | null;
+  fullName: string;
+  diameter: number;
+  style?: Record<string, string | number>;
+}): JSX.Element => {
+  const { avatarBlob } = useAvatar({
     avatarSrcURL,
-    fullName,
-    diameter,
-    style,
-  }: {
-    workspaceId: string;
-    avatarSrcURL: string | null;
-    fullName: string;
-    diameter: number;
-    style?: Record<string, string | number>;
-  }): JSX.Element => {
-    const { avatarBlob } = useAvatar({
-      avatarSrcURL,
-      getDatabaseAvatar: () => getDatabaseWorkspaceAvatar(workspaceId),
-      saveAvatarToDatabase: (url, blob) => saveWorkspaceAvatarToDatabase(workspaceId, url, blob),
-      deleteDatabaseAvatar: () => deleteDatabaseWorkspaceAvatar(workspaceId),
-      downloadAvatar: userService.downloadAvatar,
-      onError: showUpdateAvatarErrorToast,
-    });
+    getDatabaseAvatar: () => getDatabaseWorkspaceAvatar(workspaceId),
+    saveAvatarToDatabase: (url, blob) => saveWorkspaceAvatarToDatabase(workspaceId, url, blob),
+    deleteDatabaseAvatar: () => deleteDatabaseWorkspaceAvatar(workspaceId),
+    downloadAvatar: userService.downloadAvatar,
+    onError: showUpdateAvatarErrorToast,
+  });
 
-    return (
-      <Avatar
-        diameter={diameter}
-        fullName={fullName}
-        src={avatarBlob ? URL.createObjectURL(avatarBlob) : null}
-        style={style}
-      />
-    );
-  },
-);
+  return (
+    <Avatar
+      diameter={diameter}
+      fullName={fullName}
+      src={avatarBlob ? URL.createObjectURL(avatarBlob) : null}
+      style={style}
+    />
+  );
+};
 
 export default WorkspaceAvatarWrapper;

--- a/src/app/newSettings/Sections/Workspace/Overview/components/WorkspaceAvatarWrapper.tsx
+++ b/src/app/newSettings/Sections/Workspace/Overview/components/WorkspaceAvatarWrapper.tsx
@@ -1,13 +1,13 @@
 import { Avatar } from '@internxt/ui';
-import * as Sentry from '@sentry/react';
 import userService from 'app/auth/services/user.service';
-import { memo, useEffect, useState } from 'react';
+import { memo } from 'react';
 import {
   deleteDatabaseWorkspaceAvatar,
   getDatabaseWorkspaceAvatar,
   updateDatabaseWorkspaceAvatar,
 } from '../../../../../drive/services/database.service';
 import notificationsService, { ToastType } from '../../../../../notifications/services/notifications.service';
+import { useAvatar } from 'hooks/useAvatar';
 
 const showUpdateWorkspaceAvatarErrorToast = () =>
   notificationsService.show({
@@ -41,53 +41,13 @@ const WorkspaceAvatarWrapper = memo(
     diameter: number;
     style?: Record<string, string | number>;
   }): JSX.Element => {
-    const [avatarBlob, setAvatarBlob] = useState<Blob | null>(null);
-
-    useEffect(() => {
-      const handleAvatarData = async () => {
-        try {
-          if (avatarSrcURL) {
-            await handleDownload(avatarSrcURL);
-            return;
-          }
-          if (avatarSrcURL && avatarSrcURL.length > 0) deleteDatabaseWorkspaceAvatar(workspaceId);
-          setAvatarBlob(null);
-        } catch (error) {
-          Sentry.captureException(error, {
-            extra: {
-              workspaceAvatarURL: avatarSrcURL,
-            },
-          });
-          showUpdateWorkspaceAvatarErrorToast();
-          setAvatarBlob(null);
-        }
-      };
-
-      handleAvatarData();
-    }, [avatarSrcURL]);
-
-    const downloadAndSaveAvatar = async (url: string) => {
-      const avatar = await userService.downloadAvatar(url);
-      setAvatarBlob(avatar);
-      await saveWorkspaceAvatarToDatabase(workspaceId, url, avatar);
-    };
-
-    const handleDownload = async (url: string) => {
-      const databaseAvatarData = await getDatabaseWorkspaceAvatar(workspaceId).catch();
-
-      if (!databaseAvatarData) {
-        downloadAndSaveAvatar(url);
-        return;
-      }
-
-      const existsNewAvatar = databaseAvatarData.srcURL !== url;
-
-      if (existsNewAvatar) {
-        return downloadAndSaveAvatar(url);
-      }
-
-      setAvatarBlob(databaseAvatarData.avatarBlob);
-    };
+    const { avatarBlob } = useAvatar({
+      avatarSrcURL,
+      getDatabaseAvatar: () => getDatabaseWorkspaceAvatar(workspaceId),
+      saveAvatarToDatabase: (url, blob) => saveWorkspaceAvatarToDatabase(workspaceId, url, blob),
+      deleteDatabaseAvatar: () => deleteDatabaseWorkspaceAvatar(workspaceId),
+      downloadAvatar: userService.downloadAvatar,
+    });
 
     return (
       <Avatar

--- a/src/app/newSettings/Sections/Workspace/Overview/components/WorkspaceAvatarWrapper.tsx
+++ b/src/app/newSettings/Sections/Workspace/Overview/components/WorkspaceAvatarWrapper.tsx
@@ -1,19 +1,13 @@
 import { Avatar } from '@internxt/ui';
 import userService from 'app/auth/services/user.service';
+import { memo } from 'react';
 import {
   deleteDatabaseWorkspaceAvatar,
   getDatabaseWorkspaceAvatar,
   updateDatabaseWorkspaceAvatar,
 } from '../../../../../drive/services/database.service';
-import notificationsService, { ToastType } from '../../../../../notifications/services/notifications.service';
 import { useAvatar } from 'hooks/useAvatar';
 import { showUpdateAvatarErrorToast } from 'app/newSettings/Sections/Account/Account/components/AvatarWrapper';
-
-const showUpdateWorkspaceAvatarErrorToast = () =>
-  notificationsService.show({
-    text: 'Error updating workspace avatar photo',
-    type: ToastType.Error,
-  });
 
 export const saveWorkspaceAvatarToDatabase = async (workspaceId: string, url: string, avatar: Blob): Promise<void> => {
   return await updateDatabaseWorkspaceAvatar({
@@ -27,36 +21,38 @@ export const deleteWorkspaceAvatarFromDatabase = async (workspaceId: string): Pr
   return await deleteDatabaseWorkspaceAvatar(workspaceId);
 };
 
-const WorkspaceAvatarWrapper = ({
-  workspaceId,
-  avatarSrcURL,
-  fullName,
-  diameter,
-  style,
-}: {
-  workspaceId: string;
-  avatarSrcURL: string | null;
-  fullName: string;
-  diameter: number;
-  style?: Record<string, string | number>;
-}): JSX.Element => {
-  const { avatarBlob } = useAvatar({
+const WorkspaceAvatarWrapper = memo(
+  ({
+    workspaceId,
     avatarSrcURL,
-    getDatabaseAvatar: () => getDatabaseWorkspaceAvatar(workspaceId),
-    saveAvatarToDatabase: (url, blob) => saveWorkspaceAvatarToDatabase(workspaceId, url, blob),
-    deleteDatabaseAvatar: () => deleteDatabaseWorkspaceAvatar(workspaceId),
-    downloadAvatar: userService.downloadAvatar,
-    onError: showUpdateAvatarErrorToast,
-  });
+    fullName,
+    diameter,
+    style,
+  }: {
+    workspaceId: string;
+    avatarSrcURL: string | null;
+    fullName: string;
+    diameter: number;
+    style?: Record<string, string | number>;
+  }): JSX.Element => {
+    const { avatarBlob } = useAvatar({
+      avatarSrcURL,
+      getDatabaseAvatar: () => getDatabaseWorkspaceAvatar(workspaceId),
+      saveAvatarToDatabase: (url, blob) => saveWorkspaceAvatarToDatabase(workspaceId, url, blob),
+      deleteDatabaseAvatar: () => deleteDatabaseWorkspaceAvatar(workspaceId),
+      downloadAvatar: userService.downloadAvatar,
+      onError: showUpdateAvatarErrorToast,
+    });
 
-  return (
-    <Avatar
-      diameter={diameter}
-      fullName={fullName}
-      src={avatarBlob ? URL.createObjectURL(avatarBlob) : null}
-      style={style}
-    />
-  );
-};
+    return (
+      <Avatar
+        diameter={diameter}
+        fullName={fullName}
+        src={avatarBlob ? URL.createObjectURL(avatarBlob) : null}
+        style={style}
+      />
+    );
+  },
+);
 
 export default WorkspaceAvatarWrapper;

--- a/src/app/newSettings/Sections/Workspace/Overview/components/WorkspaceAvatarWrapper.tsx
+++ b/src/app/newSettings/Sections/Workspace/Overview/components/WorkspaceAvatarWrapper.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../../../drive/services/database.service';
 import notificationsService, { ToastType } from '../../../../../notifications/services/notifications.service';
 import { useAvatar } from 'hooks/useAvatar';
+import { showUpdateAvatarErrorToast } from 'app/newSettings/Sections/Account/Account/components/AvatarWrapper';
 
 const showUpdateWorkspaceAvatarErrorToast = () =>
   notificationsService.show({
@@ -47,6 +48,7 @@ const WorkspaceAvatarWrapper = memo(
       saveAvatarToDatabase: (url, blob) => saveWorkspaceAvatarToDatabase(workspaceId, url, blob),
       deleteDatabaseAvatar: () => deleteDatabaseWorkspaceAvatar(workspaceId),
       downloadAvatar: userService.downloadAvatar,
+      onError: showUpdateAvatarErrorToast,
     });
 
     return (

--- a/src/hooks/useAvatar.test.ts
+++ b/src/hooks/useAvatar.test.ts
@@ -1,0 +1,126 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { useAvatar } from './useAvatar';
+import notificationsService from 'app/notifications/services/notifications.service';
+
+describe('Tests for useAvatar custom hook', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('When the avatar URL is null, then should delete the avatar from the database and reset avatarBlob to null', async () => {
+    const getDatabaseAvatarMock = vi.fn();
+    const deleteDatabaseAvatarMock = vi.fn().mockResolvedValue(null);
+    renderHook(() =>
+      useAvatar({
+        avatarSrcURL: null,
+        deleteDatabaseAvatar: deleteDatabaseAvatarMock,
+        downloadAvatar: vi.fn(),
+        getDatabaseAvatar: getDatabaseAvatarMock,
+        saveAvatarToDatabase: vi.fn(),
+      }),
+    );
+
+    expect(deleteDatabaseAvatarMock).toHaveBeenCalledTimes(1);
+    expect(getDatabaseAvatarMock).not.toHaveBeenCalled();
+  });
+
+  it('When no avatar exists in the database, then it should download the avatar and update the database', async () => {
+    const getDatabaseAvatarMock = vi.fn().mockResolvedValue(undefined);
+    const downloadAvatarMock = vi.fn().mockResolvedValue(new Blob());
+    const saveAvatarToDatabaseMock = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() =>
+      useAvatar({
+        avatarSrcURL: 'testSrcURL',
+        deleteDatabaseAvatar: vi.fn(),
+        downloadAvatar: downloadAvatarMock,
+        getDatabaseAvatar: getDatabaseAvatarMock,
+        saveAvatarToDatabase: saveAvatarToDatabaseMock,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getDatabaseAvatarMock).toHaveBeenCalledTimes(1);
+      expect(downloadAvatarMock).toHaveBeenCalledTimes(1);
+      expect(saveAvatarToDatabaseMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('When the DB avatar url and current URL do not match, then it should download the avatar and save it to the database', async () => {
+    const getDatabaseAvatarMock = vi.fn().mockResolvedValue({
+      srcURL: 'oldSrcURL',
+      avatarBlob: new Blob(),
+      uuid: 'testUUID',
+    });
+    const downloadAvatarMock = vi.fn().mockResolvedValue(new Blob());
+    const saveAvatarToDatabaseMock = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() =>
+      useAvatar({
+        avatarSrcURL: 'newSrcURL',
+        deleteDatabaseAvatar: vi.fn(),
+        downloadAvatar: downloadAvatarMock,
+        getDatabaseAvatar: getDatabaseAvatarMock,
+        saveAvatarToDatabase: saveAvatarToDatabaseMock,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getDatabaseAvatarMock).toHaveBeenCalledTimes(1);
+      expect(downloadAvatarMock).toHaveBeenCalledTimes(1);
+      expect(saveAvatarToDatabaseMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('When the avatar is still valid, then it should not update the database and return de cached one', async () => {
+    const getDatabaseAvatarMock = vi.fn().mockResolvedValue({
+      srcURL: 'currentSrcURL',
+      avatarBlob: new Blob(),
+      uuid: 'testUUID',
+    });
+    const downloadAvatarMock = vi.fn();
+    const saveAvatarToDatabaseMock = vi.fn();
+
+    renderHook(() =>
+      useAvatar({
+        avatarSrcURL: 'currentSrcURL',
+        deleteDatabaseAvatar: vi.fn(),
+        downloadAvatar: downloadAvatarMock,
+        getDatabaseAvatar: getDatabaseAvatarMock,
+        saveAvatarToDatabase: saveAvatarToDatabaseMock,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getDatabaseAvatarMock).toHaveBeenCalled();
+      expect(downloadAvatarMock).not.toHaveBeenCalled();
+      expect(saveAvatarToDatabaseMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('When an unexpected error occurs, then a notification is shown', async () => {
+    const getDatabaseAvatarMock = vi.fn().mockRejectedValue(new Error('Unexpected error'));
+    const downloadAvatarMock = vi.fn();
+    const saveAvatarToDatabaseMock = vi.fn();
+    const notificationServiceSpy = vi.spyOn(notificationsService, 'show');
+
+    renderHook(() =>
+      useAvatar({
+        avatarSrcURL: 'currentSrcURL',
+        deleteDatabaseAvatar: vi.fn(),
+        downloadAvatar: downloadAvatarMock,
+        getDatabaseAvatar: getDatabaseAvatarMock,
+        saveAvatarToDatabase: saveAvatarToDatabaseMock,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getDatabaseAvatarMock).toHaveBeenCalled();
+      expect(downloadAvatarMock).not.toHaveBeenCalled();
+      expect(saveAvatarToDatabaseMock).not.toHaveBeenCalled();
+
+      expect(notificationServiceSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/hooks/useAvatar.test.ts
+++ b/src/hooks/useAvatar.test.ts
@@ -73,37 +73,6 @@ describe('Tests for useAvatar custom hook', () => {
     });
   });
 
-  it('When the DB avatar is expired, then it should download the avatar and save it to the database', async () => {
-    const testBlob = new Blob(['test']);
-    getDatabaseAvatarMock.mockResolvedValue({
-      srcURL: 'oldSrcURL',
-      avatarBlob: new Blob(),
-      uuid: 'testUUID',
-    });
-    downloadAvatarMock.mockResolvedValue(testBlob);
-    saveAvatarToDatabaseMock.mockResolvedValue(undefined);
-    isAvatarExpiredMock.mockReturnValue(true);
-
-    const { result } = renderHook(() =>
-      useAvatar({
-        avatarSrcURL: 'newSrcURL',
-        deleteDatabaseAvatar: deleteDatabaseAvatarMock,
-        downloadAvatar: downloadAvatarMock,
-        getDatabaseAvatar: getDatabaseAvatarMock,
-        saveAvatarToDatabase: saveAvatarToDatabaseMock,
-        onError: onErrorMock,
-      }),
-    );
-
-    await waitFor(() => {
-      expect(getDatabaseAvatarMock).toHaveBeenCalledTimes(1);
-      expect(isAvatarExpiredMock).toHaveBeenCalledWith('oldSrcURL');
-      expect(downloadAvatarMock).toHaveBeenCalledTimes(1);
-      expect(saveAvatarToDatabaseMock).toHaveBeenCalledTimes(1);
-      expect(result.current.avatarBlob).toBe(testBlob);
-    });
-  });
-
   it('When the cached avatar is expired, then it should re-download and update the database', async () => {
     const expiredBlob = new Blob(['expired']);
     getDatabaseAvatarMock.mockResolvedValue({

--- a/src/hooks/useAvatar.test.ts
+++ b/src/hooks/useAvatar.test.ts
@@ -1,68 +1,87 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { useAvatar } from './useAvatar';
-import notificationsService from 'app/notifications/services/notifications.service';
 
 describe('Tests for useAvatar custom hook', () => {
+  // Stable mock functions
+  let deleteDatabaseAvatarMock: ReturnType<typeof vi.fn>;
+  let downloadAvatarMock: ReturnType<typeof vi.fn>;
+  let getDatabaseAvatarMock: ReturnType<typeof vi.fn>;
+  let saveAvatarToDatabaseMock: ReturnType<typeof vi.fn>;
+  let onErrorMock: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     vi.resetAllMocks();
+    deleteDatabaseAvatarMock = vi.fn();
+    downloadAvatarMock = vi.fn();
+    getDatabaseAvatarMock = vi.fn();
+    saveAvatarToDatabaseMock = vi.fn();
+    onErrorMock = vi.fn();
   });
 
   it('When the avatar URL is null, then should delete the avatar from the database and reset avatarBlob to null', async () => {
-    const getDatabaseAvatarMock = vi.fn();
-    const deleteDatabaseAvatarMock = vi.fn().mockResolvedValue(null);
+    deleteDatabaseAvatarMock.mockResolvedValue(null);
+
     renderHook(() =>
       useAvatar({
         avatarSrcURL: null,
         deleteDatabaseAvatar: deleteDatabaseAvatarMock,
-        downloadAvatar: vi.fn(),
+        downloadAvatar: downloadAvatarMock,
         getDatabaseAvatar: getDatabaseAvatarMock,
-        saveAvatarToDatabase: vi.fn(),
+        saveAvatarToDatabase: saveAvatarToDatabaseMock,
+        onError: onErrorMock,
       }),
     );
 
-    expect(deleteDatabaseAvatarMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(deleteDatabaseAvatarMock).toHaveBeenCalledTimes(1);
+    });
     expect(getDatabaseAvatarMock).not.toHaveBeenCalled();
   });
 
   it('When no avatar exists in the database, then it should download the avatar and update the database', async () => {
-    const getDatabaseAvatarMock = vi.fn().mockResolvedValue(undefined);
-    const downloadAvatarMock = vi.fn().mockResolvedValue(new Blob());
-    const saveAvatarToDatabaseMock = vi.fn().mockResolvedValue(undefined);
+    const testBlob = new Blob(['test']);
+    getDatabaseAvatarMock.mockResolvedValue(undefined);
+    downloadAvatarMock.mockResolvedValue(testBlob);
+    saveAvatarToDatabaseMock.mockResolvedValue(undefined);
 
     renderHook(() =>
       useAvatar({
         avatarSrcURL: 'testSrcURL',
-        deleteDatabaseAvatar: vi.fn(),
+        deleteDatabaseAvatar: deleteDatabaseAvatarMock,
         downloadAvatar: downloadAvatarMock,
         getDatabaseAvatar: getDatabaseAvatarMock,
         saveAvatarToDatabase: saveAvatarToDatabaseMock,
+        onError: onErrorMock,
       }),
     );
 
     await waitFor(() => {
       expect(getDatabaseAvatarMock).toHaveBeenCalledTimes(1);
       expect(downloadAvatarMock).toHaveBeenCalledTimes(1);
+      expect(downloadAvatarMock).toHaveBeenCalledWith('testSrcURL', expect.any(Object));
       expect(saveAvatarToDatabaseMock).toHaveBeenCalledTimes(1);
     });
   });
 
   it('When the DB avatar url and current URL do not match, then it should download the avatar and save it to the database', async () => {
-    const getDatabaseAvatarMock = vi.fn().mockResolvedValue({
+    const testBlob = new Blob(['test']);
+    getDatabaseAvatarMock.mockResolvedValue({
       srcURL: 'oldSrcURL',
       avatarBlob: new Blob(),
       uuid: 'testUUID',
     });
-    const downloadAvatarMock = vi.fn().mockResolvedValue(new Blob());
-    const saveAvatarToDatabaseMock = vi.fn().mockResolvedValue(undefined);
+    downloadAvatarMock.mockResolvedValue(testBlob);
+    saveAvatarToDatabaseMock.mockResolvedValue(undefined);
 
     renderHook(() =>
       useAvatar({
         avatarSrcURL: 'newSrcURL',
-        deleteDatabaseAvatar: vi.fn(),
+        deleteDatabaseAvatar: deleteDatabaseAvatarMock,
         downloadAvatar: downloadAvatarMock,
         getDatabaseAvatar: getDatabaseAvatarMock,
         saveAvatarToDatabase: saveAvatarToDatabaseMock,
+        onError: onErrorMock,
       }),
     );
 
@@ -74,53 +93,49 @@ describe('Tests for useAvatar custom hook', () => {
   });
 
   it('When the avatar is still valid, then it should not update the database and return de cached one', async () => {
-    const getDatabaseAvatarMock = vi.fn().mockResolvedValue({
+    getDatabaseAvatarMock.mockResolvedValue({
       srcURL: 'currentSrcURL',
       avatarBlob: new Blob(),
       uuid: 'testUUID',
     });
-    const downloadAvatarMock = vi.fn();
-    const saveAvatarToDatabaseMock = vi.fn();
 
     renderHook(() =>
       useAvatar({
         avatarSrcURL: 'currentSrcURL',
-        deleteDatabaseAvatar: vi.fn(),
+        deleteDatabaseAvatar: deleteDatabaseAvatarMock,
         downloadAvatar: downloadAvatarMock,
         getDatabaseAvatar: getDatabaseAvatarMock,
         saveAvatarToDatabase: saveAvatarToDatabaseMock,
+        onError: onErrorMock,
       }),
     );
 
     await waitFor(() => {
       expect(getDatabaseAvatarMock).toHaveBeenCalled();
-      expect(downloadAvatarMock).not.toHaveBeenCalled();
-      expect(saveAvatarToDatabaseMock).not.toHaveBeenCalled();
     });
+    expect(downloadAvatarMock).not.toHaveBeenCalled();
+    expect(saveAvatarToDatabaseMock).not.toHaveBeenCalled();
   });
 
   it('When an unexpected error occurs, then a notification is shown', async () => {
-    const getDatabaseAvatarMock = vi.fn().mockRejectedValue(new Error('Unexpected error'));
-    const downloadAvatarMock = vi.fn();
-    const saveAvatarToDatabaseMock = vi.fn();
-    const notificationServiceSpy = vi.spyOn(notificationsService, 'show');
+    getDatabaseAvatarMock.mockRejectedValue(new Error('Unexpected error'));
 
     renderHook(() =>
       useAvatar({
         avatarSrcURL: 'currentSrcURL',
-        deleteDatabaseAvatar: vi.fn(),
+        deleteDatabaseAvatar: deleteDatabaseAvatarMock,
         downloadAvatar: downloadAvatarMock,
         getDatabaseAvatar: getDatabaseAvatarMock,
         saveAvatarToDatabase: saveAvatarToDatabaseMock,
+        onError: onErrorMock,
       }),
     );
 
     await waitFor(() => {
       expect(getDatabaseAvatarMock).toHaveBeenCalled();
-      expect(downloadAvatarMock).not.toHaveBeenCalled();
-      expect(saveAvatarToDatabaseMock).not.toHaveBeenCalled();
-
-      expect(notificationServiceSpy).toHaveBeenCalledTimes(1);
+      expect(onErrorMock).toHaveBeenCalledTimes(1);
     });
+    expect(downloadAvatarMock).not.toHaveBeenCalled();
+    expect(saveAvatarToDatabaseMock).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useAvatar.tsx
+++ b/src/hooks/useAvatar.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useCallback, useState } from 'react';
+import { AvatarBlobData } from 'app/database/services/database.service';
+import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
+
+type UseAvatarManagerProps = {
+  avatarSrcURL: string | null;
+  getDatabaseAvatar: () => Promise<AvatarBlobData | undefined>;
+  saveAvatarToDatabase: (url: string, blob: Blob) => Promise<void>;
+  deleteDatabaseAvatar: () => Promise<void>;
+  downloadAvatar: (url: string) => Promise<Blob>;
+};
+
+const showUpdateAvatarErrorToast = () =>
+  notificationsService.show({
+    text: 'Error updating avatar',
+    type: ToastType.Error,
+  });
+
+export const useAvatar = ({
+  avatarSrcURL,
+  getDatabaseAvatar,
+  saveAvatarToDatabase,
+  deleteDatabaseAvatar,
+  downloadAvatar,
+}: UseAvatarManagerProps) => {
+  const [avatarBlob, setAvatarBlob] = useState<Blob | null>(null);
+
+  const downloadAndSaveAvatar = useCallback(
+    async (url: string) => {
+      const avatar = await downloadAvatar(url);
+      setAvatarBlob(avatar);
+      await saveAvatarToDatabase(url, avatar);
+    },
+    [downloadAvatar, saveAvatarToDatabase],
+  );
+
+  const handleDownload = useCallback(
+    async (url: string) => {
+      const databaseAvatarData = await getDatabaseAvatar().catch();
+
+      if (!databaseAvatarData) {
+        return downloadAndSaveAvatar(url);
+      }
+
+      const existsNewAvatar = databaseAvatarData.srcURL !== url;
+
+      if (existsNewAvatar) {
+        return downloadAndSaveAvatar(url);
+      }
+
+      setAvatarBlob(databaseAvatarData.avatarBlob);
+    },
+    [getDatabaseAvatar, downloadAndSaveAvatar],
+  );
+
+  useEffect(() => {
+    const handleAvatarData = async () => {
+      try {
+        if (avatarSrcURL) {
+          return handleDownload(avatarSrcURL);
+        }
+
+        await deleteDatabaseAvatar();
+        setAvatarBlob(null);
+      } catch (error) {
+        showUpdateAvatarErrorToast();
+        setAvatarBlob(null);
+      }
+    };
+
+    handleAvatarData();
+  }, [avatarSrcURL]);
+
+  return { avatarBlob };
+};

--- a/src/hooks/useAvatar.tsx
+++ b/src/hooks/useAvatar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useCallback, useState } from 'react';
 import { AvatarBlobData } from 'app/database/services/database.service';
 import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
+import { t } from 'i18next';
 
 type UseAvatarManagerProps = {
   avatarSrcURL: string | null;
@@ -12,7 +13,7 @@ type UseAvatarManagerProps = {
 
 const showUpdateAvatarErrorToast = () =>
   notificationsService.show({
-    text: 'Error updating avatar',
+    text: t('error.updateAvatarError'),
     type: ToastType.Error,
   });
 

--- a/src/hooks/useAvatar.tsx
+++ b/src/hooks/useAvatar.tsx
@@ -65,7 +65,7 @@ export const useAvatar = ({
           await deleteDatabaseAvatar();
           setAvatarBlob(null);
         }
-      } catch (error) {
+      } catch {
         if (!abortController.signal.aborted) {
           onError();
           setAvatarBlob(null);

--- a/src/hooks/useAvatar.tsx
+++ b/src/hooks/useAvatar.tsx
@@ -63,7 +63,7 @@ export const useAvatar = ({
 
         await deleteDatabaseAvatar();
         setAvatarBlob(null);
-      } catch (error) {
+      } catch {
         showUpdateAvatarErrorToast();
         setAvatarBlob(null);
       }

--- a/src/hooks/useAvatar.tsx
+++ b/src/hooks/useAvatar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useCallback, useState, useRef } from 'react';
 import { AvatarBlobData } from 'app/database/services/database.service';
+import { isAvatarExpired } from 'app/utils/avatar/avatarUtils';
 
 type UseAvatarManagerProps = {
   avatarSrcURL: string | null;
@@ -34,7 +35,7 @@ export const useAvatar = ({
     async (url: string, signal?: AbortSignal) => {
       const databaseAvatarData = await getDatabaseAvatar().catch();
 
-      if (!databaseAvatarData || databaseAvatarData.srcURL !== url) {
+      if (!databaseAvatarData || isAvatarExpired(databaseAvatarData.srcURL)) {
         return downloadAndSaveAvatar(url, signal);
       }
 
@@ -76,7 +77,7 @@ export const useAvatar = ({
     return () => {
       abortController.abort();
     };
-  }, [avatarSrcURL, handleDownload, deleteDatabaseAvatar]);
+  }, [avatarSrcURL]);
 
   return { avatarBlob };
 };

--- a/src/hooks/useAvatar.tsx
+++ b/src/hooks/useAvatar.tsx
@@ -58,7 +58,8 @@ export const useAvatar = ({
     const handleAvatarData = async () => {
       try {
         if (avatarSrcURL) {
-          return handleDownload(avatarSrcURL);
+          await handleDownload(avatarSrcURL);
+          return;
         }
 
         await deleteDatabaseAvatar();


### PR DESCRIPTION
## Description

This PR improves avatar handling in the Shared dialog by:
- Using the cached avatar blob from IndexedDB when available.
- Automatically downloading and updating the avatar if a newer version exists.

This ensures faster loading and up-to-date avatars in shared views.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
