### PR TITLE
[PB-4561]: fix/await fetching the root folders

### DIFF
--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -102,6 +102,7 @@ function SharedView({
 
   const { state, actionDispatch } = useShareViewContext();
   const {
+    page,
     isLoading,
     shareFolders,
     shareFiles,
@@ -131,6 +132,11 @@ function SharedView({
   const defaultTeamId = selectedWorkspace?.workspace.defaultTeamId;
 
   useLayoutEffect(() => {
+    if (page === 0 && !folderUUID) {
+      fetchRootFolders(workspaceId);
+      dispatch(storageActions.resetSharedNamePath());
+    }
+
     if (folderUUID) {
       const onRedirectionToFolderError = (errorMessage: string) => {
         notificationsService.show({ text: errorMessage, type: ToastType.Error });

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -234,10 +234,10 @@ function SharedView({
     dispatch(sharedActions.setCurrentSharingRole(null));
   };
 
-  const onShowInvitationsModalClose = () => {
+  const onShowInvitationsModalClose = async () => {
     resetSharedViewState();
     actionDispatch(setCurrentFolderId(''));
-    fetchRootFolders(workspaceId);
+    await fetchRootFolders(workspaceId);
     dispatch(sharedThunks.getPendingInvitations());
     dispatch(uiActions.setIsInvitationsDialogOpen(false));
   };

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -234,7 +234,7 @@ function SharedView({
     dispatch(sharedActions.setCurrentSharingRole(null));
   };
 
-  const onShowInvitationsModalClose = async () => {
+  const onShowInvitationsModalClose = () => {
     resetSharedViewState();
     actionDispatch(setCurrentFolderId(''));
     dispatch(sharedThunks.getPendingInvitations());

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -237,9 +237,11 @@ function SharedView({
   const onShowInvitationsModalClose = async () => {
     resetSharedViewState();
     actionDispatch(setCurrentFolderId(''));
-    await fetchRootFolders(workspaceId);
     dispatch(sharedThunks.getPendingInvitations());
     dispatch(uiActions.setIsInvitationsDialogOpen(false));
+    setTimeout(async () => {
+      await fetchRootFolders(workspaceId);
+    }, 500);
   };
 
   const navigateToSharedFolder = (shareItem: AdvancedSharedItem) => {

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -102,7 +102,6 @@ function SharedView({
 
   const { state, actionDispatch } = useShareViewContext();
   const {
-    page,
     isLoading,
     shareFolders,
     shareFiles,

--- a/src/app/share/views/SharedLinksView/SharedView.tsx
+++ b/src/app/share/views/SharedLinksView/SharedView.tsx
@@ -132,11 +132,6 @@ function SharedView({
   const defaultTeamId = selectedWorkspace?.workspace.defaultTeamId;
 
   useLayoutEffect(() => {
-    if (page === 0 && !folderUUID) {
-      fetchRootFolders(workspaceId);
-      dispatch(storageActions.resetSharedNamePath());
-    }
-
     if (folderUUID) {
       const onRedirectionToFolderError = (errorMessage: string) => {
         notificationsService.show({ text: errorMessage, type: ToastType.Error });
@@ -239,9 +234,6 @@ function SharedView({
     actionDispatch(setCurrentFolderId(''));
     dispatch(sharedThunks.getPendingInvitations());
     dispatch(uiActions.setIsInvitationsDialogOpen(false));
-    setTimeout(async () => {
-      await fetchRootFolders(workspaceId);
-    }, 500);
   };
 
   const navigateToSharedFolder = (shareItem: AdvancedSharedItem) => {
@@ -504,9 +496,8 @@ function SharedView({
         // This is added so that in case the element is no longer shared due
         // to changes in the share dialog it will disappear from the list.
         resetSharedViewState();
-        fetchRootFolders(workspaceId);
       }
-    }, 200);
+    }, 1000);
   };
 
   const handleOnTopBarInputChanges = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/app/share/views/SharedLinksView/hooks/useFetchSharedData.tsx
+++ b/src/app/share/views/SharedLinksView/hooks/useFetchSharedData.tsx
@@ -74,7 +74,6 @@ const useFetchSharedData = () => {
   const selectedWorkspace = useSelector(workspacesSelectors.getSelectedWorkspace);
   const workspaceCredentials = useSelector(workspacesSelectors.getWorkspaceCredentials);
   const workspaceId = selectedWorkspace?.workspace.id;
-  const defaultTeamId = selectedWorkspace?.workspace.defaultTeamId;
 
   const {
     page,


### PR DESCRIPTION
## Description
This PR waits for the folder fetching to complete before displaying the accepted folder; otherwise, it may not appear unless the user reloads the window.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [x] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

Maybe we can add a timeout of 500 ms.
