### PR TITLE
[_]: feature/Add meet preview domain to postMessage authentication

### DIFF
--- a/src/app/auth/services/oauth.service.ts
+++ b/src/app/auth/services/oauth.service.ts
@@ -29,7 +29,7 @@ const isAllowedOrigin = (origin: string): boolean => {
     ) {
       return true;
     }
-  } catch (e) {
+  } catch {
     return false;
   }
 

--- a/src/app/auth/services/oauth.service.ts
+++ b/src/app/auth/services/oauth.service.ts
@@ -12,6 +12,31 @@ import envService from 'app/core/services/env.service';
 const ALLOWED_TARGET_ORIGINS = ['https://meet.internxt.com'];
 
 /**
+ * Checks if an origin matches allowed domains
+ * @param {string} origin - The origin to check
+ * @returns {boolean} True if the origin is allowed
+ */
+const isAllowedOrigin = (origin: string): boolean => {
+  if (ALLOWED_TARGET_ORIGINS.includes(origin)) {
+    return true;
+  }
+
+  try {
+    const url = new URL(origin);
+    if (
+      url.protocol === 'https:' &&
+      (url.hostname === 'meet-web.pages.dev' || url.hostname.endsWith('.meet-web.pages.dev'))
+    ) {
+      return true;
+    }
+  } catch (e) {
+    return false;
+  }
+
+  return false;
+};
+
+/**
  * Message types for postMessage communication
  */
 export enum OAuthMessageType {
@@ -56,7 +81,7 @@ const getTargetOrigin = (): string | null => {
   try {
     const openerOrigin = window.opener.location.origin;
 
-    if (ALLOWED_TARGET_ORIGINS.includes(openerOrigin)) {
+    if (isAllowedOrigin(openerOrigin)) {
       return openerOrigin;
     }
 
@@ -68,7 +93,7 @@ const getTargetOrigin = (): string | null => {
     if (referrer) {
       try {
         const referrerOrigin = new URL(referrer).origin;
-        if (ALLOWED_TARGET_ORIGINS.includes(referrerOrigin)) {
+        if (isAllowedOrigin(referrerOrigin)) {
           return referrerOrigin;
         }
       } catch (e) {


### PR DESCRIPTION
## Description

- Added  Meet preview origin validation for allowed domains in OAuth service and tests

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

- Check that could login from meet preview domain

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
