### PR TITLE
[_]: fix/disable auto email tracking for Link payment method

### DIFF
--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutView.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutView.tsx
@@ -27,6 +27,16 @@ export const PAYMENT_ELEMENT_OPTIONS: StripePaymentElementOptions = {
     radios: false,
     spacedAccordionItems: true,
   },
+  fields: {
+    billingDetails: {
+      email: 'never',
+    },
+  },
+  defaultValues: {
+    billingDetails: {
+      email: '',
+    },
+  },
 };
 
 interface CheckoutViewProps {


### PR DESCRIPTION
## Description

Prevent Stripe Link from auto-activating when user email is detected

Configure PaymentElement to not prefill email automatically, allowing users to manually opt-in to Link instead of having it activate automatically.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [ ] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
