### PR TITLE
[PB-4373]: feat/support byte-range file chunk downloading

### DIFF
--- a/src/app/drive/services/worker.service/downloadWorkerHandler.test.ts
+++ b/src/app/drive/services/worker.service/downloadWorkerHandler.test.ts
@@ -4,10 +4,11 @@ vi.mock('../download.service/downloadFileFromBlob', () => ({
 
 import streamSaver from 'streamsaver';
 import { describe, test, expect, vi, Mock, beforeEach } from 'vitest';
-import { DownloadAbortedByUserError, downloadWorkerHandler } from './downloadWorkerHandler';
+import { downloadWorkerHandler } from './downloadWorkerHandler';
 import { DriveFileData } from 'app/drive/types';
 import { MockWorker } from '../../../../__mocks__/WebWorker';
 import downloadFileFromBlob from '../download.service/downloadFileFromBlob';
+import { DownloadAbortedByUserError } from 'app/network/errors/download.errors';
 
 const writeMock = vi.fn();
 const closeMock = vi.fn();

--- a/src/app/drive/services/worker.service/downloadWorkerHandler.ts
+++ b/src/app/drive/services/worker.service/downloadWorkerHandler.ts
@@ -4,6 +4,7 @@ import { MessageData } from './types/download';
 import { createDownloadWebWorker } from '../../../../WebWorker';
 import downloadFileFromBlob from '../download.service/downloadFileFromBlob';
 import errorService from 'app/core/services/error.service';
+import { DownloadAbortedByUserError } from 'app/network/errors/download.errors';
 
 interface HandleWorkerMessagesPayload {
   worker: Worker;
@@ -181,12 +182,6 @@ export class DownloadWorkerHandler {
     if (progress && downloadCallback) {
       downloadCallback(progress);
     }
-  }
-}
-
-export class DownloadAbortedByUserError extends Error {
-  public constructor() {
-    super('Download aborted by user');
   }
 }
 

--- a/src/app/network/NetworkFacade.test.ts
+++ b/src/app/network/NetworkFacade.test.ts
@@ -1,10 +1,14 @@
 /* eslint-disable no-constant-condition */
 import { describe, it, expect, vi, beforeEach, afterEach, test } from 'vitest';
-import { DownloadFailedWithUnknownError, NetworkFacade, NoContentReceivedError } from './NetworkFacade';
+import { NetworkFacade } from './NetworkFacade';
 import { Network as NetworkModule } from '@internxt/sdk';
 import { downloadFile } from '@internxt/sdk/dist/network/download';
 import { decryptStream } from 'app/core/services/stream.service';
-import { DownloadAbortedByUserError } from 'app/drive/services/worker.service/downloadWorkerHandler';
+import {
+  DownloadAbortedByUserError,
+  DownloadFailedWithUnknownError,
+  NoContentReceivedError,
+} from './errors/download.errors';
 
 vi.mock('@internxt/sdk/dist/network/download');
 vi.mock('app/core/services/stream.service', () => ({

--- a/src/app/network/NetworkFacade.test.ts
+++ b/src/app/network/NetworkFacade.test.ts
@@ -1,0 +1,130 @@
+/* eslint-disable no-constant-condition */
+import { describe, it, expect, vi, beforeEach, afterEach, test } from 'vitest';
+import { NetworkFacade } from './NetworkFacade';
+import { Network as NetworkModule } from '@internxt/sdk';
+import { downloadFile } from '@internxt/sdk/dist/network/download';
+import { decryptStream } from 'app/core/services/stream.service';
+
+vi.mock('@internxt/sdk/dist/network/download');
+vi.mock('app/core/services/stream.service', () => ({
+  binaryStreamToBlob: vi.fn(),
+  buildProgressStream: vi.fn(),
+  decryptStream: vi.fn(),
+  joinReadableBinaryStreams: vi.fn(),
+}));
+vi.mock('async');
+vi.mock('bip39');
+vi.mock('crypto');
+
+describe('NetworkFacade', () => {
+  let networkFacade: NetworkFacade;
+  let mockNetwork: NetworkModule.Network;
+  let mockAbortController: AbortController;
+
+  beforeEach(() => {
+    mockNetwork = {} as NetworkModule.Network;
+    networkFacade = new NetworkFacade(mockNetwork);
+    mockAbortController = new AbortController();
+
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Downloading a chunk', () => {
+    const downloadExample = 'http://s3.inxt.download.com/example';
+    const bucketId = 'test-bucket';
+    const fileId = 'test-file';
+    const mnemonic = 'test-mnemonic';
+    const chunkStart = 0;
+    const chunkEnd = 1024;
+
+    test('When the download of a chunk is requested,then should download the chunk with a 206 status', async () => {
+      const mockStream = new ReadableStream();
+      const mockDecryptedStream = new ReadableStream();
+      const mockResponse = {
+        status: 206,
+        body: mockStream,
+      };
+
+      (global.fetch as any).mockResolvedValue(mockResponse);
+      (downloadFile as any).mockImplementation(
+        async (fileId, bucketId, mnemonic, network, cryptoLib, bufferFrom, downloadCallback, decryptCallback) => {
+          await downloadCallback([{ url: downloadExample }]);
+          await decryptCallback();
+        },
+      );
+      vi.mocked(decryptStream).mockReturnValue(mockDecryptedStream);
+
+      const result = await networkFacade.downloadChunk(bucketId, fileId, mnemonic, chunkStart, chunkEnd);
+
+      expect(result).toStrictEqual(mockDecryptedStream);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        downloadExample,
+        expect.objectContaining({
+          headers: {
+            Range: `bytes=${chunkStart}-${chunkEnd}`,
+            Connection: 'keep-alive',
+          },
+          keepalive: true,
+        }),
+      );
+    });
+
+    it('When the status is not 200 or 206 (successfully downloaded), then an error indicating so is thrown', async () => {
+      const mockResponse = {
+        status: 404,
+        body: new ReadableStream(),
+      };
+
+      (global.fetch as any).mockResolvedValue(mockResponse);
+      (downloadFile as any).mockImplementation(
+        async (fileId, bucketId, mnemonic, network, cryptoLib, bufferFrom, downloadCallback, decryptCallback) => {
+          await downloadCallback([{ url: downloadExample }]);
+        },
+      );
+
+      await expect(networkFacade.downloadChunk(bucketId, fileId, mnemonic, chunkStart, chunkEnd)).rejects.toThrow(
+        'Unexpected status 404',
+      );
+    });
+
+    test('When there is no body in the response, then an error is thrown', async () => {
+      const mockResponse = {
+        status: 206,
+        body: null,
+      };
+
+      (global.fetch as any).mockResolvedValue(mockResponse);
+      (downloadFile as any).mockImplementation(
+        async (fileId, bucketId, mnemonic, network, cryptoLib, bufferFrom, downloadCallback, decryptCallback) => {
+          await downloadCallback([{ url: downloadExample }]);
+        },
+      );
+
+      await expect(networkFacade.downloadChunk(bucketId, fileId, mnemonic, chunkStart, chunkEnd)).rejects.toThrow(
+        'No content received',
+      );
+    });
+
+    it('When the download is aborted, then an error indicating so is thrown', async () => {
+      const abortController = new AbortController();
+      abortController.abort();
+
+      (downloadFile as any).mockImplementation(
+        async (fileId, bucketId, mnemonic, network, cryptoLib, bufferFrom, downloadCallback, decryptCallback) => {
+          await downloadCallback([{ url: downloadExample }]);
+        },
+      );
+      await expect(
+        networkFacade.downloadChunk(bucketId, fileId, mnemonic, chunkStart, chunkEnd, {
+          abortController,
+        }),
+      ).rejects.toThrow('Download aborted');
+    });
+  });
+});

--- a/src/app/network/NetworkFacade.ts
+++ b/src/app/network/NetworkFacade.ts
@@ -17,7 +17,11 @@ import { DownloadProgressCallback, getDecryptedStream } from './download';
 import { uploadFileUint8Array, UploadProgressCallback } from './upload-utils';
 import { UPLOAD_CHUNK_SIZE, ALLOWED_CHUNK_OVERHEAD } from './networkConstants';
 import { WORKER_MESSAGE_STATES } from 'app/drive/services/worker.service/types/upload';
-import { DownloadAbortedByUserError } from 'app/drive/services/worker.service/downloadWorkerHandler';
+import {
+  DownloadAbortedByUserError,
+  DownloadFailedWithUnknownError,
+  NoContentReceivedError,
+} from './errors/download.errors';
 
 interface UploadOptions {
   uploadingCallback: UploadProgressCallback;
@@ -366,19 +370,5 @@ export class NetworkFacade {
     );
 
     return fileStream!;
-  }
-}
-
-export class DownloadFailedWithUnknownError extends Error {
-  constructor(status?: number) {
-    super(`Download failed with unknown error. Status code: ${status ?? 'unknown'}`);
-    Object.setPrototypeOf(this, DownloadFailedWithUnknownError.prototype);
-  }
-}
-
-export class NoContentReceivedError extends Error {
-  constructor() {
-    super('No content received');
-    Object.setPrototypeOf(this, NoContentReceivedError.prototype);
   }
 }

--- a/src/app/network/errors/download.errors.ts
+++ b/src/app/network/errors/download.errors.ts
@@ -1,0 +1,19 @@
+export class DownloadAbortedByUserError extends Error {
+  public constructor() {
+    super('Download aborted by user');
+  }
+}
+
+export class DownloadFailedWithUnknownError extends Error {
+  constructor(status?: number) {
+    super(`Download failed with unknown error. Status code: ${status ?? 'unknown'}`);
+    Object.setPrototypeOf(this, DownloadFailedWithUnknownError.prototype);
+  }
+}
+
+export class NoContentReceivedError extends Error {
+  constructor() {
+    super('No content received');
+    Object.setPrototypeOf(this, NoContentReceivedError.prototype);
+  }
+}

--- a/src/app/network/errors/download.errors.ts
+++ b/src/app/network/errors/download.errors.ts
@@ -1,6 +1,7 @@
 export class DownloadAbortedByUserError extends Error {
   public constructor() {
     super('Download aborted by user');
+    Object.setPrototypeOf(this, DownloadAbortedByUserError.prototype);
   }
 }
 


### PR DESCRIPTION
## Description

This PR introduces range-based chunk downloading that allows fetching specific byte segments from files using HTTP Range headers. This enables efficient streaming scenarios like video playback from arbitrary positions and parallel chunk downloads, significantly improving performance for large files by avoiding full file transfers.


## Checklist

- [ ] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

Part of the multipart download implementation.
