### PR TITLE
[_]: feat/use-uint8array-instead-of-blob-on-encrypting

### DIFF
--- a/src/app/network/crypto.test.ts
+++ b/src/app/network/crypto.test.ts
@@ -72,7 +72,7 @@ describe('Test crypto.ts functions', () => {
     const iv = Buffer.from('0b68dcbb255a4e654bbf361e73cf1b98', 'hex');
     const file = createMockFile('file.txt', 13, 'text/plain');
     const cipher = crypto.createCipheriv('aes-256-ctr', encryptionKey, iv);
-    const [encryptedFile, hash] = await getEncryptedFile(file, cipher);
+    const [encryptedFile, hash] = await getEncryptedFile(file, cipher, file.size);
     expect(encryptedFile).toBeDefined();
     expect(hash).toBe('422dab11a4f44c2ceab1f8ef39827109989607d6');
   });

--- a/src/app/network/crypto.ts
+++ b/src/app/network/crypto.ts
@@ -146,16 +146,19 @@ export async function getEncryptedFile(
   hasher.init();
   const fileParts: Uint8Array = new Uint8Array(fileLength);
 
+  let done = false;
   let offset = 0;
 
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const { done, value } = await readable.read();
-    if (done) break;
+  while (!done) {
+    const status = await readable.read();
 
-    hasher.update(value);
-    fileParts.set(value, offset);
-    offset += value.length;
+    if (!status.done) {
+      hasher.update(status.value);
+      fileParts.set(status.value, offset);
+      offset += status.value.length;
+    }
+
+    done = status.done;
   }
 
   const sha256Result = hasher.digest();

--- a/src/app/network/upload.ts
+++ b/src/app/network/upload.ts
@@ -27,8 +27,8 @@ interface IUploadParams {
   };
 }
 
-export async function uploadFileBlob(
-  content: Blob,
+export async function uploadFileUint8Array(
+  content: Uint8Array,
   url: string,
   opts: {
     progressCallback: UploadProgressCallback;
@@ -46,11 +46,7 @@ export async function uploadFileBlob(
       onUploadProgress: (progress: AxiosProgressEvent) => {
         opts.progressCallback(progress.total ?? 0, progress.loaded);
       },
-      cancelToken: new axios.CancelToken((canceler) => {
-        opts.abortController?.signal.addEventListener('abort', () => {
-          canceler();
-        });
-      }),
+      signal: opts.abortController?.signal,
     });
 
     return { etag: res.headers.etag };


### PR DESCRIPTION
## Description

Axios can send Uint8Array directly, no need to convert data to blobs

## Related Issues

Relates to [PB-4671](https://inxt.atlassian.net/browse/PB-4671)

## Related Pull Requests

- [Optimize encryption of big files](https://github.com/internxt/drive-web/pull/1605)


## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

Uploaded a 1.2 GB file and a 56 MB file from `yarn dev`, checked that the files can be viewed and successfully downloaded from prod.

## Additional Notes

axios.CancelToken is deprecated, see [link](https://axios-http.com/docs/cancellation)

while (true) is aligned with [readData of MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API/Using_readable_streams)

[PB-4623]: https://inxt.atlassian.net/browse/PB-4623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PB-4671]: https://inxt.atlassian.net/browse/PB-4671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ