### PR TITLE
[PB-4724]: fix/remove deprecated fields from checks

### DIFF
--- a/src/app/auth/components/SignUp/WorkspaceGuestSignUp.tsx
+++ b/src/app/auth/components/SignUp/WorkspaceGuestSignUp.tsx
@@ -103,7 +103,7 @@ function WorkspaceGuestSingUpView(): JSX.Element {
   useEffect(() => {
     if (user && mnemonic) {
       dispatch(userActions.setUser(user));
-      if (user?.registerCompleted && mnemonic) {
+      if (mnemonic) {
         return navigationService.push(AppView.Drive);
       }
     }

--- a/src/app/routes/hooks/Login/useLoginRedirections.tsx
+++ b/src/app/routes/hooks/Login/useLoginRedirections.tsx
@@ -92,20 +92,16 @@ const useLoginRedirections = ({
       return navigateTo(AppView.Shared, { folderuuid: folderuuidToRedirect });
     }
 
-    if (user.registerCompleted === false) {
-      return navigateTo(AppView.Login);
-    }
-
-    if (user?.registerCompleted && mnemonic && options?.isSharingInvitation) {
+    if (mnemonic && options?.isSharingInvitation) {
       return navigateTo(AppView.Shared);
     }
 
-    if (user?.registerCompleted && mnemonic && !options?.universalLinkMode) {
+    if (mnemonic && !options?.universalLinkMode) {
       return navigateTo(AppView.Drive);
     }
 
     // This is a redirect for universal link for Desktop MacOS
-    if (user?.registerCompleted && mnemonic && options?.universalLinkMode) {
+    if (mnemonic && options?.universalLinkMode) {
       return navigateTo(AppView.UniversalLinkSuccess);
     }
   };

--- a/src/app/share/views/SharedGuestSignUp/ShareGuestSingUpView.tsx
+++ b/src/app/share/views/SharedGuestSignUp/ShareGuestSingUpView.tsx
@@ -114,7 +114,7 @@ function ShareGuestSingUpView(): JSX.Element {
   useEffect(() => {
     if (user && mnemonic) {
       dispatch(userActions.setUser(user));
-      if (user?.registerCompleted && mnemonic) {
+      if (mnemonic) {
         return navigationService.push(AppView.Shared);
       }
     }


### PR DESCRIPTION
## Description

This PR removes the field `registerCompleted` from all checks since this field is deprecated. This also fixes the issue some users have when trying to log in and they are not redirected to Drive.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
