### PR TITLE
[PB-4373]: feat/decrypt stream using offset byte

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: "https://npm.pkg.github.com"
+          registry-url: 'https://npm.pkg.github.com'
       - run: echo REACT_APP_CRYPTO_SECRET=${{ secrets.REACT_APP_CRYPTO_SECRET }} >> ./.env
       - run: echo REACT_APP_STRIPE_PK=${{ secrets.REACT_APP_STRIPE_PK }} >> ./.env
       - run: echo REACT_APP_STRIPE_TEST_PK=${{ secrets.REACT_APP_STRIPE_TEST_PK }} >> ./.env
@@ -55,7 +55,7 @@ jobs:
       - name: Install Playwright Browsers
         run: yarn playwright install
       - name: Unit test run
-        run: yarn test --no-cache
+        run: yarn test
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -67,7 +67,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: "https://npm.pkg.github.com"
+          registry-url: 'https://npm.pkg.github.com'
       - run: echo "registry=https://registry.yarnpkg.com/" > .npmrc
       - run: echo "@internxt:registry=https://npm.pkg.github.com" >> .npmrc
       # You cannot read packages from other private repos with GITHUB_TOKEN

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: 'https://npm.pkg.github.com'
+          registry-url: "https://npm.pkg.github.com"
       - run: echo REACT_APP_CRYPTO_SECRET=${{ secrets.REACT_APP_CRYPTO_SECRET }} >> ./.env
       - run: echo REACT_APP_STRIPE_PK=${{ secrets.REACT_APP_STRIPE_PK }} >> ./.env
       - run: echo REACT_APP_STRIPE_TEST_PK=${{ secrets.REACT_APP_STRIPE_TEST_PK }} >> ./.env
@@ -55,7 +55,7 @@ jobs:
       - name: Install Playwright Browsers
         run: yarn playwright install
       - name: Unit test run
-        run: yarn test
+        run: yarn test --no-cache
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -67,7 +67,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: 'https://npm.pkg.github.com'
+          registry-url: "https://npm.pkg.github.com"
       - run: echo "registry=https://registry.yarnpkg.com/" > .npmrc
       - run: echo "@internxt:registry=https://npm.pkg.github.com" >> .npmrc
       # You cannot read packages from other private repos with GITHUB_TOKEN

--- a/src/app/core/services/stream.service.test.ts
+++ b/src/app/core/services/stream.service.test.ts
@@ -16,7 +16,7 @@ vi.mock('app/network/download', () => ({
 
 import { decryptStream } from './stream.service';
 import { getDecryptedStream } from 'app/network/download';
-import crypto from 'crypto';
+import { createDecipheriv } from 'crypto';
 
 describe('Stream service', () => {
   let mockDecipher: any;
@@ -31,7 +31,7 @@ describe('Stream service', () => {
     mockDecipher = {
       update: vi.fn(),
     };
-    vi.mocked(crypto.createDecipheriv).mockReturnValue(mockDecipher);
+    (createDecipheriv as any).mockReturnValue(mockDecipher);
     mockInputSlices = [
       new ReadableStream({
         start(controller) {
@@ -45,7 +45,7 @@ describe('Stream service', () => {
     test('When there is no offset, then should proceed with standard decryption', () => {
       const result = decryptStream(mockInputSlices, mockKey, mockIv);
 
-      expect(crypto.createDecipheriv).toHaveBeenCalledWith('aes-256-ctr', mockKey, mockIv);
+      expect(createDecipheriv).toHaveBeenCalledWith('aes-256-ctr', mockKey, mockIv);
       expect(mockDecipher.update).not.toHaveBeenCalled();
       expect(getDecryptedStream).toHaveBeenCalledWith(mockInputSlices, mockDecipher);
       expect(result).toBeInstanceOf(ReadableStream);
@@ -61,7 +61,7 @@ describe('Stream service', () => {
 
       const result = decryptStream(mockInputSlices, mockKey, mockIv, startOffsetByte);
 
-      expect(crypto.createDecipheriv).toHaveBeenCalledWith('aes-256-ctr', mockKey, expectedNewIv);
+      expect(createDecipheriv).toHaveBeenCalledWith('aes-256-ctr', mockKey, expectedNewIv);
       expect(mockDecipher.update).toHaveBeenCalledWith(expectedSkipBuffer);
       expect(getDecryptedStream).toHaveBeenCalledWith(mockInputSlices, mockDecipher);
       expect(result).toBeInstanceOf(ReadableStream);

--- a/src/app/core/services/stream.service.test.ts
+++ b/src/app/core/services/stream.service.test.ts
@@ -5,9 +5,6 @@ vi.mock('crypto', () => ({
 }));
 
 import { decryptStream } from './stream.service';
-import { getDecryptedStream } from 'app/network/download';
-import { createDecipheriv } from 'crypto';
-
 vi.mock('app/network/download', () => ({
   getDecryptedStream: vi.fn(
     () =>
@@ -18,6 +15,9 @@ vi.mock('app/network/download', () => ({
       }),
   ),
 }));
+
+import { getDecryptedStream } from 'app/network/download';
+import crypto from 'crypto';
 
 describe('Stream service', () => {
   let mockDecipher: any;
@@ -32,7 +32,7 @@ describe('Stream service', () => {
     mockDecipher = {
       update: vi.fn(),
     };
-    vi.mocked(createDecipheriv).mockReturnValue(mockDecipher);
+    vi.mocked(crypto.createDecipheriv).mockReturnValue(mockDecipher);
     mockInputSlices = [
       new ReadableStream({
         start(controller) {
@@ -46,7 +46,7 @@ describe('Stream service', () => {
     test('When there is no offset, then should proceed with standard decryption', () => {
       const result = decryptStream(mockInputSlices, mockKey, mockIv);
 
-      expect(createDecipheriv).toHaveBeenCalledWith('aes-256-ctr', mockKey, mockIv);
+      expect(crypto.createDecipheriv).toHaveBeenCalledWith('aes-256-ctr', mockKey, mockIv);
       expect(mockDecipher.update).not.toHaveBeenCalled();
       expect(getDecryptedStream).toHaveBeenCalledWith(mockInputSlices, mockDecipher);
       expect(result).toBeInstanceOf(ReadableStream);
@@ -62,7 +62,7 @@ describe('Stream service', () => {
 
       const result = decryptStream(mockInputSlices, mockKey, mockIv, startOffsetByte);
 
-      expect(createDecipheriv).toHaveBeenCalledWith('aes-256-ctr', mockKey, expectedNewIv);
+      expect(crypto.createDecipheriv).toHaveBeenCalledWith('aes-256-ctr', mockKey, expectedNewIv);
       expect(mockDecipher.update).toHaveBeenCalledWith(expectedSkipBuffer);
       expect(getDecryptedStream).toHaveBeenCalledWith(mockInputSlices, mockDecipher);
       expect(result).toBeInstanceOf(ReadableStream);

--- a/src/app/core/services/stream.service.test.ts
+++ b/src/app/core/services/stream.service.test.ts
@@ -3,8 +3,6 @@ import { describe, it, expect, vi, beforeEach, test } from 'vitest';
 vi.mock('crypto', () => ({
   createDecipheriv: vi.fn(),
 }));
-
-import { decryptStream } from './stream.service';
 vi.mock('app/network/download', () => ({
   getDecryptedStream: vi.fn(
     () =>
@@ -16,6 +14,7 @@ vi.mock('app/network/download', () => ({
   ),
 }));
 
+import { decryptStream } from './stream.service';
 import { getDecryptedStream } from 'app/network/download';
 import crypto from 'crypto';
 

--- a/src/app/core/services/stream.service.test.ts
+++ b/src/app/core/services/stream.service.test.ts
@@ -43,7 +43,7 @@ describe('Stream service', () => {
   });
 
   describe('Decrypt Stream', () => {
-    test('When there is no offset, then should create a new cipher', () => {
+    test('When there is no offset, then should proceed with standard decryption', () => {
       const result = decryptStream(mockInputSlices, mockKey, mockIv);
 
       expect(createDecipheriv).toHaveBeenCalledWith('aes-256-ctr', mockKey, mockIv);

--- a/src/app/core/services/stream.service.test.ts
+++ b/src/app/core/services/stream.service.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, test } from 'vitest';
+
+vi.mock('crypto', () => ({
+  createDecipheriv: vi.fn(),
+}));
+
+import { decryptStream } from './stream.service';
+import { getDecryptedStream } from 'app/network/download';
+import { createDecipheriv } from 'crypto';
+
+vi.mock('app/network/download', () => ({
+  getDecryptedStream: vi.fn(
+    () =>
+      new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+  ),
+}));
+
+describe('Stream service', () => {
+  let mockDecipher: any;
+  let mockKey: Buffer;
+  let mockIv: Buffer;
+  let mockInputSlices: ReadableStream<Uint8Array>[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockKey = Buffer.from('0'.repeat(64), 'hex');
+    mockIv = Buffer.from('0'.repeat(32), 'hex');
+    mockDecipher = {
+      update: vi.fn(),
+    };
+    vi.mocked(createDecipheriv).mockReturnValue(mockDecipher);
+    mockInputSlices = [
+      new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+    ];
+  });
+
+  describe('Decrypt Stream', () => {
+    test('When there is no offset, then should create a new cipher', () => {
+      const result = decryptStream(mockInputSlices, mockKey, mockIv);
+
+      expect(createDecipheriv).toHaveBeenCalledWith('aes-256-ctr', mockKey, mockIv);
+      expect(mockDecipher.update).not.toHaveBeenCalled();
+      expect(getDecryptedStream).toHaveBeenCalledWith(mockInputSlices, mockDecipher);
+      expect(result).toBeInstanceOf(ReadableStream);
+    });
+
+    it('When there is an offset, then should calculate a new IV and skip the buffer', () => {
+      const startOffsetByte = 20;
+
+      const ivBigInt = BigInt('0x' + mockIv.toString('hex'));
+      const expectedNewIvHex = (ivBigInt + BigInt(1)).toString(16).padStart(32, '0');
+      const expectedNewIv = Buffer.from(expectedNewIvHex, 'hex');
+      const expectedSkipBuffer = Buffer.alloc(4, 0);
+
+      const result = decryptStream(mockInputSlices, mockKey, mockIv, startOffsetByte);
+
+      expect(createDecipheriv).toHaveBeenCalledWith('aes-256-ctr', mockKey, expectedNewIv);
+      expect(mockDecipher.update).toHaveBeenCalledWith(expectedSkipBuffer);
+      expect(getDecryptedStream).toHaveBeenCalledWith(mockInputSlices, mockDecipher);
+      expect(result).toBeInstanceOf(ReadableStream);
+    });
+  });
+});

--- a/src/app/core/services/stream.service.ts
+++ b/src/app/core/services/stream.service.ts
@@ -1,5 +1,5 @@
 import { getDecryptedStream } from 'app/network/download';
-import { createDecipheriv, Decipher } from 'crypto';
+import crypto, { Decipher } from 'crypto';
 
 type BinaryStream = ReadableStream<Uint8Array>;
 
@@ -73,10 +73,10 @@ export function decryptStream(
 
     const skipBuffer = Buffer.alloc(startOffset, 0);
 
-    decipher = createDecipheriv('aes-256-ctr', key, newIv);
+    decipher = crypto.createDecipheriv('aes-256-ctr', key, newIv);
     decipher.update(skipBuffer);
   } else {
-    decipher = createDecipheriv('aes-256-ctr', key, iv);
+    decipher = crypto.createDecipheriv('aes-256-ctr', key, iv);
   }
 
   return getDecryptedStream(inputSlices, decipher);

--- a/src/app/drive/services/downloadManager.service.test.ts
+++ b/src/app/drive/services/downloadManager.service.test.ts
@@ -34,7 +34,6 @@ import { downloadFile } from 'app/network/download';
 import { downloadWorkerHandler } from './worker.service/downloadWorkerHandler';
 
 vi.mock('./../../network/requests', () => ({ ConnectionLostError: vi.fn(), NetworkCredentials: {} }));
-vi.mock('app/core/services/stream.service', () => ({ downloadFile: vi.fn(), NetworkCredentials: {} }));
 vi.mock('app/tasks/services/tasks.service', () => ({
   default: {
     create: vi.fn(),
@@ -86,6 +85,9 @@ vi.mock('app/network/download', () => ({
 
 vi.mock('app/core/services/stream.service', () => ({
   binaryStreamToBlob: vi.fn(),
+  buildProgressStream: vi.fn(),
+  decryptStream: vi.fn(),
+  joinReadableBinaryStreams: vi.fn(),
 }));
 
 vi.mock('app/core/services/local-storage.service', () => ({

--- a/src/app/workers/downloadWorker.test.ts
+++ b/src/app/workers/downloadWorker.test.ts
@@ -7,14 +7,12 @@ vi.mock('app/drive/services/download.service/createFileDownloadStream', () => ({
   default: vi.fn(),
 }));
 
-vi.mock('app/core/services/stream.service', () => {
-  const actual = vi.importActual<typeof import('app/core/services/stream.service')>('app/core/services/stream.service');
-
-  return {
-    ...actual,
-    binaryStreamToBlob: vi.fn(),
-  };
-});
+vi.mock('app/core/services/stream.service', () => ({
+  binaryStreamToBlob: vi.fn(),
+  buildProgressStream: vi.fn(),
+  decryptStream: vi.fn(),
+  joinReadableBinaryStreams: vi.fn(),
+}));
 
 describe('Download Worker', () => {
   const mockFile = {


### PR DESCRIPTION
## Description

This PR enables decrypting encrypted streams from any byte position instead of requiring decryption from the beginning. The implementation adjusts the AES-CTR initialization vector based on the block number and skips intra-block bytes to align the decipher with the requested offset.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [ ] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

This approach is based on the existing [CLI implementation](https://github.com/internxt/cli/blob/bd91485a7f51be32270e2d9e5abe585e08169399/src/services/crypto.service.ts#L122).