### PR TITLE
[PB-4574]: feat/add timeout to fetch workspaces after accepting invitation

### DIFF
--- a/src/app/auth/components/LogIn/LogIn.tsx
+++ b/src/app/auth/components/LogIn/LogIn.tsx
@@ -67,7 +67,7 @@ export default function LogIn(): JSX.Element {
 
   useEffect(() => {
     handleShareInvitation();
-    handleWorkspaceInvitation();
+    handleWorkspaceInvitation(dispatch);
   }, []);
 
   useEffect(() => {

--- a/src/app/core/components/Sidenav/PendingInvitationsDialog.tsx
+++ b/src/app/core/components/Sidenav/PendingInvitationsDialog.tsx
@@ -45,7 +45,9 @@ const PendingInvitationsDialog = ({
     setIsLoading(true);
     try {
       token && (await workspacesService.acceptWorkspaceInvite({ invitationId, token }));
-      dispatch(workspaceThunks.fetchWorkspaces());
+      setTimeout(() => {
+        dispatch(workspaceThunks.fetchWorkspaces());
+      }, 3000);
     } catch (err) {
       const appError = err as AppError;
       if (appError.status === WORKSPACE_INVITATION_BAD_REQUEST) {

--- a/src/app/core/components/Sidenav/PendingInvitationsDialog.tsx
+++ b/src/app/core/components/Sidenav/PendingInvitationsDialog.tsx
@@ -10,6 +10,7 @@ import { workspaceThunks } from 'app/store/slices/workspaces/workspacesStore';
 import dayjs from 'dayjs';
 import AppError from 'app/core/types';
 import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
+import { wait } from 'app/utils/timeUtils';
 
 const WORKSPACE_INVITATION_BAD_REQUEST = 400;
 
@@ -45,9 +46,8 @@ const PendingInvitationsDialog = ({
     setIsLoading(true);
     try {
       token && (await workspacesService.acceptWorkspaceInvite({ invitationId, token }));
-      setTimeout(() => {
-        dispatch(workspaceThunks.fetchWorkspaces());
-      }, 3000);
+      await wait(3000);
+      dispatch(workspaceThunks.fetchWorkspaces());
     } catch (err) {
       const appError = err as AppError;
       if (appError.status === WORKSPACE_INVITATION_BAD_REQUEST) {

--- a/src/app/routes/hooks/Login/useLoginRedirections.tsx
+++ b/src/app/routes/hooks/Login/useLoginRedirections.tsx
@@ -74,6 +74,7 @@ const useLoginRedirections = ({
         await wait(2000);
         dispatch(workspaceThunks.fetchWorkspaces());
       } catch (error) {
+        console.error('ERROR WHILE ACCEPTING OR DECLINING WORKSPACE INVITATION: ', error);
         const notificationText = isDeclineAction
           ? t('preferences.workspace.members.invitationFlow.error.declinedError')
           : t('preferences.workspace.members.invitationFlow.error.acceptedError');

--- a/src/app/routes/hooks/Login/useLoginRedirections.tsx
+++ b/src/app/routes/hooks/Login/useLoginRedirections.tsx
@@ -2,6 +2,9 @@ import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import { t } from 'i18next';
 import { AppView } from '../../../core/types';
 import workspacesService from 'app/core/services/workspace.service';
+import { workspaceThunks } from 'app/store/slices/workspaces/workspacesStore';
+import { AppDispatch } from 'app/store';
+import { wait } from 'app/utils/timeUtils';
 
 const useLoginRedirections = ({
   navigateTo,
@@ -46,30 +49,35 @@ const useLoginRedirections = ({
     }
   };
 
-  const handleWorkspaceInvitation = async () => {
+  const handleWorkspaceInvitation = async (dispatch: AppDispatch) => {
     if (workspaceInvitationId && token) {
       const isDeclineAction = sharingAction === 'decline';
       try {
         await workspacesService.validateWorkspaceInvitation(workspaceInvitationId);
-        processWorkspaceInvitation(isDeclineAction, workspaceInvitationId, token)
-          .then(() => {
-            navigateTo(AppView.Login);
-            const notificationText = isDeclineAction
-              ? t('preferences.workspace.members.invitationFlow.declinedSuccessfully')
-              : t('preferences.workspace.members.invitationFlow.acceptedSuccessfully');
-            showNotification({ text: notificationText, isError: false });
-          })
-          .catch(() => {
-            const notificationText = isDeclineAction
-              ? t('preferences.workspace.members.invitationFlow.error.declinedError')
-              : t('preferences.workspace.members.invitationFlow.error.acceptedError');
-            showNotification({ text: notificationText, isError: true });
-          });
       } catch (error) {
         showNotification({
           text: t('linkExpired.title'),
           isError: true,
         });
+
+        return;
+      }
+
+      try {
+        await processWorkspaceInvitation(isDeclineAction, workspaceInvitationId, token);
+
+        navigateTo(AppView.Login);
+        const notificationText = isDeclineAction
+          ? t('preferences.workspace.members.invitationFlow.declinedSuccessfully')
+          : t('preferences.workspace.members.invitationFlow.acceptedSuccessfully');
+        showNotification({ text: notificationText, isError: false });
+        await wait(2000);
+        dispatch(workspaceThunks.fetchWorkspaces());
+      } catch (error) {
+        const notificationText = isDeclineAction
+          ? t('preferences.workspace.members.invitationFlow.error.declinedError')
+          : t('preferences.workspace.members.invitationFlow.error.acceptedError');
+        showNotification({ text: notificationText, isError: true });
       }
     }
   };


### PR DESCRIPTION
## Description

This PR implements a timeout to fetch the workspaces after accepting an invitation.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

Instead of fetching the workspaces after accepting an invitation, perhaps we can obtain them when the user opens the Workspaces dropdown menu, just as we do with pending workspace invitations.