### PR TITLE
[_]: fix/user avatar

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@internxt/css-config": "^1.0.3",
     "@internxt/inxt-js": "=1.2.21",
     "@internxt/lib": "^1.2.0",
-    "@internxt/sdk": "=1.10.3",
+    "@internxt/sdk": "=1.10.9",
     "@internxt/ui": "^0.0.23",
     "@phosphor-icons/react": "^2.1.7",
     "@popperjs/core": "^2.11.6",

--- a/src/app/auth/services/user.service.ts
+++ b/src/app/auth/services/user.service.ts
@@ -31,6 +31,13 @@ const refreshUserData = async (
   return usersClient.getUserData({ userUuid: userUUID });
 };
 
+const refreshAvatarUser = async (): Promise<{
+  avatar: string | null;
+}> => {
+  const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
+  return usersClient.refreshAvatarUser();
+};
+
 const updateUserProfile = (payload: Required<UpdateProfilePayload>): Promise<void> => {
   const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
   const token = localStorageService.get('xNewToken') ?? undefined;
@@ -92,6 +99,7 @@ const userService = {
   checkChangeEmailLinkExpiration,
   preCreateUser,
   refreshUserData,
+  refreshAvatarUser,
   downloadAvatar,
 };
 

--- a/src/app/core/components/Sidenav/Sidenav.tsx
+++ b/src/app/core/components/Sidenav/Sidenav.tsx
@@ -26,13 +26,6 @@ import { STORAGE_KEYS } from '../../../core/services/storage-keys';
 import { HUNDRED_TB } from '../../../core/constants';
 import { useEffect } from 'react';
 import { sharedThunks } from 'app/store/slices/sharedLinks';
-import { useAvatar } from 'hooks/useAvatar';
-import { deleteDatabaseProfileAvatar, getDatabaseProfileAvatar } from 'app/drive/services/database.service';
-import userService from 'app/auth/services/user.service';
-import {
-  saveAvatarToDatabase,
-  showUpdateAvatarErrorToast,
-} from 'app/newSettings/Sections/Account/Account/components/AvatarWrapper';
 
 interface SidenavProps {
   user: UserSettings | undefined;
@@ -126,14 +119,6 @@ const Sidenav = ({
   const pendingInvitations = useAppSelector((state: RootState) => state.shared.pendingInvitations);
   const selectedWorkspace = useAppSelector(workspacesSelectors.getSelectedWorkspace);
   const workspaceUuid = selectedWorkspace?.workspaceUser.workspaceId;
-  const { avatarBlob } = useAvatar({
-    avatarSrcURL: user?.avatar || null,
-    deleteDatabaseAvatar: deleteDatabaseProfileAvatar,
-    downloadAvatar: userService.downloadAvatar,
-    getDatabaseAvatar: getDatabaseProfileAvatar,
-    saveAvatarToDatabase: saveAvatarToDatabase,
-    onError: showUpdateAvatarErrorToast,
-  });
 
   useEffect(() => {
     dispatch(sharedThunks.getPendingInvitations());
@@ -219,7 +204,7 @@ const Sidenav = ({
             <WorkspaceSelectorContainer
               user={{
                 ...user,
-                avatar: avatarBlob ? URL.createObjectURL(avatarBlob) : user.avatar,
+                avatar: user.avatar,
               }}
             />
           )}

--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -41,13 +41,6 @@ import './ShareDialog.scss';
 import envService from 'app/core/services/env.service';
 import { User } from './components/User';
 import { InvitedUsersSkeletonLoader } from './components/InvitedUsersSkeletonLoader';
-import { useAvatar } from 'hooks/useAvatar';
-import { deleteDatabaseProfileAvatar, getDatabaseProfileAvatar } from 'app/drive/services/database.service';
-import userService from 'app/auth/services/user.service';
-import {
-  saveAvatarToDatabase,
-  showUpdateAvatarErrorToast,
-} from 'app/newSettings/Sections/Account/Account/components/AvatarWrapper';
 import {
   AccessMode,
   InvitedUserProps,
@@ -82,14 +75,14 @@ const isAdvancedShareItem = (item: DriveItemData | AdvancedSharedItem): item is 
   return item['encryptionKey'];
 };
 
-const getLocalUserData = (avatarSrc?: string) => {
+const getLocalUserData = () => {
   const user = localStorageService.getUser() as UserSettings;
   const ownerData = {
     name: user.name,
     lastname: user.lastname,
     email: user.email,
     sharingId: '',
-    avatar: avatarSrc ?? user.avatar,
+    avatar: user.avatar,
     uuid: user.uuid,
     role: {
       id: 'NONE',
@@ -114,14 +107,6 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
   const isOpen = useAppSelector((state: RootState) => state.ui.isShareDialogOpen);
   const isWorkspace = !!useAppSelector(workspacesSelectors.getSelectedWorkspace);
   const itemToShare = useAppSelector((state) => state.storage.itemToShare);
-  const { avatarBlob } = useAvatar({
-    avatarSrcURL: props?.user?.avatar,
-    deleteDatabaseAvatar: deleteDatabaseProfileAvatar,
-    downloadAvatar: userService.downloadAvatar,
-    getDatabaseAvatar: getDatabaseProfileAvatar,
-    saveAvatarToDatabase: saveAvatarToDatabase,
-    onError: showUpdateAvatarErrorToast,
-  });
 
   const [roles, setRoles] = useState<Role[]>([]);
   const [inviteDialogRoles, setInviteDialogRoles] = useState<Role[]>([]);
@@ -220,8 +205,7 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
       // the server throws an error when there are no users with shared item,
       // that means that the local user is the owner as there is nobody else with this shared file.
       if (isUserOwner) {
-        const ownerAvatar = avatarBlob ? URL.createObjectURL(avatarBlob) : undefined;
-        const ownerData = getLocalUserData(ownerAvatar);
+        const ownerData = getLocalUserData();
         setInvitedUsers([{ ...ownerData, roleName: 'owner' }]);
       }
     }

--- a/src/app/newSettings/Sections/Account/Account/components/AvatarWrapper.tsx
+++ b/src/app/newSettings/Sections/Account/Account/components/AvatarWrapper.tsx
@@ -1,12 +1,6 @@
 import { memo } from 'react';
-import {
-  deleteDatabaseProfileAvatar,
-  getDatabaseProfileAvatar,
-  updateDatabaseProfileAvatar,
-} from '../../../../../drive/services/database.service';
+import { updateDatabaseProfileAvatar } from '../../../../../drive/services/database.service';
 import { Avatar } from '@internxt/ui';
-import userService from 'app/auth/services/user.service';
-import { useAvatar } from 'hooks/useAvatar';
 import { t } from 'i18next';
 import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
 
@@ -43,23 +37,7 @@ const AvatarWrapper = memo(
     diameter: number;
     style?: Record<string, string | number>;
   }): JSX.Element => {
-    const { avatarBlob } = useAvatar({
-      avatarSrcURL,
-      deleteDatabaseAvatar: deleteDatabaseProfileAvatar,
-      downloadAvatar: userService.downloadAvatar,
-      getDatabaseAvatar: getDatabaseProfileAvatar,
-      saveAvatarToDatabase: saveAvatarToDatabase,
-      onError: showUpdateAvatarErrorToast,
-    });
-
-    return (
-      <Avatar
-        diameter={diameter}
-        fullName={fullName}
-        src={avatarBlob ? URL.createObjectURL(avatarBlob) : null}
-        style={style}
-      />
-    );
+    return <Avatar diameter={diameter} fullName={fullName} src={avatarSrcURL} style={style} />;
   },
 );
 

--- a/src/app/store/slices/user/index.ts
+++ b/src/app/store/slices/user/index.ts
@@ -100,13 +100,6 @@ export const refreshAvatarThunk = createAsyncThunk<void, { forceRefresh?: boolea
             avatar: refreshedAvatar ?? userAvatar,
           }),
         );
-        localStorageService.set(
-          LocalStorageItem.User,
-          JSON.stringify({
-            ...currentUser,
-            avatar: refreshedAvatar ?? userAvatar,
-          }),
-        );
       }
     } catch (err) {
       errorService.reportError(err, { extra: { thunk: 'refreshAvatarUser' } });

--- a/src/app/utils/avatar/avatarUtils.test.ts
+++ b/src/app/utils/avatar/avatarUtils.test.ts
@@ -114,8 +114,7 @@ describe('refreshAvatar', () => {
     const dateStr = now
       .toISOString()
       .replace(/[:-]/g, '')
-      .replace(/\.\d{3}Z$/, '')
-      .replace('T', 'T');
+      .replace(/\.\d{3}Z$/, '');
 
     const validUrl = `https://avatar-url.com/file.png?X-Amz-Date=${dateStr}Z&X-Amz-Expires=3600`;
 

--- a/src/app/utils/avatar/avatarUtils.test.ts
+++ b/src/app/utils/avatar/avatarUtils.test.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { beforeEach, describe, expect, it, Mock, test, vi } from 'vitest';
 import userService from '../../auth/services/user.service';
-import { getAvatarExpiration, isAvatarExpired, syncAvatarIfNeeded } from './avatarUtils';
+import { getAvatarExpiration, isAvatarExpired, refreshAvatar } from './avatarUtils';
 import { getDatabaseProfileAvatar, updateDatabaseProfileAvatar } from '../../drive/services/database.service';
 
 vi.mock('../../drive/services/database.service', async () => {
@@ -18,6 +18,7 @@ vi.mock('../../drive/services/database.service', async () => {
 vi.mock('../../auth/services/user.service', () => ({
   default: {
     downloadAvatar: vi.fn(),
+    refreshAvatarUser: vi.fn(),
   },
 }));
 
@@ -60,62 +61,70 @@ describe('Check if avatar URL is expired or not', () => {
   });
 });
 
-describe('Sync avatar if needed', () => {
+describe('refreshAvatar', () => {
   const uuid = 'mocked-user-id';
-  const avatarUrl = 'https://avatar-url.com/file.png?X-Amz-Date=20200101T000000Z&X-Amz-Expires=60';
+  const expiredAvatarUrl = 'https://avatar-url.com/file.png?X-Amz-Date=20200101T000000Z&X-Amz-Expires=60';
+  const newAvatarUrl = 'https://avatar.new-url.com/avatar.png';
+  const avatarBlob = new Blob(['mocked-avatar']);
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.resetModules();
   });
 
-  it('When no avatar URL is provided, then it should not update the database', async () => {
-    await syncAvatarIfNeeded(uuid, '');
+  test('When no avatar URL is provided, then it should not update the database', async () => {
+    await refreshAvatar(uuid, null);
     expect(getDatabaseProfileAvatar).not.toHaveBeenCalled();
     expect(updateDatabaseProfileAvatar).not.toHaveBeenCalled();
   });
 
-  it('When no avatar is stored, then it should download and update the database with the new one', async () => {
+  test('When no avatar is stored, then it should download and update the database with the new one', async () => {
     (getDatabaseProfileAvatar as Mock).mockResolvedValue(undefined);
-    vi.spyOn(userService, 'downloadAvatar').mockResolvedValue(new Blob(['data']));
+    vi.spyOn(userService, 'refreshAvatarUser').mockResolvedValue({ avatar: newAvatarUrl });
+    vi.spyOn(userService, 'downloadAvatar').mockResolvedValue(avatarBlob);
 
-    await syncAvatarIfNeeded(uuid, avatarUrl);
+    const result = await refreshAvatar(uuid, expiredAvatarUrl);
 
-    expect(updateDatabaseProfileAvatar).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sourceURL: avatarUrl,
-        uuid,
-      }),
-    );
+    expect(result).toBe(newAvatarUrl);
+    expect(userService.refreshAvatarUser).toHaveBeenCalled();
+    expect(userService.downloadAvatar).toHaveBeenCalledWith(newAvatarUrl);
+    expect(updateDatabaseProfileAvatar).toHaveBeenCalledWith({
+      sourceURL: expiredAvatarUrl,
+      avatarBlob,
+      uuid,
+    });
   });
 
-  it('When the stored avatar is expired, then it should update the database', async () => {
-    (getDatabaseProfileAvatar as Mock).mockResolvedValueOnce({ srcURL: avatarUrl });
-    vi.spyOn(userService, 'downloadAvatar').mockResolvedValue(new Blob(['data']));
+  test('When the stored avatar is expired, then it should update the database', async () => {
+    (getDatabaseProfileAvatar as Mock).mockResolvedValueOnce({ srcURL: expiredAvatarUrl });
+    vi.spyOn(userService, 'refreshAvatarUser').mockResolvedValue({ avatar: newAvatarUrl });
+    vi.spyOn(userService, 'downloadAvatar').mockResolvedValue(avatarBlob);
 
-    await syncAvatarIfNeeded(uuid, avatarUrl);
+    const result = await refreshAvatar(uuid, expiredAvatarUrl);
 
-    expect(updateDatabaseProfileAvatar).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sourceURL: avatarUrl,
-        uuid,
-      }),
-    );
+    expect(result).toBe(newAvatarUrl);
+    expect(updateDatabaseProfileAvatar).toHaveBeenCalledWith({
+      sourceURL: expiredAvatarUrl,
+      avatarBlob,
+      uuid,
+    });
   });
 
-  it('When the stored avatar is still valid, then it should not update the database', async () => {
+  test('When the stored avatar is still valid, then it should not update the database', async () => {
     const now = new Date();
     const dateStr = now
       .toISOString()
       .replace(/[:-]/g, '')
-      .replace(/\.\d{3}Z$/, 'Z')
-      .replace('Z', '');
+      .replace(/\.\d{3}Z$/, '')
+      .replace('T', 'T');
 
-    const url = `https://avatar-url.com/file.png?X-Amz-Date=${dateStr}Z&X-Amz-Expires=3600`;
-    (getDatabaseProfileAvatar as Mock).mockResolvedValueOnce({ srcURL: url });
+    const validUrl = `https://avatar-url.com/file.png?X-Amz-Date=${dateStr}Z&X-Amz-Expires=3600`;
 
-    await syncAvatarIfNeeded(uuid, url);
+    (getDatabaseProfileAvatar as Mock).mockResolvedValueOnce({ srcURL: validUrl });
 
+    const result = await refreshAvatar(uuid, validUrl);
+
+    expect(result).toBe(validUrl);
     expect(updateDatabaseProfileAvatar).not.toHaveBeenCalled();
+    expect(userService.refreshAvatarUser).not.toHaveBeenCalled();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1919,12 +1919,13 @@
   resolved "https://npm.pkg.github.com/download/@internxt/prettier-config/1.0.2/5bd220b8de76734448db5475b3e0c01f9d22c19b#5bd220b8de76734448db5475b3e0c01f9d22c19b"
   integrity sha512-t4HiqvCbC7XgQepwWlIaFJe3iwW7HCf6xOSU9nKTV0tiGqOPz7xMtIgLEloQrDA34Cx4PkOYBXrvFPV6RxSFAA==
 
-"@internxt/sdk@=1.10.3":
-  version "1.10.3"
-  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.10.3/4903964fb3db71d20921f421e9f2f0eb51ddddeb#4903964fb3db71d20921f421e9f2f0eb51ddddeb"
-  integrity sha512-ouZM3jJMZf/1izTksQ9t6lwAG2ISooIZIjLE51nR0Z41xE3DlnjvEb7itAzcRTIT7z5cX6ZpHPlY0uhsLbJ3Bw==
+"@internxt/sdk@=1.10.9":
+  version "1.10.9"
+  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.10.9/0c019f19795675f5e41bbf5a0ac3dda28da1a942#0c019f19795675f5e41bbf5a0ac3dda28da1a942"
+  integrity sha512-OF99TRv6iKZ44mydVsJH7rit8GQJj9Yg/UJcFjHO+rLMeJjmR956LJVv/QpiQv/LFUh8e+QF3iYqnoO/XSyI6w==
   dependencies:
     axios "1.10.0"
+    uuid "11.1.0"
 
 "@internxt/ui@^0.0.23":
   version "0.0.23"
@@ -9667,6 +9668,11 @@ util@^0.12.4, util@^0.12.5:
     is-generator-function "^1.0.7"
     is-typed-array "^1.1.3"
     which-typed-array "^1.1.2"
+
+uuid@11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
 uuid@=8.3.2, uuid@^8.3.0:
   version "8.3.2"


### PR DESCRIPTION
## Description
This PR implements a new thunk to refresh the user's avatar when it is expired. The function is triggered when the user opens the app or reloads it.

The idea is:

- Get the stored user data.
- Check the expiration date of the avatar:
   - If the avatar is expired, refresh the avatar URL and download the new blob.
   - If the avatar is still valid, use the cached blob.

By doing this, we ensure the app always has a valid avatar URL and a working blob to display the user's profile image properly.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
