### PR TITLE
[PB-4444]: Add unit tests for Checkout services and store reducer

### DIFF
--- a/src/views/Checkout/services/auth-checkout.service.test.ts
+++ b/src/views/Checkout/services/auth-checkout.service.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import authCheckoutService from './auth-checkout.service';
+import * as authService from 'app/auth/services/auth.service';
+
+vi.mock('app/auth/services/auth.service', () => ({
+  logIn: vi.fn(),
+  signUp: vi.fn(),
+}));
+
+describe('authCheckoutService', () => {
+  const mockDispatch = vi.fn();
+  const mockDoRegister = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authenticateUser', () => {
+    it('authenticates existing user with credentials', async () => {
+      await authCheckoutService.authenticateUser({
+        email: 'user@example.com',
+        password: 'password123',
+        authMethod: 'signIn',
+        captcha: 'captcha_token',
+        dispatch: mockDispatch,
+        doRegister: mockDoRegister,
+      });
+
+      expect(authService.logIn).toHaveBeenCalledWith({
+        email: 'user@example.com',
+        password: 'password123',
+        twoFactorCode: '',
+        dispatch: mockDispatch,
+      });
+      expect(authService.signUp).not.toHaveBeenCalled();
+    });
+
+    it('creates new user account', async () => {
+      await authCheckoutService.authenticateUser({
+        email: 'newuser@example.com',
+        password: 'password123',
+        authMethod: 'signUp',
+        captcha: 'captcha_token',
+        dispatch: mockDispatch,
+        doRegister: mockDoRegister,
+      });
+
+      expect(authService.signUp).toHaveBeenCalledWith({
+        doSignUp: mockDoRegister,
+        email: 'newuser@example.com',
+        password: 'password123',
+        token: 'captcha_token',
+        redeemCodeObject: false,
+        dispatch: mockDispatch,
+      });
+      expect(authService.logIn).not.toHaveBeenCalled();
+    });
+
+    it('does nothing for already signed in users', async () => {
+      await authCheckoutService.authenticateUser({
+        email: 'user@example.com',
+        password: 'password123',
+        authMethod: 'userIsSignedIn',
+        captcha: 'captcha_token',
+        dispatch: mockDispatch,
+        doRegister: mockDoRegister,
+      });
+
+      expect(authService.logIn).not.toHaveBeenCalled();
+      expect(authService.signUp).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/views/Checkout/services/payment.service.test.ts
+++ b/src/views/Checkout/services/payment.service.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loadStripe } from '@stripe/stripe-js/pure';
+import paymentService from './payment.service';
+import { SdkFactory } from '../../../app/core/factory/sdk';
+import envService from '../../../app/core/services/env.service';
+import localStorageService from '../../../app/core/services/local-storage.service';
+import axios from 'axios';
+import { UserType } from '@internxt/sdk/dist/drive/payments/types/types';
+import { StripeSessionMode } from '../types';
+
+vi.mock('@stripe/stripe-js/pure');
+vi.mock('axios');
+
+describe('paymentService', () => {
+  const mockPaymentsClient = {
+    createCustomer: vi.fn(),
+    createSubscription: vi.fn(),
+    createPaymentIntent: vi.fn(),
+    createSession: vi.fn(),
+    getSetupIntent: vi.fn(),
+    getDefaultPaymentMethod: vi.fn(),
+    getInvoices: vi.fn(),
+    getUserSubscription: vi.fn(),
+    getPrices: vi.fn(),
+    isCouponUsedByUser: vi.fn(),
+    getPromoCodesUsedByUser: vi.fn(),
+    requestPreventCancellation: vi.fn(),
+    preventCancellation: vi.fn(),
+    applyRedeemCode: vi.fn(),
+    updateSubscriptionPrice: vi.fn(),
+    updateWorkspaceMembers: vi.fn(),
+    cancelSubscription: vi.fn(),
+    updateCustomerBillingInfo: vi.fn(),
+  };
+
+  const mockStripe = {
+    redirectToCheckout: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(SdkFactory, 'getNewApiInstance').mockReturnValue({
+      createPaymentsClient: vi.fn().mockResolvedValue(mockPaymentsClient),
+    } as any);
+    vi.mocked(loadStripe).mockResolvedValue(mockStripe as any);
+  });
+
+  describe('getStripe', () => {
+    it('initializes Stripe with production key', async () => {
+      vi.spyOn(envService, 'isProduction').mockReturnValue(true);
+      vi.spyOn(envService, 'getVariable').mockReturnValue('pk_live_test');
+
+      const stripe = await paymentService.getStripe();
+
+      expect(loadStripe).toHaveBeenCalledWith('pk_live_test');
+      expect(stripe).toBe(mockStripe);
+    });
+  });
+
+  describe('getCustomerId', () => {
+    it('returns customer ID and token', async () => {
+      const mockResponse = { customerId: 'cus_123', token: 'tok_123' };
+      mockPaymentsClient.createCustomer.mockResolvedValue(mockResponse);
+
+      const result = await paymentService.getCustomerId('John Doe', 'john@example.com', 'US', 'VAT123');
+
+      expect(mockPaymentsClient.createCustomer).toHaveBeenCalledWith('John Doe', 'john@example.com', 'US', 'VAT123');
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('createSubscription', () => {
+    it('creates subscription with promo code and seats', async () => {
+      const mockResponse = { clientSecret: 'cs_123', subscriptionId: 'sub_123' };
+      mockPaymentsClient.createSubscription.mockResolvedValue(mockResponse);
+
+      const result = await paymentService.createSubscription('cus_123', 'price_123', 'tok_123', 'usd', 'PROMO10', 2);
+
+      expect(mockPaymentsClient.createSubscription).toHaveBeenCalledWith(
+        'cus_123',
+        'price_123',
+        'tok_123',
+        2,
+        'usd',
+        'PROMO10',
+      );
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('createPaymentIntent', () => {
+    it('creates payment intent for plan', async () => {
+      const mockResponse = { clientSecret: 'cs_123', id: 'pi_123' };
+      mockPaymentsClient.createPaymentIntent.mockResolvedValue(mockResponse);
+
+      const result = await paymentService.createPaymentIntent('cus_123', 1000, 'plan_123', 'tok_123', 'usd', 'PROMO');
+
+      expect(mockPaymentsClient.createPaymentIntent).toHaveBeenCalledWith(
+        'cus_123',
+        1000,
+        'plan_123',
+        'tok_123',
+        'usd',
+        'PROMO',
+      );
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('createSession', () => {
+    it('creates checkout session', async () => {
+      const payload = { mode: 'subscription' as StripeSessionMode, priceId: 'price_123' };
+      const mockResponse = { id: 'cs_123' };
+      mockPaymentsClient.createSession.mockResolvedValue(mockResponse);
+
+      const result = await paymentService.createSession(payload);
+
+      expect(mockPaymentsClient.createSession).toHaveBeenCalledWith(payload);
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('updateSubscriptionPrice', () => {
+    it('changes plan with discount applied', async () => {
+      mockPaymentsClient.updateSubscriptionPrice.mockResolvedValue({
+        userSubscription: { id: 'sub_123' },
+        request3DSecure: false,
+        clientSecret: 'cs_123',
+      });
+
+      await paymentService.updateSubscriptionPrice({
+        priceId: 'price_123',
+        coupon: 'DISCOUNT',
+        userType: UserType.Individual,
+      });
+
+      expect(mockPaymentsClient.updateSubscriptionPrice).toHaveBeenCalledWith({
+        priceId: 'price_123',
+        couponCode: 'DISCOUNT',
+        userType: UserType.Individual,
+      });
+    });
+  });
+
+  describe('cancelSubscription', () => {
+    it('terminates active subscription', async () => {
+      mockPaymentsClient.cancelSubscription.mockResolvedValue(undefined);
+
+      await paymentService.cancelSubscription(UserType.Individual);
+
+      expect(mockPaymentsClient.cancelSubscription).toHaveBeenCalledWith(UserType.Individual);
+    });
+  });
+
+  describe('requestPreventCancellation', () => {
+    it('checks eligibility for retention offer', async () => {
+      mockPaymentsClient.requestPreventCancellation.mockResolvedValue({ elegible: true });
+
+      const result = await paymentService.requestPreventCancellation();
+
+      expect(mockPaymentsClient.requestPreventCancellation).toHaveBeenCalled();
+      expect(result.elegible).toBe(true);
+    });
+  });
+
+  describe('getUserSubscription', () => {
+    it('retrieves individual user subscription details', async () => {
+      const mockSubscription = {
+        id: 'sub_123',
+        type: 'subscription',
+        status: 'active',
+      };
+      mockPaymentsClient.getUserSubscription.mockResolvedValue(mockSubscription as any);
+
+      const result = await paymentService.getUserSubscription(UserType.Individual);
+
+      expect(mockPaymentsClient.getUserSubscription).toHaveBeenCalledWith(UserType.Individual);
+      expect(result).toEqual(mockSubscription);
+    });
+
+    it('retrieves subscription without specifying user type', async () => {
+      const mockSubscription = {
+        id: 'sub_456',
+        type: 'subscription',
+        status: 'active',
+      };
+      mockPaymentsClient.getUserSubscription.mockResolvedValue(mockSubscription as any);
+
+      const result = await paymentService.getUserSubscription();
+
+      expect(mockPaymentsClient.getUserSubscription).toHaveBeenCalledWith(undefined);
+      expect(result).toEqual(mockSubscription);
+    });
+  });
+
+  describe('getPrices', () => {
+    it('fetches prices for specific currency and user type', async () => {
+      const mockPrices = [
+        { id: 'price_1', amount: 999, currency: 'eur' },
+        { id: 'price_2', amount: 1999, currency: 'eur' },
+      ];
+      mockPaymentsClient.getPrices.mockResolvedValue(mockPrices as any);
+
+      const result = await paymentService.getPrices('eur', UserType.Individual);
+
+      expect(mockPaymentsClient.getPrices).toHaveBeenCalledWith('eur', UserType.Individual);
+      expect(result).toEqual(mockPrices);
+    });
+
+    it('fetches prices without parameters', async () => {
+      const mockPrices = [{ id: 'price_3', amount: 1299, currency: 'usd' }];
+      mockPaymentsClient.getPrices.mockResolvedValue(mockPrices as any);
+
+      const result = await paymentService.getPrices();
+
+      expect(mockPaymentsClient.getPrices).toHaveBeenCalledWith(undefined, undefined);
+      expect(result).toEqual(mockPrices);
+    });
+  });
+
+  describe('isCouponUsedByUser', () => {
+    it('detects when user already redeemed coupon', async () => {
+      const couponCode = 'SAVE20';
+      mockPaymentsClient.isCouponUsedByUser.mockResolvedValue({ couponUsed: true });
+
+      const result = await paymentService.isCouponUsedByUser(couponCode);
+
+      expect(mockPaymentsClient.isCouponUsedByUser).toHaveBeenCalledWith({ couponCode });
+      expect(result).toEqual({ couponUsed: true });
+    });
+
+    it('allows unused coupons to be applied', async () => {
+      const couponCode = 'DISCOUNT10';
+      mockPaymentsClient.isCouponUsedByUser.mockResolvedValue({ couponUsed: false });
+
+      const result = await paymentService.isCouponUsedByUser(couponCode);
+
+      expect(mockPaymentsClient.isCouponUsedByUser).toHaveBeenCalledWith({ couponCode: 'DISCOUNT10' });
+      expect(result).toEqual({ couponUsed: false });
+    });
+  });
+  describe('createSubscriptionWithTrial', () => {
+    it('activates free trial period', async () => {
+      vi.spyOn(localStorageService, 'get').mockReturnValue('token');
+      vi.spyOn(envService, 'getVariable').mockReturnValue('https://api.test.com');
+      vi.mocked(axios.post).mockResolvedValue({ data: { clientSecret: 'cs_123' } });
+
+      await paymentService.createSubscriptionWithTrial('cus_123', 'price_123', 'tok_123', 'trial_tok', 'usd');
+
+      expect(axios.post).toHaveBeenCalledWith(
+        'https://api.test.com/create-subscription-with-trial?trialToken=trial_tok',
+        { customerId: 'cus_123', priceId: 'price_123', currency: 'usd', token: 'tok_123' },
+        { headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' } },
+      );
+    });
+
+    it('throws error when authentication fails', async () => {
+      vi.spyOn(localStorageService, 'get').mockReturnValue(null);
+
+      await expect(paymentService.createSubscriptionWithTrial('cus', 'price', 'tok', 'trial')).rejects.toThrow();
+    });
+  });
+});

--- a/src/views/Checkout/store/checkoutReducer.test.ts
+++ b/src/views/Checkout/store/checkoutReducer.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+import { checkoutReducer, initialStateForCheckout } from './checkoutReducer';
+import { State } from './types';
+import { PriceWithTax } from '@internxt/sdk/dist/payments/types';
+import { DisplayPrice, UserType } from '@internxt/sdk/dist/drive/payments/types/types';
+import { CouponCodeData, PartialErrorState } from '../types';
+import { StripeElementsOptions } from '@stripe/stripe-js';
+
+describe('checkoutReducer', () => {
+  const createMockPlan = (id: string, currency: string, amount: number, type: UserType): PriceWithTax => ({
+    price: {
+      id,
+      currency,
+      amount,
+      bytes: 107374182400,
+      interval: 'month',
+      decimalAmount: 9.99,
+      type,
+      product: `prod_${id}`,
+    },
+    taxes: { tax: 0, decimalTax: 0, amountWithTax: amount, decimalAmountWithTax: 9.99 },
+  });
+
+  describe('initialStateForCheckout', () => {
+    it('provides default checkout state', () => {
+      expect(initialStateForCheckout.plan).toBeNull();
+      expect(initialStateForCheckout.isPaying).toBe(false);
+      expect(initialStateForCheckout.authMethod).toBe('signUp');
+      expect(initialStateForCheckout.seatsForBusinessSubscription).toBe(1);
+    });
+  });
+
+  describe('SET_PLAN', () => {
+    it('updates selected plan', () => {
+      const mockPlan = createMockPlan('123', 'usd', 999, UserType.Individual);
+      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_PLAN', payload: mockPlan });
+
+      expect(result.plan).toEqual(mockPlan);
+      expect(result).not.toBe(initialStateForCheckout);
+    });
+  });
+
+  describe('SET_CURRENT_PLAN_SELECTED', () => {
+    it('updates currently viewing plan', () => {
+      const mockPlan = createMockPlan('456', 'eur', 1999, UserType.Business);
+      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_CURRENT_PLAN_SELECTED', payload: mockPlan });
+
+      expect(result.currentSelectedPlan).toEqual(mockPlan);
+    });
+  });
+
+  describe('SET_AVATAR_BLOB', () => {
+    it('stores user avatar image', () => {
+      const mockBlob = new Blob(['avatar'], { type: 'image/png' });
+      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_AVATAR_BLOB', payload: mockBlob });
+      expect(result.avatarBlob).toBe(mockBlob);
+    });
+  });
+
+  describe('boolean state setters', () => {
+    it('tracks payment processing status', () => {
+      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_IS_PAYING', payload: true });
+      expect(result.isPaying).toBe(true);
+    });
+
+    it('marks checkout as ready to display', () => {
+      const result = checkoutReducer(initialStateForCheckout, {
+        type: 'SET_IS_CHECKOUT_READY_TO_RENDER',
+        payload: true,
+      });
+      expect(result.isCheckoutReadyToRender).toBe(true);
+    });
+
+    it('controls subscription update dialog visibility', () => {
+      const result = checkoutReducer(initialStateForCheckout, {
+        type: 'SET_IS_UPDATE_SUBSCRIPTION_DIALOG_OPEN',
+        payload: true,
+      });
+      expect(result.isUpdateSubscriptionDialogOpen).toBe(true);
+    });
+
+    it('tracks subscription update progress', () => {
+      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_IS_UPDATING_SUBSCRIPTION', payload: true });
+      expect(result.isUpdatingSubscription).toBe(true);
+    });
+  });
+
+  describe('SET_COUNTRY', () => {
+    it('stores billing country', () => {
+      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_COUNTRY', payload: 'US' });
+      expect(result.country).toBe('US');
+    });
+  });
+
+  describe('SET_PRICES', () => {
+    it('updates available pricing options', () => {
+      const mockPrices: DisplayPrice[] = [
+        {
+          id: 'price_1',
+          currency: 'usd',
+          amount: 999,
+          bytes: 107374182400,
+          interval: 'month',
+          userType: UserType.Individual,
+        },
+        {
+          id: 'price_2',
+          currency: 'usd',
+          amount: 1999,
+          bytes: 214748364800,
+          interval: 'year',
+          userType: UserType.Individual,
+        },
+      ];
+      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_PRICES', payload: mockPrices });
+      expect(result.prices).toEqual(mockPrices);
+    });
+  });
+
+  describe('string state setters', () => {
+    it('saves customer name from payment form', () => {
+      const result = checkoutReducer(initialStateForCheckout, {
+        type: 'SET_USER_NAME_FROM_ADDRESS_ELEMENT',
+        payload: 'John Doe',
+      });
+      expect(result.userNameFromAddressElement).toBe('John Doe');
+    });
+
+    it('applies promotional code', () => {
+      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_PROMO_CODE_NAME', payload: 'SUMMER2024' });
+      expect(result.promoCodeName).toBe('SUMMER2024');
+    });
+  });
+
+  describe('complex state setters', () => {
+    it('stores coupon details', () => {
+      const mockCoupon: CouponCodeData = { codeId: 'promo_123', codeName: 'DISCOUNT20', percentOff: 20 };
+      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_COUPON_CODE_DATA', payload: mockCoupon });
+      expect(result.couponCodeData).toEqual(mockCoupon);
+    });
+
+    it('configures Stripe payment elements', () => {
+      const mockOptions: StripeElementsOptions = { mode: 'payment', amount: 999, currency: 'usd' };
+      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_ELEMENTS_OPTIONS', payload: mockOptions });
+      expect(result.elementsOptions).toEqual(mockOptions);
+    });
+
+    it('switches between signup and login', () => {
+      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_AUTH_METHOD', payload: 'signIn' });
+      expect(result.authMethod).toBe('signIn');
+    });
+
+    it('captures checkout error state', () => {
+      const mockError: PartialErrorState = { stripe: 'Payment failed', auth: 'Authentication error' };
+      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_ERROR', payload: mockError });
+      expect(result.error).toEqual(mockError);
+    });
+
+    it('adjusts business plan seats', () => {
+      const result = checkoutReducer(initialStateForCheckout, {
+        type: 'SET_SEATS_FOR_BUSINESS_SUBSCRIPTION',
+        payload: 5,
+      });
+      expect(result.seatsForBusinessSubscription).toBe(5);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns unchanged state for unknown actions', () => {
+      expect(checkoutReducer(initialStateForCheckout, {} as never)).toBe(initialStateForCheckout);
+    });
+
+    it('creates new state object on every action', () => {
+      const customState: State = { ...initialStateForCheckout, country: 'FR', isPaying: true };
+      const result = checkoutReducer(customState, { type: 'SET_COUNTRY', payload: 'US' });
+
+      expect(result).not.toBe(customState);
+      expect(customState.country).toBe('FR');
+      expect(result.country).toBe('US');
+      expect(result.isPaying).toBe(true);
+    });
+  });
+});

--- a/src/views/Checkout/store/checkoutReducer.test.ts
+++ b/src/views/Checkout/store/checkoutReducer.test.ts
@@ -21,163 +21,174 @@ describe('checkoutReducer', () => {
     taxes: { tax: 0, decimalTax: 0, amountWithTax: amount, decimalAmountWithTax: 9.99 },
   });
 
-  describe('initialStateForCheckout', () => {
-    it('provides default checkout state', () => {
-      expect(initialStateForCheckout.plan).toBeNull();
-      expect(initialStateForCheckout.isPaying).toBe(false);
-      expect(initialStateForCheckout.authMethod).toBe('signUp');
-      expect(initialStateForCheckout.seatsForBusinessSubscription).toBe(1);
-    });
+  it('starts with the correct initial values', () => {
+    expect(initialStateForCheckout.plan).toBeNull();
+    expect(initialStateForCheckout.isPaying).toBe(false);
+    expect(initialStateForCheckout.authMethod).toBe('signUp');
+    expect(initialStateForCheckout.seatsForBusinessSubscription).toBe(1);
   });
 
-  describe('SET_PLAN', () => {
-    it('updates selected plan', () => {
-      const mockPlan = createMockPlan('123', 'usd', 999, UserType.Individual);
-      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_PLAN', payload: mockPlan });
+  it('changes selected plans without affecting other information', () => {
+    const customState: State = { ...initialStateForCheckout, country: 'FR', isPaying: true };
+    const mockPlan = createMockPlan('123', 'usd', 999, UserType.Individual);
 
-      expect(result.plan).toEqual(mockPlan);
-      expect(result).not.toBe(initialStateForCheckout);
-    });
+    const setPlanResult = checkoutReducer(customState, { type: 'SET_PLAN', payload: mockPlan });
+    expect(setPlanResult.plan).toEqual(mockPlan);
+    expect(setPlanResult.country).toBe('FR');
+    expect(setPlanResult.isPaying).toBe(true);
+    expect(setPlanResult).not.toBe(customState);
+
+    const setCurrentPlanResult = checkoutReducer(
+      { ...initialStateForCheckout, promoCodeName: 'PROMO123', seatsForBusinessSubscription: 5 },
+      { type: 'SET_CURRENT_PLAN_SELECTED', payload: mockPlan },
+    );
+    expect(setCurrentPlanResult.currentSelectedPlan).toEqual(mockPlan);
+    expect(setCurrentPlanResult.promoCodeName).toBe('PROMO123');
+    expect(setCurrentPlanResult.seatsForBusinessSubscription).toBe(5);
   });
 
-  describe('SET_CURRENT_PLAN_SELECTED', () => {
-    it('updates currently viewing plan', () => {
-      const mockPlan = createMockPlan('456', 'eur', 1999, UserType.Business);
-      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_CURRENT_PLAN_SELECTED', payload: mockPlan });
+  it('updates user avatar, country, and prices without losing other data', () => {
+    const mockBlob = new Blob(['avatar'], { type: 'image/png' });
+    const avatarResult = checkoutReducer(
+      { ...initialStateForCheckout, authMethod: 'signIn', isCheckoutReadyToRender: true },
+      { type: 'SET_AVATAR_BLOB', payload: mockBlob },
+    );
+    expect(avatarResult.avatarBlob).toBe(mockBlob);
+    expect(avatarResult.authMethod).toBe('signIn');
+    expect(avatarResult.isCheckoutReadyToRender).toBe(true);
 
-      expect(result.currentSelectedPlan).toEqual(mockPlan);
-    });
+    const countryResult = checkoutReducer(
+      { ...initialStateForCheckout, isPaying: false, authMethod: 'signIn' },
+      { type: 'SET_COUNTRY', payload: 'US' },
+    );
+    expect(countryResult.country).toBe('US');
+    expect(countryResult.isPaying).toBe(false);
+    expect(countryResult.authMethod).toBe('signIn');
+
+    const mockPrices: DisplayPrice[] = [
+      {
+        id: 'price_1',
+        currency: 'usd',
+        amount: 999,
+        bytes: 107374182400,
+        interval: 'month',
+        userType: UserType.Individual,
+      },
+    ];
+    const pricesResult = checkoutReducer(
+      { ...initialStateForCheckout, country: 'GB', seatsForBusinessSubscription: 3 },
+      { type: 'SET_PRICES', payload: mockPrices },
+    );
+    expect(pricesResult.prices).toEqual(mockPrices);
+    expect(pricesResult.country).toBe('GB');
+    expect(pricesResult.seatsForBusinessSubscription).toBe(3);
   });
 
-  describe('SET_AVATAR_BLOB', () => {
-    it('stores user avatar image', () => {
-      const mockBlob = new Blob(['avatar'], { type: 'image/png' });
-      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_AVATAR_BLOB', payload: mockBlob });
-      expect(result.avatarBlob).toBe(mockBlob);
-    });
+  it('tracks payment and loading status without erasing existing information', () => {
+    const payingResult = checkoutReducer(
+      { ...initialStateForCheckout, country: 'ES', userNameFromAddressElement: 'Jane Smith' },
+      { type: 'SET_IS_PAYING', payload: true },
+    );
+    expect(payingResult.isPaying).toBe(true);
+    expect(payingResult.country).toBe('ES');
+    expect(payingResult.userNameFromAddressElement).toBe('Jane Smith');
+
+    const readyResult = checkoutReducer(
+      { ...initialStateForCheckout, isPaying: true, promoCodeName: 'WELCOME' },
+      { type: 'SET_IS_CHECKOUT_READY_TO_RENDER', payload: true },
+    );
+    expect(readyResult.isCheckoutReadyToRender).toBe(true);
+    expect(readyResult.isPaying).toBe(true);
+    expect(readyResult.promoCodeName).toBe('WELCOME');
+
+    const dialogResult = checkoutReducer(
+      { ...initialStateForCheckout, isUpdatingSubscription: true, seatsForBusinessSubscription: 10 },
+      { type: 'SET_IS_UPDATE_SUBSCRIPTION_DIALOG_OPEN', payload: true },
+    );
+    expect(dialogResult.isUpdateSubscriptionDialogOpen).toBe(true);
+    expect(dialogResult.isUpdatingSubscription).toBe(true);
+    expect(dialogResult.seatsForBusinessSubscription).toBe(10);
+
+    const updatingResult = checkoutReducer(
+      { ...initialStateForCheckout, isUpdateSubscriptionDialogOpen: true, country: 'DE' },
+      { type: 'SET_IS_UPDATING_SUBSCRIPTION', payload: true },
+    );
+    expect(updatingResult.isUpdatingSubscription).toBe(true);
+    expect(updatingResult.isUpdateSubscriptionDialogOpen).toBe(true);
+    expect(updatingResult.country).toBe('DE');
   });
 
-  describe('boolean state setters', () => {
-    it('tracks payment processing status', () => {
-      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_IS_PAYING', payload: true });
-      expect(result.isPaying).toBe(true);
-    });
+  it('saves user name and promo codes while keeping everything else intact', () => {
+    const userNameResult = checkoutReducer(
+      { ...initialStateForCheckout, isCheckoutReadyToRender: true, country: 'IT' },
+      { type: 'SET_USER_NAME_FROM_ADDRESS_ELEMENT', payload: 'John Doe' },
+    );
+    expect(userNameResult.userNameFromAddressElement).toBe('John Doe');
+    expect(userNameResult.isCheckoutReadyToRender).toBe(true);
+    expect(userNameResult.country).toBe('IT');
 
-    it('marks checkout as ready to display', () => {
-      const result = checkoutReducer(initialStateForCheckout, {
-        type: 'SET_IS_CHECKOUT_READY_TO_RENDER',
-        payload: true,
-      });
-      expect(result.isCheckoutReadyToRender).toBe(true);
-    });
-
-    it('controls subscription update dialog visibility', () => {
-      const result = checkoutReducer(initialStateForCheckout, {
-        type: 'SET_IS_UPDATE_SUBSCRIPTION_DIALOG_OPEN',
-        payload: true,
-      });
-      expect(result.isUpdateSubscriptionDialogOpen).toBe(true);
-    });
-
-    it('tracks subscription update progress', () => {
-      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_IS_UPDATING_SUBSCRIPTION', payload: true });
-      expect(result.isUpdatingSubscription).toBe(true);
-    });
+    const promoCodeResult = checkoutReducer(
+      { ...initialStateForCheckout, isPaying: true, seatsForBusinessSubscription: 7 },
+      { type: 'SET_PROMO_CODE_NAME', payload: 'SUMMER2024' },
+    );
+    expect(promoCodeResult.promoCodeName).toBe('SUMMER2024');
+    expect(promoCodeResult.isPaying).toBe(true);
+    expect(promoCodeResult.seatsForBusinessSubscription).toBe(7);
   });
 
-  describe('SET_COUNTRY', () => {
-    it('stores billing country', () => {
-      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_COUNTRY', payload: 'US' });
-      expect(result.country).toBe('US');
-    });
+  it('handles coupons, payment settings, login method, errors, and seats without losing other details', () => {
+    const mockCoupon: CouponCodeData = { codeId: 'promo_123', codeName: 'DISCOUNT20', percentOff: 20 };
+    const couponResult = checkoutReducer(
+      { ...initialStateForCheckout, promoCodeName: 'EXISTING', country: 'CA' },
+      { type: 'SET_COUPON_CODE_DATA', payload: mockCoupon },
+    );
+    expect(couponResult.couponCodeData).toEqual(mockCoupon);
+    expect(couponResult.promoCodeName).toBe('EXISTING');
+    expect(couponResult.country).toBe('CA');
+
+    const mockOptions: StripeElementsOptions = { mode: 'payment', amount: 999, currency: 'usd' };
+    const elementsResult = checkoutReducer(
+      { ...initialStateForCheckout, isPaying: false, authMethod: 'signIn' },
+      { type: 'SET_ELEMENTS_OPTIONS', payload: mockOptions },
+    );
+    expect(elementsResult.elementsOptions).toEqual(mockOptions);
+    expect(elementsResult.isPaying).toBe(false);
+    expect(elementsResult.authMethod).toBe('signIn');
+
+    const authResult = checkoutReducer(
+      { ...initialStateForCheckout, isCheckoutReadyToRender: true, userNameFromAddressElement: 'Test User' },
+      { type: 'SET_AUTH_METHOD', payload: 'signIn' },
+    );
+    expect(authResult.authMethod).toBe('signIn');
+    expect(authResult.isCheckoutReadyToRender).toBe(true);
+    expect(authResult.userNameFromAddressElement).toBe('Test User');
+
+    const mockError: PartialErrorState = { stripe: 'Payment failed', auth: 'Authentication error' };
+    const errorResult = checkoutReducer(
+      { ...initialStateForCheckout, isPaying: true, country: 'MX' },
+      { type: 'SET_ERROR', payload: mockError },
+    );
+    expect(errorResult.error).toEqual(mockError);
+    expect(errorResult.isPaying).toBe(true);
+    expect(errorResult.country).toBe('MX');
+
+    const seatsResult = checkoutReducer(
+      { ...initialStateForCheckout, promoCodeName: 'BUSINESS', isUpdatingSubscription: true },
+      { type: 'SET_SEATS_FOR_BUSINESS_SUBSCRIPTION', payload: 5 },
+    );
+    expect(seatsResult.seatsForBusinessSubscription).toBe(5);
+    expect(seatsResult.promoCodeName).toBe('BUSINESS');
+    expect(seatsResult.isUpdatingSubscription).toBe(true);
   });
 
-  describe('SET_PRICES', () => {
-    it('updates available pricing options', () => {
-      const mockPrices: DisplayPrice[] = [
-        {
-          id: 'price_1',
-          currency: 'usd',
-          amount: 999,
-          bytes: 107374182400,
-          interval: 'month',
-          userType: UserType.Individual,
-        },
-        {
-          id: 'price_2',
-          currency: 'usd',
-          amount: 1999,
-          bytes: 214748364800,
-          interval: 'year',
-          userType: UserType.Individual,
-        },
-      ];
-      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_PRICES', payload: mockPrices });
-      expect(result.prices).toEqual(mockPrices);
-    });
-  });
+  it('ignores unknown actions and creates new copies when making changes', () => {
+    expect(checkoutReducer(initialStateForCheckout, {} as never)).toBe(initialStateForCheckout);
 
-  describe('string state setters', () => {
-    it('saves customer name from payment form', () => {
-      const result = checkoutReducer(initialStateForCheckout, {
-        type: 'SET_USER_NAME_FROM_ADDRESS_ELEMENT',
-        payload: 'John Doe',
-      });
-      expect(result.userNameFromAddressElement).toBe('John Doe');
-    });
-
-    it('applies promotional code', () => {
-      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_PROMO_CODE_NAME', payload: 'SUMMER2024' });
-      expect(result.promoCodeName).toBe('SUMMER2024');
-    });
-  });
-
-  describe('complex state setters', () => {
-    it('stores coupon details', () => {
-      const mockCoupon: CouponCodeData = { codeId: 'promo_123', codeName: 'DISCOUNT20', percentOff: 20 };
-      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_COUPON_CODE_DATA', payload: mockCoupon });
-      expect(result.couponCodeData).toEqual(mockCoupon);
-    });
-
-    it('configures Stripe payment elements', () => {
-      const mockOptions: StripeElementsOptions = { mode: 'payment', amount: 999, currency: 'usd' };
-      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_ELEMENTS_OPTIONS', payload: mockOptions });
-      expect(result.elementsOptions).toEqual(mockOptions);
-    });
-
-    it('switches between signup and login', () => {
-      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_AUTH_METHOD', payload: 'signIn' });
-      expect(result.authMethod).toBe('signIn');
-    });
-
-    it('captures checkout error state', () => {
-      const mockError: PartialErrorState = { stripe: 'Payment failed', auth: 'Authentication error' };
-      const result = checkoutReducer(initialStateForCheckout, { type: 'SET_ERROR', payload: mockError });
-      expect(result.error).toEqual(mockError);
-    });
-
-    it('adjusts business plan seats', () => {
-      const result = checkoutReducer(initialStateForCheckout, {
-        type: 'SET_SEATS_FOR_BUSINESS_SUBSCRIPTION',
-        payload: 5,
-      });
-      expect(result.seatsForBusinessSubscription).toBe(5);
-    });
-  });
-
-  describe('edge cases', () => {
-    it('returns unchanged state for unknown actions', () => {
-      expect(checkoutReducer(initialStateForCheckout, {} as never)).toBe(initialStateForCheckout);
-    });
-
-    it('creates new state object on every action', () => {
-      const customState: State = { ...initialStateForCheckout, country: 'FR', isPaying: true };
-      const result = checkoutReducer(customState, { type: 'SET_COUNTRY', payload: 'US' });
-
-      expect(result).not.toBe(customState);
-      expect(customState.country).toBe('FR');
-      expect(result.country).toBe('US');
-      expect(result.isPaying).toBe(true);
-    });
+    const customState: State = { ...initialStateForCheckout, country: 'FR', isPaying: true };
+    const result = checkoutReducer(customState, { type: 'SET_COUNTRY', payload: 'US' });
+    expect(result).not.toBe(customState);
+    expect(customState.country).toBe('FR');
+    expect(result.country).toBe('US');
+    expect(result.isPaying).toBe(true);
   });
 });


### PR DESCRIPTION
## Description

  Added comprehensive test coverage for:
  - authCheckoutService payment methods and subscription handling
  - paymentService checkout sessions, subscriptions, and trial creation
  - checkoutReducer state management for coupons, seats, and currency

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Main PR](https://github.com/internxt/drive-web/pull/1714)
-->

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
