### PR TITLE
[_]: fix/handle setup intent for subs and fix useless redirects for coupons

### DIFF
--- a/src/app/payment/hooks/useUserPayment.test.ts
+++ b/src/app/payment/hooks/useUserPayment.test.ts
@@ -7,7 +7,7 @@ import envService from 'app/core/services/env.service';
 import { UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import navigationService from 'app/core/services/navigation.service';
 import { AppView } from 'app/core/types';
-import { HandleUserPaymentPayload } from '../types';
+import { ProcessPurchasePayload, UseUserPaymentPayload } from '../types';
 
 describe('Custom hook to handle payments', () => {
   describe('Get subscription data to do the payment', () => {
@@ -87,39 +87,41 @@ describe('Custom hook to handle payments', () => {
   });
 
   describe('Handle Subscription Payment', () => {
+    test('When the user attemts to purchase a subscription with 100% OFF, then the setup of the payment method is done, the sub is created and the user confirms the payment', async () => {});
     test('When the user attempts to purchase a subscription, then the subscription is created, the necessary data is stored and the user confirms the payment', async () => {
       const { handleSubscriptionPayment } = useUserPayment();
 
       const createSubscriptionSpy = vi.spyOn(checkoutService, 'createSubscription').mockResolvedValue({
         clientSecret: 'client_secret',
-        type: 'payment',
+        type: 'setup',
         paymentIntentId: 'pi_123',
         subscriptionId: 'sub_123',
       });
       const confirmPayment = vi.fn().mockResolvedValue({ error: undefined });
+      const setupIntent = vi.fn().mockResolvedValue({ error: undefined });
+      const translate = vi.fn().mockImplementation(() => {});
       // Spy for savePaymentDataInLocalStorage function
       const localStorageServiceSpy = vi.spyOn(localStorageService, 'set').mockImplementation(() => {});
 
-      const subscriptionPaymentPayload = {
+      const subscriptionPaymentPayload: ProcessPurchasePayload = {
         customerId: 'customer_id',
         priceId: 'price_id',
         token: 'token',
-
         currency: 'currency',
         seatsForBusinessSubscription: 1,
-        elements: {
-          confirmPayment: vi.fn(),
-        },
+        elements: vi.fn() as any,
         currentSelectedPlan: {
           price: {
             interval: 'year',
             type: UserType.Individual,
           },
-        },
+        } as any,
         confirmPayment,
+        confirmSetupIntent: setupIntent,
+        translate: translate,
       };
 
-      await handleSubscriptionPayment(subscriptionPaymentPayload as any);
+      await handleSubscriptionPayment(subscriptionPaymentPayload);
 
       expect(createSubscriptionSpy).toHaveBeenCalledWith({
         customerId: subscriptionPaymentPayload.customerId,
@@ -132,7 +134,7 @@ describe('Custom hook to handle payments', () => {
 
       expect(localStorageServiceSpy).toHaveBeenCalledTimes(5);
 
-      expect(confirmPayment).toHaveBeenCalledWith({
+      expect(setupIntent).toHaveBeenCalledWith({
         elements: subscriptionPaymentPayload.elements,
         clientSecret: 'client_secret',
         confirmParams: {
@@ -245,6 +247,7 @@ describe('Custom hook to handle payments', () => {
       const payment = useUserPayment();
 
       const confirmPayment = vi.fn().mockResolvedValue({ error: undefined });
+      const setupIntent = vi.fn().mockResolvedValue({ error: undefined });
       const createSubscriptionSpy = vi.spyOn(checkoutService, 'createSubscription').mockResolvedValue({
         clientSecret: 'client_secret',
         type: 'payment',
@@ -259,7 +262,7 @@ describe('Custom hook to handle payments', () => {
       // Spy for savePaymentDataInLocalStorage function
       vi.spyOn(localStorageService, 'set').mockImplementation(() => {});
 
-      const subscriptionPaymentPayload: HandleUserPaymentPayload = {
+      const subscriptionPaymentPayload: UseUserPaymentPayload = {
         customerId: 'customer_id',
         priceId: 'price_id',
         token: 'token',
@@ -280,6 +283,7 @@ describe('Custom hook to handle payments', () => {
           },
         } as any,
         confirmPayment,
+        confirmSetupIntent: setupIntent,
         gclidStored: null,
       };
 
@@ -293,6 +297,7 @@ describe('Custom hook to handle payments', () => {
       const payment = useUserPayment();
 
       const confirmPayment = vi.fn().mockResolvedValue({ error: undefined });
+      const setupIntent = vi.fn().mockResolvedValue({ error: undefined });
       const createSubscriptionSpy = vi.spyOn(checkoutService, 'createSubscription').mockResolvedValue({
         clientSecret: 'client_secret',
         type: 'payment',
@@ -307,7 +312,7 @@ describe('Custom hook to handle payments', () => {
       // Spy for savePaymentDataInLocalStorage function
       vi.spyOn(localStorageService, 'set').mockImplementation(() => {});
 
-      const subscriptionPaymentPayload: HandleUserPaymentPayload = {
+      const subscriptionPaymentPayload: UseUserPaymentPayload = {
         customerId: 'customer_id',
         priceId: 'price_id',
         token: 'token',
@@ -328,6 +333,7 @@ describe('Custom hook to handle payments', () => {
           },
         } as any,
         confirmPayment,
+        confirmSetupIntent: setupIntent,
         gclidStored: null,
       };
 
@@ -341,6 +347,7 @@ describe('Custom hook to handle payments', () => {
       const payment = useUserPayment();
 
       const confirmPayment = vi.fn().mockResolvedValue({ error: undefined });
+      const setupIntent = vi.fn().mockResolvedValue({ error: undefined });
       const createSubscriptionSpy = vi.spyOn(checkoutService, 'createSubscription').mockResolvedValue({
         clientSecret: 'client_secret',
         type: 'payment',
@@ -356,7 +363,7 @@ describe('Custom hook to handle payments', () => {
       vi.spyOn(localStorageService, 'set').mockImplementation(() => {});
       const navigationServiceSpy = vi.spyOn(navigationService, 'push').mockImplementation(() => {});
 
-      const subscriptionPaymentPayload: HandleUserPaymentPayload = {
+      const subscriptionPaymentPayload: UseUserPaymentPayload = {
         customerId: 'customer_id',
         priceId: 'price_id',
         token: 'token',
@@ -377,6 +384,7 @@ describe('Custom hook to handle payments', () => {
           },
         } as any,
         confirmPayment,
+        confirmSetupIntent: setupIntent,
         gclidStored: null,
       };
 

--- a/src/app/payment/types.ts
+++ b/src/app/payment/types.ts
@@ -129,6 +129,8 @@ export interface ProcessPurchasePayload {
   currency: string;
   elements: StripeElements;
   confirmPayment: Stripe['confirmPayment'];
+  confirmSetupIntent: Stripe['confirmSetup'];
+  translate: (key: string) => string;
   currentSelectedPlan: PriceWithTax;
   seatsForBusinessSubscription?: number;
   couponCodeData?: CouponCodeData;
@@ -142,6 +144,7 @@ export interface UseUserPaymentPayload {
   selectedPlan: PriceWithTax;
   elements: StripeElements;
   confirmPayment: Stripe['confirmPayment'];
+  confirmSetupIntent: Stripe['confirmSetup'];
   gclidStored: string | null;
   translate: (key: string) => string;
   couponCodeData?: CouponCodeData;

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
@@ -236,11 +236,6 @@ const CheckoutViewWrapper = () => {
       setSelectedPlan(priceWithTaxes);
     } catch (error) {
       console.error('Error fetching price with taxes', error);
-      if (user) {
-        navigationService.push(AppView.Drive);
-      } else {
-        navigationService.push(AppView.Signup);
-      }
     }
   };
 
@@ -450,6 +445,7 @@ const CheckoutViewWrapper = () => {
       } else {
         await handleUserPayment({
           confirmPayment: stripeSDK.confirmPayment,
+          confirmSetupIntent: stripeSDK.confirmSetup,
           couponCodeData: couponCodeData,
           currency: currentSelectedPlan.price.currency,
           priceId: currentSelectedPlan.price.id,


### PR DESCRIPTION
## Description

This PR fixes the problem we have when a wrong coupon code is added (where the user is redacted to the home page) and also fixes the setupIntent for subscriptions.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
