### PR TITLE
[_]: Preserve white listed params during logout

### DIFF
--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -92,6 +92,21 @@ export type AuthenticateUserParams = {
   doSignUp?: RegisterFunction;
 };
 
+const getCurrentUrlParams = (): Record<string, string> => {
+  const currentParams = new URLSearchParams(window.location.search);
+  const preservedParams: Record<string, string> = {};
+
+  const safeParams = ['universalLink', 'folderuuid'];
+
+  currentParams.forEach((value, key) => {
+    if (safeParams.includes(key)) {
+      preservedParams[key] = value;
+    }
+  });
+
+  return preservedParams;
+};
+
 export async function logOut(loginParams?: Record<string, string>): Promise<void> {
   try {
     const token = localStorageService.get('xNewToken') ?? undefined;
@@ -108,7 +123,10 @@ export async function logOut(loginParams?: Record<string, string>): Promise<void
   localStorageService.clear();
   RealtimeService.getInstance().stop();
   if (!navigationService.isCurrentPath(AppView.BlockedAccount) && !navigationService.isCurrentPath(AppView.Checkout)) {
-    navigationService.push(AppView.Login, loginParams);
+    const preservedParams = getCurrentUrlParams();
+    const urlParams = { ...preservedParams, ...loginParams };
+
+    navigationService.push(AppView.Login, urlParams);
   }
 }
 


### PR DESCRIPTION
## Description

Preserve white listed url params during logout.
Now, when the app receives a 401 from backend, it logouts user automatically and the url params are removed. In some cases we want to preserve this parameters, such as when the login fails and we want to redirect to the application's opening screen with a successful login.

## Related Issues

-

## Related Pull Requests

-

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [x] QA Passed

## Testing Process

- Enter to an url as [BASE_URL]/login?universalLink=true, fail the login, and check that the params still in the url.

## Additional Notes
