### PR TITLE
[PB-5313]: feature/pass the user address when creating an invoice

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@iconscout/react-unicons": "^1.1.6",
     "@internxt/css-config": "1.0.3",
     "@internxt/lib": "1.4.1",
-    "@internxt/sdk": "=1.11.16",
+    "@internxt/sdk": "=1.11.17",
     "@internxt/ui": "0.0.26",
     "@phosphor-icons/react": "^2.1.7",
     "@popperjs/core": "^2.11.6",

--- a/src/app/payment/hooks/useUserPayment.test.ts
+++ b/src/app/payment/hooks/useUserPayment.test.ts
@@ -8,6 +8,7 @@ import navigationService from '../../core/services/navigation.service';
 import { AppView } from '../../core/types';
 import { PaymentType, ProcessPurchasePayload, UseUserPaymentPayload } from '../types';
 import notificationsService from '../../notifications/services/notifications.service';
+import { CreateSubscriptionPayload } from '@internxt/sdk/dist/payments/types';
 
 const mockHostname = 'https://hostname.com';
 
@@ -36,14 +37,14 @@ describe('Custom hook to handle payments', () => {
 
       const { getSubscriptionPaymentIntent } = useUserPayment();
 
-      const subscriptionPaymentIntentPayload = {
+      const subscriptionPaymentIntentPayload: CreateSubscriptionPayload = {
         customerId: 'customer_id',
         priceId: 'price_id',
         token: 'token',
         currency: 'eur',
         captchaToken: 'captcha_token',
         promoCodeId: 'promo_code_id',
-        seatsForBusinessSubscription: 1,
+        quantity: 1,
       };
 
       const response = await getSubscriptionPaymentIntent(subscriptionPaymentIntentPayload);
@@ -55,7 +56,7 @@ describe('Custom hook to handle payments', () => {
         currency: subscriptionPaymentIntentPayload.currency,
         promoCodeId: subscriptionPaymentIntentPayload.promoCodeId,
         captchaToken: subscriptionPaymentIntentPayload.captchaToken,
-        quantity: subscriptionPaymentIntentPayload.seatsForBusinessSubscription,
+        quantity: subscriptionPaymentIntentPayload.quantity,
       });
       expect(response).toStrictEqual({
         type: 'payment',
@@ -83,6 +84,7 @@ describe('Custom hook to handle payments', () => {
         token: 'token',
         promoCodeId: 'promo_code_id',
         captchaToken: 'captcha_token',
+        userAddress: '1.1.1.1',
       };
 
       const response = await getLifetimePaymentIntent(lifetimePaymentIntentPayload);
@@ -106,6 +108,7 @@ describe('Custom hook to handle payments', () => {
         token: 'encoded-customer-id',
         promoCodeId: 'promo_code_id',
         captchaToken: 'captcha_token',
+        userAddress: '1.1.1.1',
       };
       const paymentIntentResponse = {
         type: PaymentType['CRYPTO'] as const,
@@ -169,6 +172,7 @@ describe('Custom hook to handle payments', () => {
           },
         } as any,
         captchaToken: 'captcha_token',
+        userAddress: '1.1.1.1',
         confirmPayment,
         confirmSetupIntent: setupIntent,
         translate: translate,
@@ -226,6 +230,7 @@ describe('Custom hook to handle payments', () => {
           },
         } as any,
         captchaToken: 'captcha_token',
+        userAddress: '1.1.1.1',
         confirmPayment,
         confirmSetupIntent: setupIntent,
         translate: translate,
@@ -284,6 +289,7 @@ describe('Custom hook to handle payments', () => {
           },
         } as any,
         captchaToken: 'captcha_token',
+        userAddress: '1.1.1.1',
         confirmPayment,
         confirmSetupIntent: setupIntent,
         translate: translate,
@@ -446,6 +452,7 @@ describe('Custom hook to handle payments', () => {
           },
         } as any,
         captchaToken: 'captcha_token',
+        userAddress: '1.1.1.1',
         confirmPayment,
         confirmSetupIntent: setupIntent,
         gclidStored: null,
@@ -493,6 +500,7 @@ describe('Custom hook to handle payments', () => {
           },
         } as any,
         captchaToken: 'captcha_token',
+        userAddress: '1.1.1.1',
         confirmPayment,
         confirmSetupIntent: setupIntent,
         gclidStored: null,
@@ -536,6 +544,7 @@ describe('Custom hook to handle payments', () => {
           },
         } as any,
         captchaToken: 'captcha_token',
+        userAddress: '1.1.1.1',
         confirmPayment,
         confirmSetupIntent: setupIntent,
         gclidStored: null,

--- a/src/app/payment/hooks/useUserPayment.ts
+++ b/src/app/payment/hooks/useUserPayment.ts
@@ -16,6 +16,7 @@ import {
 } from '../types';
 import { ActionDialog } from 'app/contexts/dialog-manager/ActionDialogManager.context';
 import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
+import { CreateSubscriptionPayload } from '@internxt/sdk/dist/payments/types';
 
 export const useUserPayment = () => {
   const getSubscriptionPaymentIntent = async ({
@@ -23,10 +24,10 @@ export const useUserPayment = () => {
     priceId,
     token,
     currency,
-    seatsForBusinessSubscription,
+    quantity,
     captchaToken,
     promoCodeId,
-  }: CreatePaymentIntentPayload) => {
+  }: CreateSubscriptionPayload) => {
     const {
       type: paymentType,
       clientSecret: client_secret,
@@ -39,7 +40,7 @@ export const useUserPayment = () => {
       currency,
       captchaToken,
       promoCodeId,
-      quantity: seatsForBusinessSubscription,
+      quantity,
     });
 
     return {
@@ -55,6 +56,7 @@ export const useUserPayment = () => {
     priceId,
     currency,
     token,
+    userAddress,
     captchaToken,
     promoCodeId,
   }: CreatePaymentIntentPayload) => {
@@ -62,6 +64,7 @@ export const useUserPayment = () => {
       customerId,
       priceId,
       currency,
+      userAddress,
       token,
       captchaToken,
       promoCodeId: promoCodeId,
@@ -142,7 +145,7 @@ export const useUserPayment = () => {
       customerId,
       priceId,
       token,
-      seatsForBusinessSubscription,
+      quantity: seatsForBusinessSubscription,
       captchaToken,
       promoCodeId: couponCodeData?.codeId,
       currency,
@@ -183,6 +186,7 @@ export const useUserPayment = () => {
     couponCodeData,
     elements,
     captchaToken,
+    userAddress,
     confirmPayment,
     openCryptoPaymentDialog,
   }: ProcessPurchasePayload) => {
@@ -199,6 +203,7 @@ export const useUserPayment = () => {
       token,
       captchaToken,
       promoCodeId: couponCodeData?.codeId,
+      userAddress,
       currency,
     });
 
@@ -245,6 +250,7 @@ export const useUserPayment = () => {
     gclidStored,
     seatsForBusinessSubscription = 1,
     captchaToken,
+    userAddress,
     translate,
     confirmPayment,
     openCryptoPaymentDialog,
@@ -277,6 +283,7 @@ export const useUserPayment = () => {
           couponCodeData,
           seatsForBusinessSubscription,
           captchaToken,
+          userAddress,
           translate,
           confirmPayment,
           confirmSetupIntent,
@@ -293,6 +300,7 @@ export const useUserPayment = () => {
           token,
           couponCodeData,
           captchaToken,
+          userAddress,
           translate,
           confirmPayment,
           openCryptoPaymentDialog,

--- a/src/app/payment/services/checkout.service.test.ts
+++ b/src/app/payment/services/checkout.service.test.ts
@@ -189,6 +189,7 @@ describe('Checkout Service tests', () => {
         token: 'user_mocked_token',
         currency: 'eur',
         captchaToken: 'captcha_token',
+        userAddress: '1.1.1.1',
       };
 
       const createInvoiceResponse = await checkoutService.createPaymentIntent(createInvoicePayload);
@@ -208,6 +209,7 @@ describe('Checkout Service tests', () => {
         currency: 'eur',
         promoCodeId: 'promo_code_name',
         captchaToken: 'captcha_token',
+        userAddress: '1.1.1.1',
       };
 
       const createInvoiceResponse = await checkoutService.createPaymentIntent(createInvoicePayload);

--- a/src/app/payment/services/checkout.service.ts
+++ b/src/app/payment/services/checkout.service.ts
@@ -109,6 +109,7 @@ export const createPaymentIntent = async ({
   token,
   currency,
   captchaToken,
+  userAddress,
   promoCodeId,
 }: CreatePaymentIntentPayload): Promise<PaymentIntent> => {
   const checkoutClient = await SdkFactory.getNewApiInstance().createCheckoutClient();
@@ -118,6 +119,7 @@ export const createPaymentIntent = async ({
     token,
     currency,
     captchaToken,
+    userAddress,
     promoCodeId,
   });
 };

--- a/src/app/payment/types.ts
+++ b/src/app/payment/types.ts
@@ -120,6 +120,7 @@ export interface CreatePaymentIntentPayload {
   token: string;
   currency: string;
   captchaToken: string;
+  userAddress: string;
   seatsForBusinessSubscription?: number;
   promoCodeId?: string;
 }
@@ -131,6 +132,7 @@ export interface ProcessPurchasePayload {
   currency: string;
   elements: StripeElements;
   captchaToken: string;
+  userAddress: string;
   confirmPayment: Stripe['confirmPayment'];
   confirmSetupIntent: Stripe['confirmSetup'];
   openCryptoPaymentDialog?: (key: ActionDialog, config?: DialogActionConfig) => void;
@@ -147,6 +149,7 @@ export interface UseUserPaymentPayload {
   currency: string;
   selectedPlan: PriceWithTax;
   elements: StripeElements;
+  userAddress: string;
   confirmPayment: Stripe['confirmPayment'];
   confirmSetupIntent: Stripe['confirmSetup'];
   openCryptoPaymentDialog?: (key: ActionDialog, config?: DialogActionConfig) => void;

--- a/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
+++ b/src/app/payment/views/IntegratedCheckoutView/CheckoutViewWrapper.tsx
@@ -509,6 +509,7 @@ const CheckoutViewWrapper = () => {
           captchaToken: intentCaptcha,
           seatsForBusinessSubscription,
           openCryptoPaymentDialog,
+          userAddress: userLocationData?.ip as string,
         });
       }
     } catch (err) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1907,10 +1907,10 @@
   version "1.0.2"
   resolved "https://codeload.github.com/internxt/prettier-config/tar.gz/9fa74e9a2805e1538b50c3809324f1c9d0f3e4f9"
 
-"@internxt/sdk@=1.11.16":
-  version "1.11.16"
-  resolved "https://registry.yarnpkg.com/@internxt/sdk/-/sdk-1.11.16.tgz#66a8908310a88838a5458497955f5167c72b345e"
-  integrity sha512-l2Vk62fLNKOA4mRcq0x9FSvetDQ/L4iyqr9paQOnTZI4Rlp66QFWhU/21a00Whl19ni+1/D/tp1aA5CHZWTa5Q==
+"@internxt/sdk@=1.11.17":
+  version "1.11.17"
+  resolved "https://registry.yarnpkg.com/@internxt/sdk/-/sdk-1.11.17.tgz#2f5bdada5d3cbf5cfc685a21c24b5df3ff51d8c8"
+  integrity sha512-91iEUvZizlwX6KBEFJ3JdFiGrhMBQ9R54sTc3Pei9QtV2FYTU8nTVEPYAg39tLOGzT/kVuplYOtBxfk6wFtSDA==
   dependencies:
     axios "1.13.2"
     uuid "11.1.0"


### PR DESCRIPTION
## Description

Pass the user's address when creating a new invoice for a one-time (lifetime) plan purchase.


## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [ ] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
