### PR TITLE
[_]: fix/error while purchasing a subscription

### DIFF
--- a/src/app/newSettings/Sections/Account/Plans/PlansSection.tsx
+++ b/src/app/newSettings/Sections/Account/Plans/PlansSection.tsx
@@ -146,8 +146,6 @@ const PlansSection = ({ changeSection, onClosePreferences }: PlansSectionProps) 
 
       const userPlan = prices.find((p) => p.productId === individualSubscription?.productId && p.interval === interval);
 
-      console.log('USER PLAN: ', { userPlan, plan, individualPrices: prices });
-
       if (userPlan) {
         setPriceSelected(userPlan);
       }

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutView.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutView.tsx
@@ -23,7 +23,6 @@ export const PAYMENT_ELEMENT_OPTIONS: StripePaymentElementOptions = {
   },
   layout: {
     type: 'accordion',
-    defaultCollapsed: true,
     radios: false,
     spacedAccordionItems: true,
   },

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutView.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutView.tsx
@@ -63,6 +63,15 @@ const CheckoutView = ({
   const stripeSDK = useStripe();
   const elements = useElements();
   const [isCryptoDropdownOpen, setIsCryptoDropdownOpen] = useState<boolean>(false);
+  const {
+    isPaying,
+    error,
+    authMethod,
+    couponCodeData,
+    seatsForBusinessSubscription,
+    currentSelectedPlan,
+    selectedCurrency,
+  } = checkoutViewVariables;
 
   const onCryptoDropdownToggle = () => {
     if (!isCryptoDropdownOpen) {
@@ -75,18 +84,9 @@ const CheckoutView = ({
 
   const onStripePaymentExpanded = () => {
     onCurrencyTypeChanges(PaymentType['FIAT']);
+    checkoutViewManager.onCurrencyChange(currentSelectedPlan?.price.currency ?? 'eur');
     setIsCryptoDropdownOpen(false);
   };
-
-  const {
-    isPaying,
-    error,
-    authMethod,
-    couponCodeData,
-    seatsForBusinessSubscription,
-    currentSelectedPlan,
-    selectedCurrency,
-  } = checkoutViewVariables;
 
   const {
     register,


### PR DESCRIPTION
## Description

This PR fixes payment method selection by opening the first available payment method as default when none is selected (card).

Additionally, it fixes a bug where selecting crypto and then switching to another payment method would still use crypto. Now the selection correctly resets to the newly selected method, preventing the previous payment method from persisting.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
