### PR TITLE
[PB-4446]: test: add unit specs for error and socket services

### DIFF
--- a/src/services/error.service.test.ts
+++ b/src/services/error.service.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { addBreadcrumb, captureException } from '@sentry/react';
+import { AxiosError, AxiosResponse } from 'axios';
+import AppError from 'app/core/types';
+import errorService from './error.service';
+import envService from './env.service';
+
+vi.mock('@sentry/react', () => ({
+  addBreadcrumb: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+vi.mock('./env.service', () => ({
+  default: { getVariable: vi.fn() },
+}));
+
+describe('Error Service', () => {
+  const mockEnvService = vi.mocked(envService.getVariable);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createAxiosError = (data: unknown, status?: number): AxiosError => {
+    const error = new AxiosError('Request failed');
+    if (status !== undefined) {
+      error.response = { data, status, statusText: '', headers: {}, config: {} as never } as AxiosResponse;
+    }
+    return error;
+  };
+
+  describe('reportError', () => {
+    it('should call captureException with exception and optional context', () => {
+      const error = new Error('Test error');
+      const context = { tags: { module: 'test' } };
+      mockEnvService.mockReturnValue('production');
+
+      errorService.reportError(error);
+      expect(captureException).toHaveBeenCalledWith(error, undefined);
+
+      errorService.reportError(error, context);
+      expect(captureException).toHaveBeenCalledWith(error, context);
+    });
+
+    it('should log error to console only in development mode', () => {
+      const error = new Error('Test error');
+      mockEnvService.mockReturnValue('development');
+
+      errorService.reportError(error);
+
+      expect(console.error).toHaveBeenCalledWith(
+        '[ERROR_CATCHED]: This error has been catched and is being reported to Sentry',
+        error,
+      );
+      expect(captureException).toHaveBeenCalled();
+    });
+
+    it('should not log to console in production mode', () => {
+      mockEnvService.mockReturnValue('production');
+
+      errorService.reportError('String error');
+
+      expect(console.error).not.toHaveBeenCalled();
+      expect(captureException).toHaveBeenCalled();
+    });
+  });
+
+  describe('addBreadcrumb', () => {
+    it('should call Sentry addBreadcrumb with breadcrumb props', () => {
+      const breadcrumb = { message: 'User clicked button', category: 'user', level: 'info' as const };
+      const breadcrumbWithData = { message: 'API call', category: 'http', data: { url: '/api/test' } };
+
+      errorService.addBreadcrumb(breadcrumb);
+      expect(addBreadcrumb).toHaveBeenCalledWith(breadcrumb);
+
+      errorService.addBreadcrumb(breadcrumbWithData);
+      expect(addBreadcrumb).toHaveBeenCalledWith(breadcrumbWithData);
+    });
+  });
+
+  describe('castError', () => {
+    describe('AxiosError handling', () => {
+      it('should cast AxiosError with error field prioritized over message', () => {
+        const result1 = errorService.castError(createAxiosError({ error: 'Custom error message' }, 400));
+        expect(result1).toBeInstanceOf(AppError);
+        expect(result1.message).toBe('Custom error message');
+        expect(result1.status).toBe(400);
+
+        const result2 = errorService.castError(
+          createAxiosError({ error: 'Error field', message: 'Message field' }, 500),
+        );
+        expect(result2.message).toBe('Error field');
+      });
+
+      it('should cast AxiosError with message field when error field is absent', () => {
+        const result = errorService.castError(createAxiosError({ message: 'Custom message' }, 404));
+        expect(result.message).toBe('Custom message');
+        expect(result.status).toBe(404);
+      });
+
+      it('should use default message when response data is empty or no response', () => {
+        const result1 = errorService.castError(createAxiosError({}, 503));
+        expect(result1.message).toBe('Unknown error');
+        expect(result1.status).toBe(503);
+
+        const result2 = errorService.castError(new AxiosError('Network error'));
+        expect(result2.message).toBe('Unknown error');
+        expect(result2.status).toBeUndefined();
+      });
+    });
+
+    describe('String and Error instance handling', () => {
+      it('should cast string error to AppError', () => {
+        const result = errorService.castError('Simple error message');
+        expect(result).toBeInstanceOf(AppError);
+        expect(result.message).toBe('Simple error message');
+        expect(result.status).toBeUndefined();
+      });
+
+      it('should cast Error instance to AppError with optional status', () => {
+        const result1 = errorService.castError(new Error('Standard error'));
+        expect(result1.message).toBe('Standard error');
+        expect(result1.status).toBeUndefined();
+
+        const errorWithStatus = Object.assign(new Error('Error with status'), { status: 401 });
+        const result2 = errorService.castError(errorWithStatus);
+        expect(result2.message).toBe('Error with status');
+        expect(result2.status).toBe(401);
+      });
+
+      it('should handle Error with empty message', () => {
+        const result = errorService.castError(new Error(''));
+        expect(result.message).toBe('Unknown error');
+      });
+    });
+
+    describe('Object and edge cases', () => {
+      it('should cast object with message and status', () => {
+        const result = errorService.castError({ message: 'Object error', status: 422 });
+        expect(result).toBeInstanceOf(AppError);
+        expect(result.message).toBe('Object error');
+        expect(result.status).toBe(422);
+      });
+
+      it('should handle objects and primitives without message as unknown error', () => {
+        const testCases = [{ foo: 'bar' }, { status: 403 }, 404, false, [1, 2, 3]];
+
+        for (const error of testCases) {
+          const result = errorService.castError(error);
+          expect(result).toBeInstanceOf(AppError);
+          expect(result.message).toBe('Unknown error');
+        }
+      });
+    });
+  });
+});

--- a/src/services/socket.service.test.ts
+++ b/src/services/socket.service.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
+import RealtimeService, { SOCKET_EVENTS } from './socket.service';
+import localStorageService from './local-storage.service';
+import envService from './env.service';
+
+const { mockSocket, ioMock } = vi.hoisted(() => {
+  const mockSocket = {
+    id: 'mock-socket-id',
+    connected: true,
+    disconnected: false,
+    on: vi.fn(),
+    removeAllListeners: vi.fn(),
+    close: vi.fn(),
+  };
+
+  const ioMock = vi.fn(() => mockSocket);
+
+  return { mockSocket, ioMock };
+});
+
+vi.mock('socket.io-client', () => ({
+  default: ioMock,
+}));
+
+vi.mock('./local-storage.service', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('./env.service', () => ({
+  default: {
+    getVariable: vi.fn(),
+  },
+}));
+
+describe('RealtimeService', () => {
+  let service: RealtimeService;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (RealtimeService as unknown as { instance: RealtimeService | undefined }).instance = undefined;
+    service = RealtimeService.getInstance();
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(envService.getVariable).mockImplementation((key: string) => {
+      if (key === 'nodeEnv') return 'test';
+      if (key === 'notifications') return 'https://notifications.example.com';
+      return '';
+    });
+
+    vi.mocked(localStorageService.get).mockReturnValue('mock-token-123');
+
+    mockSocket.id = 'mock-socket-id';
+    mockSocket.connected = true;
+    mockSocket.disconnected = false;
+    mockSocket.on.mockClear();
+    mockSocket.removeAllListeners.mockClear();
+    mockSocket.close.mockClear();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('Service instance management', () => {
+    it('When requesting the service multiple times, then the same instance is returned', () => {
+      const instance1 = RealtimeService.getInstance();
+      const instance2 = RealtimeService.getInstance();
+
+      expect(instance1).toBe(instance2);
+    });
+  });
+
+  describe('Event constants', () => {
+    it('When accessing event types, then FILE_CREATED event is available', () => {
+      expect(SOCKET_EVENTS).toHaveProperty('FILE_CREATED');
+      expect(SOCKET_EVENTS.FILE_CREATED).toBe('FILE_CREATED');
+    });
+  });
+
+  describe('Establishing realtime connection', () => {
+    it('When initializing the service, then it connects with authentication and credentials', () => {
+      service.init();
+
+      expect(ioMock).toHaveBeenCalledWith('https://notifications.example.com', {
+        auth: { token: 'mock-token-123' },
+        reconnection: false,
+        withCredentials: true,
+      });
+    });
+
+    it.each(['connect', 'disconnect', 'connect_error'])(
+      'When initializing, then %s events are monitored',
+      (eventName) => {
+        service.init();
+        expect(mockSocket.on).toHaveBeenCalledWith(eventName, expect.any(Function));
+      },
+    );
+
+    it('When connection succeeds, then the callback is notified', () => {
+      const onConnectedCallback = vi.fn();
+      service.init(onConnectedCallback);
+
+      const connectHandler = mockSocket.on.mock.calls.find((call) => call[0] === 'connect')?.[1];
+      connectHandler?.();
+
+      expect(onConnectedCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      { env: 'production', reconnection: true, logs: false },
+      { env: 'development', reconnection: false, logs: true },
+    ])(
+      'When running in $env, then reconnection is $reconnection and logging is $logs',
+      ({ env, reconnection, logs }) => {
+        vi.mocked(envService.getVariable).mockImplementation((key: string) => {
+          if (key === 'nodeEnv') return env;
+          if (key === 'notifications') return 'https://notifications.example.com';
+          return '';
+        });
+
+        service.init();
+
+        expect(ioMock).toHaveBeenCalledWith('https://notifications.example.com', {
+          auth: { token: 'mock-token-123' },
+          reconnection,
+          withCredentials: true,
+        });
+
+        if (logs) {
+          expect(consoleLogSpy).toHaveBeenCalledWith('[REALTIME]: CONNECTING...');
+        } else {
+          expect(consoleLogSpy).not.toHaveBeenCalledWith('[REALTIME]: CONNECTING...');
+        }
+      },
+    );
+  });
+
+  describe('Retrieving connection identifier', () => {
+    it('When connected, then the unique client ID is provided', () => {
+      service.init();
+
+      const clientId = service.getClientId();
+
+      expect(clientId).toBe('mock-socket-id');
+    });
+
+    it('When not connected, then an error is raised', () => {
+      expect(() => service.getClientId()).toThrow('Realtime service is not connected');
+    });
+  });
+
+  describe('Receiving realtime notifications', () => {
+    it('When subscribing to events, then notifications are received and handled', () => {
+      service.init();
+      const callback = vi.fn();
+      const eventData = { type: 'FILE_CREATED', payload: { fileId: '123' } };
+
+      const result = service.onEvent(callback);
+
+      expect(result).toBe(true);
+      expect(mockSocket.on).toHaveBeenCalledWith('event', expect.any(Function));
+
+      const eventHandler = mockSocket.on.mock.calls.find((call) => call[0] === 'event')?.[1];
+      eventHandler?.(eventData);
+
+      expect(callback).toHaveBeenCalledWith(eventData);
+    });
+
+    it('When connection is lost, then subscription fails gracefully', () => {
+      service.init();
+      mockSocket.disconnected = true;
+
+      const result = service.onEvent(vi.fn());
+
+      expect(result).toBe(false);
+      expect(consoleLogSpy).toHaveBeenCalledWith('[REALTIME] SOCKET IS DISCONNECTED');
+    });
+  });
+
+  describe('Cleaning up event subscriptions', () => {
+    it('When removing listeners, then all active subscriptions are cleared', () => {
+      service.init();
+      service.removeAllListeners();
+
+      expect(mockSocket.removeAllListeners).toHaveBeenCalledTimes(1);
+    });
+
+    it('When cleaning up without initialization, then no errors occur', () => {
+      expect(() => service.removeAllListeners()).not.toThrow();
+    });
+  });
+
+  describe('Closing the connection', () => {
+    it.each([
+      { connected: true, closes: true },
+      { connected: false, closes: false },
+    ])('When connection status is $connected, then closing $closes the socket', ({ connected, closes }) => {
+      service.init();
+      mockSocket.connected = connected;
+
+      service.stop();
+
+      if (closes) {
+        expect(mockSocket.close).toHaveBeenCalledTimes(1);
+      } else {
+        expect(mockSocket.close).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe('Complete workflow', () => {
+    it('When using the service end-to-end, then all operations work together', () => {
+      const onConnected = vi.fn();
+      const eventCallback = vi.fn();
+
+      service.init(onConnected);
+      const connectHandler = mockSocket.on.mock.calls.find((call) => call[0] === 'connect')?.[1];
+      connectHandler?.();
+
+      service.onEvent(eventCallback);
+      const eventHandler = mockSocket.on.mock.calls.find((call) => call[0] === 'event')?.[1];
+      eventHandler?.({ type: 'FILE_CREATED' });
+
+      service.stop();
+
+      expect(onConnected).toHaveBeenCalled();
+      expect(eventCallback).toHaveBeenCalled();
+      expect(mockSocket.close).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/socket.service.test.ts
+++ b/src/services/socket.service.test.ts
@@ -67,7 +67,7 @@ describe('RealtimeService', () => {
   });
 
   describe('Service instance management', () => {
-    it('When requesting the service multiple times, then the same instance is returned', () => {
+    it('returns the same service instance across multiple requests', () => {
       const instance1 = RealtimeService.getInstance();
       const instance2 = RealtimeService.getInstance();
 
@@ -76,14 +76,14 @@ describe('RealtimeService', () => {
   });
 
   describe('Event constants', () => {
-    it('When accessing event types, then FILE_CREATED event is available', () => {
+    it('provides predefined event types for subscription', () => {
       expect(SOCKET_EVENTS).toHaveProperty('FILE_CREATED');
       expect(SOCKET_EVENTS.FILE_CREATED).toBe('FILE_CREATED');
     });
   });
 
   describe('Establishing realtime connection', () => {
-    it('When initializing the service, then it connects with authentication and credentials', () => {
+    it('establishes a secure connection with authentication when initialized', () => {
       service.init();
 
       expect(ioMock).toHaveBeenCalledWith('https://notifications.example.com', {
@@ -94,14 +94,14 @@ describe('RealtimeService', () => {
     });
 
     it.each(['connect', 'disconnect', 'connect_error'])(
-      'When initializing, then %s events are monitored',
+      'monitors connection lifecycle through %s events',
       (eventName) => {
         service.init();
         expect(mockSocket.on).toHaveBeenCalledWith(eventName, expect.any(Function));
       },
     );
 
-    it('When connection succeeds, then the callback is notified', () => {
+    it('notifies the application when connection is successfully established', () => {
       const onConnectedCallback = vi.fn();
       service.init(onConnectedCallback);
 
@@ -115,7 +115,7 @@ describe('RealtimeService', () => {
       { env: 'production', reconnection: true, logs: false },
       { env: 'development', reconnection: false, logs: true },
     ])(
-      'When running in $env, then reconnection is $reconnection and logging is $logs',
+      'adjusts behavior for $env environment with reconnection=$reconnection and logging=$logs',
       ({ env, reconnection, logs }) => {
         vi.mocked(envService.getVariable).mockImplementation((key: string) => {
           if (key === 'nodeEnv') return env;
@@ -141,7 +141,7 @@ describe('RealtimeService', () => {
   });
 
   describe('Retrieving connection identifier', () => {
-    it('When connected, then the unique client ID is provided', () => {
+    it('provides a unique identifier for the connected client', () => {
       service.init();
 
       const clientId = service.getClientId();
@@ -149,13 +149,13 @@ describe('RealtimeService', () => {
       expect(clientId).toBe('mock-socket-id');
     });
 
-    it('When not connected, then an error is raised', () => {
+    it('reports an error when requesting the client ID before connecting', () => {
       expect(() => service.getClientId()).toThrow('Realtime service is not connected');
     });
   });
 
   describe('Receiving realtime notifications', () => {
-    it('When subscribing to events, then notifications are received and handled', () => {
+    it('delivers realtime notifications to subscribed listeners', () => {
       service.init();
       const callback = vi.fn();
       const eventData = { type: 'FILE_CREATED', payload: { fileId: '123' } };
@@ -171,7 +171,7 @@ describe('RealtimeService', () => {
       expect(callback).toHaveBeenCalledWith(eventData);
     });
 
-    it('When connection is lost, then subscription fails gracefully', () => {
+    it('prevents event subscriptions when the connection is lost', () => {
       service.init();
       mockSocket.disconnected = true;
 
@@ -183,14 +183,14 @@ describe('RealtimeService', () => {
   });
 
   describe('Cleaning up event subscriptions', () => {
-    it('When removing listeners, then all active subscriptions are cleared', () => {
+    it('clears all active event subscriptions when requested', () => {
       service.init();
       service.removeAllListeners();
 
       expect(mockSocket.removeAllListeners).toHaveBeenCalledTimes(1);
     });
 
-    it('When cleaning up without initialization, then no errors occur', () => {
+    it('handles cleanup safely even when not initialized', () => {
       expect(() => service.removeAllListeners()).not.toThrow();
     });
   });
@@ -199,7 +199,7 @@ describe('RealtimeService', () => {
     it.each([
       { connected: true, closes: true },
       { connected: false, closes: false },
-    ])('When connection status is $connected, then closing $closes the socket', ({ connected, closes }) => {
+    ])('closes the socket only when connected (connected=$connected, closes=$closes)', ({ connected, closes }) => {
       service.init();
       mockSocket.connected = connected;
 
@@ -214,7 +214,7 @@ describe('RealtimeService', () => {
   });
 
   describe('Complete workflow', () => {
-    it('When using the service end-to-end, then all operations work together', () => {
+    it('connects, receives notifications, and disconnects successfully in a complete flow', () => {
       const onConnected = vi.fn();
       const eventCallback = vi.fn();
 

--- a/src/services/workspace.service.test.ts
+++ b/src/services/workspace.service.test.ts
@@ -532,21 +532,4 @@ describe('workspace service', () => {
       );
     });
   });
-
-  describe('When validating the default export', () => {
-    it('should export all required functions', () => {
-      [
-        'getWorkspaces',
-        'getWorkspacesMembers',
-        'getWorkspaceTeams',
-        'inviteUserToTeam',
-        'createTeam',
-        'shareItemWithTeam',
-        'getWorkspace',
-        'leaveWorkspace',
-      ].forEach((fn) => {
-        expect(workspacesService[fn]).toBeDefined();
-      });
-    });
-  });
 });

--- a/src/services/workspace.service.test.ts
+++ b/src/services/workspace.service.test.ts
@@ -1,0 +1,552 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WorkspaceLogType } from '@internxt/sdk/dist/workspaces';
+import errorService from './error.service';
+import workspacesService, * as workspaceService from './workspace.service';
+
+const mockIds = {
+  workspaceId: 'workspace-123',
+  teamId: 'team-456',
+  memberId: 'member-789',
+  invitationId: 'invitation-abc',
+  token: 'token-xyz',
+  uuid: 'uuid-def',
+};
+
+const mockWorkspacesClient = {
+  getWorkspaces: vi.fn(),
+  getWorkspacesMembers: vi.fn(),
+  getWorkspacesTeams: vi.fn(),
+  getWorkspacesTeamMembers: vi.fn(),
+  getMemberDetails: vi.fn(),
+  inviteMemberToWorkspace: vi.fn(),
+  acceptInvitation: vi.fn(),
+  declineInvitation: vi.fn(),
+  setupWorkspace: vi.fn(),
+  editWorkspace: vi.fn(),
+  updateAvatar: vi.fn(),
+  deleteAvatar: vi.fn(),
+  createTeam: vi.fn(),
+  editTeam: vi.fn(),
+  deleteTeam: vi.fn(),
+  addTeamUser: vi.fn(),
+  removeTeamUser: vi.fn(),
+  changeTeamManager: vi.fn(),
+  createFileEntry: vi.fn(),
+  createFolder: vi.fn(),
+  getWorkspaceCredentials: vi.fn(),
+  changeUserRole: vi.fn(),
+  getWorkspacePendingInvitations: vi.fn(),
+  getPersonalTrash: vi.fn(),
+  validateWorkspaceInvitation: vi.fn(),
+  getPendingInvites: vi.fn(),
+  emptyPersonalTrash: vi.fn(),
+  shareItem: vi.fn(),
+  getWorkspaceTeamSharedFoldersV2: vi.fn(),
+  getWorkspaceTeamSharedFilesV2: vi.fn(),
+  getWorkspaceTeamSharedFolderFoldersV2: vi.fn(),
+  getWorkspaceTeamSharedFolderFilesV2: vi.fn(),
+  getUsersAndTeamsAnItemIsShareWidth: vi.fn(),
+  getFolders: vi.fn(),
+  getFiles: vi.fn(),
+  deactivateMember: vi.fn(),
+  activateMember: vi.fn(),
+  removeMember: vi.fn(),
+  getMemberUsage: vi.fn(),
+  modifyMemberUsage: vi.fn(),
+  getWorkspace: vi.fn(),
+  getWorkspaceUsage: vi.fn(),
+  leaveWorkspace: vi.fn(),
+  getWorkspaceLogs: vi.fn(),
+};
+
+vi.mock('app/core/factory/sdk', () => ({
+  SdkFactory: {
+    getNewApiInstance: vi.fn(() => ({
+      createWorkspacesClient: vi.fn(() => mockWorkspacesClient),
+    })),
+  },
+}));
+
+vi.mock('./error.service', () => ({
+  default: {
+    castError: vi.fn((error) => error),
+  },
+}));
+
+const testErrorHandling = async (fn: () => Promise<any>, mockFn: any) => {
+  const mockError = new Error('Test error');
+  mockFn.mockRejectedValue(mockError);
+  await expect(fn()).rejects.toThrow();
+  expect(errorService.castError).toHaveBeenCalledWith(mockError);
+};
+
+describe('workspace service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('When retrieving workspace information', () => {
+    it.each([
+      {
+        name: 'all workspaces',
+        fn: 'getWorkspaces',
+        args: [],
+        mockData: { workspaces: [{ id: mockIds.workspaceId }] },
+      },
+      {
+        name: 'specific workspace',
+        fn: 'getWorkspace',
+        args: [mockIds.workspaceId],
+        mockData: { id: mockIds.workspaceId },
+      },
+    ])('should return $name', async ({ fn, args, mockData }) => {
+      mockWorkspacesClient[fn].mockResolvedValue(mockData);
+      const result = await workspaceService[fn](...args);
+      expect(result).toEqual(mockData);
+      expect(mockWorkspacesClient[fn]).toHaveBeenCalledWith(...args);
+    });
+
+    it('should handle errors when retrieving workspace fails', async () => {
+      await testErrorHandling(
+        () => workspaceService.getWorkspace(mockIds.workspaceId),
+        mockWorkspacesClient.getWorkspace,
+      );
+    });
+  });
+
+  describe('When managing workspace members', () => {
+    it.each([
+      {
+        name: 'workspace members',
+        fn: 'getWorkspacesMembers',
+        args: [mockIds.workspaceId],
+        mockData: { members: [{ id: mockIds.memberId }] },
+      },
+      {
+        name: 'member details',
+        fn: 'getMemberDetails',
+        args: [mockIds.workspaceId, mockIds.memberId],
+        mockData: { id: mockIds.memberId, email: 'test@example.com' },
+      },
+    ])('should return $name', async ({ fn, args, mockData }) => {
+      mockWorkspacesClient[fn].mockResolvedValue(mockData);
+      const result = await workspaceService[fn](...args);
+      expect(result).toEqual(mockData);
+      expect(mockWorkspacesClient[fn]).toHaveBeenCalledWith(...args);
+    });
+
+    it('should invite a user to the team', async () => {
+      const inviteBody = {
+        invitedUserEmail: 'user@example.com',
+        workspaceId: mockIds.workspaceId,
+        encryptedMnemonicInBase64: 'encrypted',
+        encryptionAlgorithm: 'aes-256-gcm',
+        message: 'Welcome',
+      };
+      mockWorkspacesClient.inviteMemberToWorkspace.mockResolvedValue(undefined);
+      await workspaceService.inviteUserToTeam(inviteBody);
+      expect(mockWorkspacesClient.inviteMemberToWorkspace).toHaveBeenCalledWith(inviteBody);
+    });
+
+    it.each([
+      { name: 'deactivate', clientFn: 'deactivateMember', serviceFn: 'deactivateMember' },
+      { name: 'reactivate', clientFn: 'activateMember', serviceFn: 'reactivateMember' },
+      { name: 'remove', clientFn: 'removeMember', serviceFn: 'removeMember' },
+    ])('should $name a member', async ({ clientFn, serviceFn }) => {
+      mockWorkspacesClient[clientFn].mockResolvedValue(undefined);
+      await workspaceService[serviceFn](mockIds.workspaceId, mockIds.memberId);
+      expect(mockWorkspacesClient[clientFn]).toHaveBeenCalledWith(mockIds.workspaceId, mockIds.memberId);
+    });
+
+    it('should handle errors when member action fails', async () => {
+      await testErrorHandling(
+        () => workspaceService.removeMember(mockIds.workspaceId, mockIds.memberId),
+        mockWorkspacesClient.removeMember,
+      );
+    });
+  });
+
+  describe('When handling workspace invitations', () => {
+    it.each([
+      { name: 'accept', fn: 'acceptWorkspaceInvite', clientFn: 'acceptInvitation' },
+      { name: 'decline', fn: 'declineWorkspaceInvite', clientFn: 'declineInvitation' },
+    ])('should $name an invitation', async ({ fn, clientFn }) => {
+      mockWorkspacesClient[clientFn].mockResolvedValue(undefined);
+      await workspaceService[fn]({ invitationId: mockIds.invitationId, token: mockIds.token });
+      expect(mockWorkspacesClient[clientFn]).toHaveBeenCalledWith(mockIds.invitationId, mockIds.token);
+    });
+
+    it.each([
+      { isDecline: false, expectedMethod: 'acceptInvitation' },
+      { isDecline: true, expectedMethod: 'declineInvitation' },
+    ])('should process invitation correctly when decline is $isDecline', async ({ isDecline, expectedMethod }) => {
+      mockWorkspacesClient[expectedMethod].mockResolvedValue(undefined);
+      await workspaceService.processInvitation(isDecline, mockIds.invitationId, mockIds.token);
+      expect(mockWorkspacesClient[expectedMethod]).toHaveBeenCalledWith(mockIds.invitationId, mockIds.token);
+    });
+
+    it.each([
+      {
+        name: 'workspace invitation',
+        fn: 'validateWorkspaceInvitation',
+        args: [mockIds.invitationId],
+        mockData: { uuid: mockIds.uuid },
+      },
+      {
+        name: 'pending invitations',
+        fn: 'getWorkspacePendingInvitations',
+        args: [mockIds.workspaceId, 10, 0],
+        mockData: [{ id: mockIds.invitationId }],
+      },
+      { name: 'all pending invites', fn: 'getPendingInvites', args: [], mockData: { invites: [] } },
+    ])('should retrieve $name', async ({ fn, args, mockData }) => {
+      mockWorkspacesClient[fn].mockResolvedValue(mockData);
+      const result = await workspaceService[fn](...args);
+      expect(result).toEqual(mockData);
+    });
+  });
+
+  describe('When managing workspace settings', () => {
+    it('should set up a new workspace', async () => {
+      const setupInfo = {
+        workspaceId: mockIds.workspaceId,
+        name: 'New Workspace',
+        description: 'Description',
+        address: '123 Main St',
+        encryptedMnemonic: 'encrypted',
+      };
+      mockWorkspacesClient.setupWorkspace.mockResolvedValue(undefined);
+      await workspaceService.setupWorkspace(setupInfo);
+      expect(mockWorkspacesClient.setupWorkspace).toHaveBeenCalledWith(setupInfo);
+    });
+
+    it('should edit workspace details', async () => {
+      const details = { name: 'Updated Name' };
+      mockWorkspacesClient.editWorkspace.mockResolvedValue(undefined);
+      await workspaceService.editWorkspace(mockIds.workspaceId, details);
+      expect(mockWorkspacesClient.editWorkspace).toHaveBeenCalledWith(mockIds.workspaceId, details);
+    });
+
+    it('should update workspace avatar', async () => {
+      const mockAvatar = new Blob(['avatar'], { type: 'image/png' });
+      const mockData = { avatar: 'avatar-url' };
+      mockWorkspacesClient.updateAvatar.mockResolvedValue(mockData);
+      const result = await workspaceService.updateWorkspaceAvatar(mockIds.workspaceId, mockAvatar);
+      expect(result).toEqual(mockData);
+      expect(mockWorkspacesClient.updateAvatar).toHaveBeenCalledWith(mockIds.workspaceId, { avatar: mockAvatar });
+    });
+
+    it.each([
+      { name: 'delete avatar', fn: 'deleteWorkspaceAvatar', clientFn: 'deleteAvatar' },
+      { name: 'leave workspace', fn: 'leaveWorkspace', clientFn: 'leaveWorkspace' },
+    ])('should $name', async ({ fn, clientFn }) => {
+      mockWorkspacesClient[clientFn].mockResolvedValue(undefined);
+      await workspaceService[fn](mockIds.workspaceId);
+      expect(mockWorkspacesClient[clientFn]).toHaveBeenCalledWith(mockIds.workspaceId);
+    });
+
+    it('should handle errors when deleting avatar fails', async () => {
+      await testErrorHandling(
+        () => workspaceService.deleteWorkspaceAvatar(mockIds.workspaceId),
+        mockWorkspacesClient.deleteAvatar,
+      );
+    });
+  });
+
+  describe('When managing teams', () => {
+    it.each([
+      { name: 'workspace teams', fn: 'getWorkspaceTeams', args: [mockIds.workspaceId], mockData: { teams: [] } },
+      { name: 'team members', fn: 'getTeamMembers', args: [mockIds.teamId], mockData: { members: [] } },
+    ])('should return $name', async ({ fn, args, mockData }) => {
+      mockWorkspacesClient[
+        fn === 'getWorkspaceTeams' ? 'getWorkspacesTeams' : 'getWorkspacesTeamMembers'
+      ].mockResolvedValue(mockData);
+      const result = await workspaceService[fn](...args);
+      expect(result).toEqual(mockData);
+    });
+
+    it('should create a new team', async () => {
+      const teamData = { workspaceId: mockIds.workspaceId, name: 'Team', managerId: mockIds.memberId };
+      mockWorkspacesClient.createTeam.mockResolvedValue(undefined);
+      await workspaceService.createTeam(teamData);
+      expect(mockWorkspacesClient.createTeam).toHaveBeenCalledWith(teamData);
+    });
+
+    it('should edit team name', async () => {
+      mockWorkspacesClient.editTeam.mockResolvedValue(undefined);
+      await workspaceService.editTeam(mockIds.teamId, 'New Name');
+      expect(mockWorkspacesClient.editTeam).toHaveBeenCalledWith({ teamId: mockIds.teamId, name: 'New Name' });
+    });
+
+    it('should delete a team', async () => {
+      mockWorkspacesClient.deleteTeam.mockResolvedValue(undefined);
+      await workspaceService.deleteTeam(mockIds.workspaceId, mockIds.teamId);
+      expect(mockWorkspacesClient.deleteTeam).toHaveBeenCalledWith({
+        workspaceId: mockIds.workspaceId,
+        teamId: mockIds.teamId,
+      });
+    });
+
+    it.each([
+      { name: 'add', fn: 'addTeamUser', service: 'addTeamUser' },
+      { name: 'remove', fn: 'removeTeamUser', service: 'removeTeamUser' },
+    ])('should $name a user to/from team', async ({ fn, service }) => {
+      mockWorkspacesClient[fn].mockResolvedValue(undefined);
+      await workspaceService[service](mockIds.teamId, mockIds.uuid);
+      expect(mockWorkspacesClient[fn]).toHaveBeenCalledWith(mockIds.teamId, mockIds.uuid);
+    });
+
+    it('should change team manager', async () => {
+      mockWorkspacesClient.changeTeamManager.mockResolvedValue(undefined);
+      await workspaceService.changeTeamManager(mockIds.workspaceId, mockIds.teamId, mockIds.memberId);
+      expect(mockWorkspacesClient.changeTeamManager).toHaveBeenCalledWith(
+        mockIds.workspaceId,
+        mockIds.teamId,
+        mockIds.memberId,
+      );
+    });
+
+    it('should change user role', async () => {
+      const roleData = { teamId: mockIds.teamId, memberId: mockIds.memberId, role: 'admin' };
+      mockWorkspacesClient.changeUserRole.mockResolvedValue(undefined);
+      await workspaceService.changeUserRole(roleData);
+      expect(mockWorkspacesClient.changeUserRole).toHaveBeenCalledWith(mockIds.teamId, mockIds.memberId, 'admin');
+    });
+  });
+
+  describe('When managing files and folders', () => {
+    it('should create a file entry', async () => {
+      const fileEntry = {
+        name: 'doc.pdf',
+        size: 1024,
+        bucket: 'bucket-123',
+        fileId: 'file-id',
+        encryptVersion: '03-aes',
+        folderUuid: 'folder-uuid',
+        type: 'pdf' as const,
+        plainName: 'doc.pdf',
+        modificationTime: '2023-01-01T00:00:00Z',
+        date: '2023-01-01T00:00:00Z',
+      };
+      const mockData = { id: 'file-123' };
+      mockWorkspacesClient.createFileEntry.mockResolvedValue(mockData);
+      const result = await workspaceService.createFileEntry(fileEntry, mockIds.workspaceId, 'token');
+      expect(result).toEqual(mockData);
+      expect(mockWorkspacesClient.createFileEntry).toHaveBeenCalledWith(fileEntry, mockIds.workspaceId, 'token');
+    });
+
+    it('should create a folder', () => {
+      const payload = { workspaceId: mockIds.workspaceId, plainName: 'Folder', parentFolderUuid: 'parent-uuid' };
+      const mockPromise = Promise.resolve({ id: 'folder-123' });
+      const mockCanceler = vi.fn();
+      mockWorkspacesClient.createFolder.mockReturnValue([mockPromise, mockCanceler]);
+      const [promise, canceler] = workspaceService.createFolder(payload);
+      expect(promise).toBe(mockPromise);
+      expect(canceler).toBe(mockCanceler);
+    });
+
+    it.each([
+      { type: 'folders', fn: 'getWorkspaceFolders', clientFn: 'getFolders' },
+      { type: 'files', fn: 'getWorkspaceFiles', clientFn: 'getFiles' },
+    ])('should retrieve workspace $type', ({ fn, clientFn }) => {
+      const mockPromise = Promise.resolve({ items: [] });
+      const mockCanceler = vi.fn();
+      mockWorkspacesClient[clientFn].mockReturnValue([mockPromise, mockCanceler]);
+      const [promise] = workspaceService[fn](mockIds.workspaceId, 'folder-id', 0, 50);
+      expect(promise).toBe(mockPromise);
+      expect(mockWorkspacesClient[clientFn]).toHaveBeenCalledWith(
+        mockIds.workspaceId,
+        'folder-id',
+        0,
+        50,
+        'plainName',
+        'ASC',
+      );
+    });
+  });
+
+  describe('When managing trash', () => {
+    it.each(['file', 'folder'] as const)('should retrieve trash items for %s', async (type) => {
+      const mockData = { items: [] };
+      mockWorkspacesClient.getPersonalTrash.mockResolvedValue(mockData);
+      const result = await workspaceService.getTrashItems(mockIds.workspaceId, type, 0);
+      expect(result).toEqual(mockData);
+      expect(mockWorkspacesClient.getPersonalTrash).toHaveBeenCalledWith(mockIds.workspaceId, type, 0);
+    });
+
+    it('should empty trash', async () => {
+      mockWorkspacesClient.emptyPersonalTrash.mockResolvedValue(undefined);
+      await workspaceService.emptyTrash(mockIds.workspaceId);
+      expect(mockWorkspacesClient.emptyPersonalTrash).toHaveBeenCalledWith(mockIds.workspaceId);
+    });
+
+    it('should handle errors when emptying trash fails', async () => {
+      await testErrorHandling(
+        () => workspaceService.emptyTrash(mockIds.workspaceId),
+        mockWorkspacesClient.emptyPersonalTrash,
+      );
+    });
+  });
+
+  describe('When managing shared items', () => {
+    it('should share an item with team', async () => {
+      const payload = {
+        workspaceId: mockIds.workspaceId,
+        itemType: 'folder' as const,
+        itemId: 'item-123',
+        teamUUID: mockIds.teamId,
+        roleId: 'role-123',
+        encryptedPassword: 'encrypted',
+      };
+      const mockData = { shareId: 'share-123' };
+      mockWorkspacesClient.shareItem.mockResolvedValue(mockData);
+      const result = await workspaceService.shareItemWithTeam(payload);
+      expect(result).toEqual(mockData);
+    });
+
+    it.each([
+      { type: 'folders', fn: 'getAllWorkspaceTeamSharedFolders', clientFn: 'getWorkspaceTeamSharedFoldersV2' },
+      { type: 'files', fn: 'getAllWorkspaceTeamSharedFiles', clientFn: 'getWorkspaceTeamSharedFilesV2' },
+    ])('should retrieve all shared $type', ({ fn, clientFn }) => {
+      const mockPromise = Promise.resolve({ items: [] });
+      const mockCanceler = vi.fn();
+      mockWorkspacesClient[clientFn].mockReturnValue([mockPromise, mockCanceler]);
+      const [promise] = workspaceService[fn](mockIds.workspaceId);
+      expect(promise).toBe(mockPromise);
+    });
+
+    it.each([
+      {
+        type: 'folders',
+        fn: 'getAllWorkspaceTeamSharedFolderFolders',
+        clientFn: 'getWorkspaceTeamSharedFolderFoldersV2',
+      },
+      { type: 'files', fn: 'getAllWorkspaceTeamSharedFolderFiles', clientFn: 'getWorkspaceTeamSharedFolderFilesV2' },
+    ])('should retrieve $type within shared folder', ({ fn, clientFn }) => {
+      const mockPromise = Promise.resolve({ items: [] });
+      const mockCanceler = vi.fn();
+      mockWorkspacesClient[clientFn].mockReturnValue([mockPromise, mockCanceler]);
+      const [promise] = workspaceService[fn](mockIds.workspaceId, 'shared-uuid', 1, 50);
+      expect(promise).toBe(mockPromise);
+    });
+
+    it('should retrieve users and teams an item is shared with', () => {
+      const mockPromise = Promise.resolve({ users: [], teams: [] });
+      const mockCanceler = vi.fn();
+      mockWorkspacesClient.getUsersAndTeamsAnItemIsShareWidth.mockReturnValue([mockPromise, mockCanceler]);
+      const [promise] = workspaceService.getUsersAndTeamsAnItemIsShareWidth({
+        workspaceId: mockIds.workspaceId,
+        itemType: 'folder',
+        itemId: 'item-123',
+      });
+      expect(promise).toBe(mockPromise);
+    });
+  });
+
+  describe('When managing workspace credentials and usage', () => {
+    it.each([
+      {
+        name: 'workspace credentials',
+        fn: 'getWorkspaceCredentials',
+        clientFn: 'getWorkspaceCredentials',
+        args: [mockIds.workspaceId],
+        mockData: { publicKey: 'key-123' },
+      },
+      {
+        name: 'member usage',
+        fn: 'getUsage',
+        clientFn: 'getMemberUsage',
+        args: [mockIds.workspaceId],
+        mockData: { used: 1024, total: 5120 },
+      },
+      {
+        name: 'workspace usage',
+        fn: 'getWorkspaceUsage',
+        clientFn: 'getWorkspaceUsage',
+        args: [mockIds.workspaceId],
+        mockData: { totalWorkspaceSpace: 10240, spaceAssigned: 5120, spaceUsed: 2048 },
+      },
+    ])('should retrieve $name', async ({ fn, clientFn, args, mockData }) => {
+      mockWorkspacesClient[clientFn].mockResolvedValue(mockData);
+      const result = await workspaceService[fn](...args);
+      expect(result).toEqual(mockData);
+    });
+
+    it('should modify member usage limit', async () => {
+      const mockData = { id: mockIds.memberId, spaceLimit: 10240 };
+      mockWorkspacesClient.modifyMemberUsage.mockResolvedValue(mockData);
+      const result = await workspaceService.modifyMemberUsage(mockIds.workspaceId, mockIds.memberId, 10240);
+      expect(result).toEqual(mockData);
+    });
+
+    it('should handle errors when retrieving workspace usage fails', async () => {
+      await testErrorHandling(
+        () => workspaceService.getWorkspaceUsage(mockIds.workspaceId),
+        mockWorkspacesClient.getWorkspaceUsage,
+      );
+    });
+  });
+
+  describe('When retrieving workspace logs', () => {
+    it.each([
+      {
+        name: 'default parameters',
+        params: { workspaceId: mockIds.workspaceId, limit: 50 },
+        expectedCall: [mockIds.workspaceId, 50, 0, undefined, undefined, undefined, undefined, 'createdAt:DESC'],
+      },
+      {
+        name: 'custom filters',
+        params: {
+          workspaceId: mockIds.workspaceId,
+          limit: 100,
+          offset: 10,
+          member: mockIds.memberId,
+          activity: [WorkspaceLogType.ShareFile, WorkspaceLogType.ShareFolder],
+          lastDays: 7,
+          summary: true,
+          orderBy: 'createdAt:ASC',
+        },
+        expectedCall: [
+          mockIds.workspaceId,
+          100,
+          10,
+          mockIds.memberId,
+          [WorkspaceLogType.ShareFile, WorkspaceLogType.ShareFolder],
+          7,
+          true,
+          'createdAt:ASC',
+        ],
+      },
+    ])('should retrieve workspace activity logs with $name', async ({ params, expectedCall }) => {
+      const mockData = [{ id: 'log-1' }];
+      mockWorkspacesClient.getWorkspaceLogs.mockResolvedValue(mockData);
+      const result = await workspaceService.getWorkspaceLogs(params);
+      expect(result).toEqual(mockData);
+      expect(mockWorkspacesClient.getWorkspaceLogs).toHaveBeenCalledWith(...expectedCall);
+    });
+
+    it('should handle errors when retrieving logs fails', async () => {
+      await testErrorHandling(
+        () => workspaceService.getWorkspaceLogs({ workspaceId: mockIds.workspaceId, limit: 50 }),
+        mockWorkspacesClient.getWorkspaceLogs,
+      );
+    });
+  });
+
+  describe('When validating the default export', () => {
+    it('should export all required functions', () => {
+      [
+        'getWorkspaces',
+        'getWorkspacesMembers',
+        'getWorkspaceTeams',
+        'inviteUserToTeam',
+        'createTeam',
+        'shareItemWithTeam',
+        'getWorkspace',
+        'leaveWorkspace',
+      ].forEach((fn) => {
+        expect(workspacesService[fn]).toBeDefined();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

Add Vitest suites for the shared error and socket services to validate error reporting, websocket lifecycle, and event handling expected after the common-module restructure.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Main PR](https://github.com/internxt/drive-web/pull/1739)
-->

## Checklist

- [ ] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
