### PR TITLE
[_] feature/Add 'authOrigin' to preserved URL parameters

### DIFF
--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -96,7 +96,7 @@ const getCurrentUrlParams = (): Record<string, string> => {
   const currentParams = new URLSearchParams(window.location.search);
   const preservedParams: Record<string, string> = {};
 
-  const safeParams = ['universalLink', 'folderuuid', 'redirectUri'];
+  const safeParams = ['universalLink', 'folderuuid', 'redirectUri', 'authOrigin'];
 
   currentParams.forEach((value, key) => {
     if (safeParams.includes(key)) {


### PR DESCRIPTION
## Description

- Add 'authOrigin' to preserved URL parameters

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

- Verify that the Meet login retains the OAuth parameters when the user does not enter the password correctly

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
