### PR TITLE
[MKT-664]:feat/Meta Pixel Implementation for Lead and Purchase

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,17 +109,6 @@
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
       })(window, document, 'script', 'dataLayer', '%REACT_APP_GOOGLE_TAG_MANAGER%');
-      
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : '';
-        j.async = true;
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-        f.parentNode.insertBefore(j, f);
-       })(window, document, 'script', 'dataLayer', '%REACT_APP_GOOGLE_TAG_MANAGER_2"%');
     </script>
     <!-- End Google Tag Manager -->
 
@@ -1699,14 +1688,6 @@
     <noscript
       ><iframe
         src="https://www.googletagmanager.com/ns.html?id=%REACT_APP_GOOGLE_TAG_MANAGER%"
-        height="0"
-        width="0"
-        style="display: none; visibility: hidden"
-      ></iframe
-    ></noscript>
-    <noscript
-      ><iframe
-        src="https://www.googletagmanager.com/ns.html?id=%REACT_APP_GOOGLE_TAG_MANAGER_2%"
         height="0"
         width="0"
         style="display: none; visibility: hidden"

--- a/src/app/analytics/meta.service.test.ts
+++ b/src/app/analytics/meta.service.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { trackLead, trackPurchase } from './meta.service';
+import localStorageService from 'app/core/services/local-storage.service';
+
+vi.mock('app/core/services/local-storage.service', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+describe('Meta Tracking Service', () => {
+  let mockDataLayer: any[];
+  let mockFbq: vi.Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockDataLayer = [];
+    mockFbq = vi.fn();
+
+    Object.defineProperty(window, 'dataLayer', {
+      value: mockDataLayer,
+      writable: true,
+      configurable: true,
+    });
+
+    Object.defineProperty(window, 'fbq', {
+      value: mockFbq,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  describe('trackLead', () => {
+    it('When valid data is provided, then lead event is pushed to dataLayer', () => {
+      const email = 'test@example.com';
+      const userID = 'user123';
+
+      trackLead(email, userID);
+
+      expect(mockDataLayer).toHaveLength(1);
+      expect(mockDataLayer[0]).toMatchObject({
+        event: 'leadSuccessful',
+        eventCategory: 'User',
+        eventAction: 'registration_complete',
+        userEmail: email,
+        userID: userID,
+      });
+    });
+
+    it('When dataLayer is not available, then no event is pushed', () => {
+      Object.defineProperty(window, 'dataLayer', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      const initialLength = mockDataLayer.length;
+      trackLead('test@example.com', 'user123');
+
+      expect(mockDataLayer).toHaveLength(initialLength);
+    });
+
+    it('When fbq is not available, then no event is pushed', () => {
+      Object.defineProperty(window, 'fbq', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      const initialLength = mockDataLayer.length;
+      trackLead('test@example.com', 'user123');
+
+      expect(mockDataLayer).toHaveLength(initialLength);
+    });
+  });
+
+  describe('trackPurchase', () => {
+    beforeEach(() => {
+      vi.mocked(localStorageService.get).mockImplementation((key) => {
+        if (key === 'amountPaid') return '99.99';
+        if (key === 'currency') return 'USD';
+        return null;
+      });
+    });
+
+    it('When valid data is provided, then purchase event is pushed to dataLayer', () => {
+      const email = 'buyer@example.com';
+      const userID = 'user456';
+
+      trackPurchase(email, userID);
+
+      expect(localStorageService.get).toHaveBeenCalledWith('amountPaid');
+      expect(localStorageService.get).toHaveBeenCalledWith('currency');
+      expect(mockDataLayer).toHaveLength(1);
+      expect(mockDataLayer[0]).toMatchObject({
+        event: 'purchaseSuccessful',
+        ecommerce: {
+          value: 99.99,
+          currency: 'USD',
+        },
+        userEmail: email,
+        userID: userID,
+      });
+    });
+
+    it('When dataLayer is not available, then no event is pushed', () => {
+      Object.defineProperty(window, 'dataLayer', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      trackPurchase('test@example.com', 'user123');
+
+      expect(localStorageService.get).not.toHaveBeenCalled();
+    });
+
+    it('When fbq is not available, then no event is pushed', () => {
+      Object.defineProperty(window, 'fbq', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      trackPurchase('test@example.com', 'user123');
+
+      expect(localStorageService.get).not.toHaveBeenCalled();
+    });
+
+    it('When amountPaid is not available, then no event is pushed', () => {
+      vi.mocked(localStorageService.get).mockImplementation((key) => {
+        if (key === 'amountPaid') return null;
+        if (key === 'currency') return 'USD';
+        return null;
+      });
+
+      trackPurchase('test@example.com', 'user123');
+
+      expect(mockDataLayer).toHaveLength(0);
+    });
+
+    it('When currency is not available, then no event is pushed', () => {
+      vi.mocked(localStorageService.get).mockImplementation((key) => {
+        if (key === 'amountPaid') return '99.99';
+        if (key === 'currency') return null;
+        return null;
+      });
+
+      trackPurchase('test@example.com', 'user123');
+
+      expect(mockDataLayer).toHaveLength(0);
+    });
+
+    it('When both amountPaid and currency are not available, then no event is pushed', () => {
+      vi.mocked(localStorageService.get).mockReturnValue(null);
+
+      trackPurchase('test@example.com', 'user123');
+
+      expect(mockDataLayer).toHaveLength(0);
+    });
+
+    it('When amountPaid is a string, then it is correctly parsed as float', () => {
+      vi.mocked(localStorageService.get).mockImplementation((key) => {
+        if (key === 'amountPaid') return '123.45';
+        if (key === 'currency') return 'EUR';
+        return null;
+      });
+
+      trackPurchase('test@example.com', 'user123');
+
+      expect(mockDataLayer[0].ecommerce.value).toBe(123.45);
+      expect(typeof mockDataLayer[0].ecommerce.value).toBe('number');
+    });
+  });
+});

--- a/src/app/analytics/meta.service.test.ts
+++ b/src/app/analytics/meta.service.test.ts
@@ -2,12 +2,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { trackLead, trackPurchase } from './meta.service';
 import localStorageService from 'app/core/services/local-storage.service';
 
-vi.mock('app/core/services/local-storage.service', () => ({
-  default: {
-    get: vi.fn(),
-  },
-}));
-
 describe('Meta Tracking Service', () => {
   let mockDataLayer: any[];
   let mockFbq: vi.Mock;
@@ -77,7 +71,7 @@ describe('Meta Tracking Service', () => {
 
   describe('trackPurchase', () => {
     beforeEach(() => {
-      vi.mocked(localStorageService.get).mockImplementation((key) => {
+      vi.spyOn(localStorageService, 'get').mockImplementation((key) => {
         if (key === 'amountPaid') return '99.99';
         if (key === 'currency') return 'USD';
         return null;
@@ -129,7 +123,7 @@ describe('Meta Tracking Service', () => {
     });
 
     it('When amountPaid is not available, then no event is pushed', () => {
-      vi.mocked(localStorageService.get).mockImplementation((key) => {
+      vi.spyOn(localStorageService, 'get').mockImplementation((key) => {
         if (key === 'amountPaid') return null;
         if (key === 'currency') return 'USD';
         return null;
@@ -141,7 +135,7 @@ describe('Meta Tracking Service', () => {
     });
 
     it('When currency is not available, then no event is pushed', () => {
-      vi.mocked(localStorageService.get).mockImplementation((key) => {
+      vi.spyOn(localStorageService, 'get').mockImplementation((key) => {
         if (key === 'amountPaid') return '99.99';
         if (key === 'currency') return null;
         return null;
@@ -153,7 +147,7 @@ describe('Meta Tracking Service', () => {
     });
 
     it('When both amountPaid and currency are not available, then no event is pushed', () => {
-      vi.mocked(localStorageService.get).mockReturnValue(null);
+      vi.spyOn(localStorageService, 'get').mockReturnValue(null);
 
       trackPurchase('test@example.com', 'user123');
 
@@ -161,7 +155,7 @@ describe('Meta Tracking Service', () => {
     });
 
     it('When amountPaid is a string, then it is correctly parsed as float', () => {
-      vi.mocked(localStorageService.get).mockImplementation((key) => {
+      vi.spyOn(localStorageService, 'get').mockImplementation((key) => {
         if (key === 'amountPaid') return '123.45';
         if (key === 'currency') return 'EUR';
         return null;

--- a/src/app/analytics/meta.service.ts
+++ b/src/app/analytics/meta.service.ts
@@ -1,7 +1,7 @@
 import localStorageService from 'app/core/services/local-storage.service';
 
 const canTrack = () => {
-  return typeof globalThis.window !== 'undefined' && (window as any).dataLayer && (window as any).fbq;
+  return typeof globalThis !== 'undefined' && (globalThis as any).dataLayer && (globalThis as any).fbq;
 };
 
 export const trackLead = (email: string, userID: string) => {

--- a/src/app/analytics/meta.service.ts
+++ b/src/app/analytics/meta.service.ts
@@ -1,0 +1,44 @@
+import localStorageService from 'app/core/services/local-storage.service';
+
+const canTrack = () => {
+  return typeof window !== 'undefined' && (window as any).dataLayer && (window as any).fbq;
+};
+
+export const trackLead = (email: string, userID: string) => {
+  if (!canTrack()) {
+    return;
+  }
+
+  (window as any).dataLayer.push({
+    event: 'leadSuccessful',
+    eventCategory: 'User',
+    eventAction: 'registration_complete',
+    userEmail: email,
+    userID: userID,
+  });
+};
+
+export const trackPurchase = (email: string, userID: string) => {
+  if (!canTrack()) return;
+
+  const amountPaid = localStorageService.get('amountPaid');
+  const currency = localStorageService.get('currency');
+
+  if (!amountPaid || !currency) {
+    return;
+  }
+
+  const value = parseFloat(amountPaid);
+
+  (window as any).dataLayer.push({
+    event: 'purchaseSuccessful',
+
+    ecommerce: {
+      value: value,
+      currency: currency,
+    },
+
+    userEmail: email,
+    userID: userID,
+  });
+};

--- a/src/app/analytics/meta.service.ts
+++ b/src/app/analytics/meta.service.ts
@@ -1,7 +1,7 @@
 import localStorageService from 'app/core/services/local-storage.service';
 
 const canTrack = () => {
-  return typeof window !== 'undefined' && (window as any).dataLayer && (window as any).fbq;
+  return typeof globalThis.window !== 'undefined' && (window as any).dataLayer && (window as any).fbq;
 };
 
 export const trackLead = (email: string, userID: string) => {
@@ -9,7 +9,7 @@ export const trackLead = (email: string, userID: string) => {
     return;
   }
 
-  (window as any).dataLayer.push({
+  globalThis.window.dataLayer.push({
     event: 'leadSuccessful',
     eventCategory: 'User',
     eventAction: 'registration_complete',
@@ -28,9 +28,9 @@ export const trackPurchase = (email: string, userID: string) => {
     return;
   }
 
-  const value = parseFloat(amountPaid);
+  const value = Number.parseFloat(amountPaid);
 
-  (window as any).dataLayer.push({
+  globalThis.window.dataLayer.push({
     event: 'purchaseSuccessful',
 
     ecommerce: {

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -29,6 +29,8 @@ interface Window {
   _adftrack: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   rdt: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fbq: any;
   grecaptcha: {
     ready: (cb: () => void) => void;
     execute: (siteKey: string, { action: string }) => Promise<string>;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -12,6 +12,7 @@ import { ChangePasswordPayloadNew } from '@internxt/sdk/dist/drive/users/types';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import * as Sentry from '@sentry/react';
 import { trackSignUp } from 'app/analytics/impact.service';
+import { trackLead } from 'app/analytics/meta.service';
 import { getCookie, setCookie } from 'app/analytics/utils';
 import localStorageService from 'app/core/services/local-storage.service';
 import navigationService from 'app/core/services/navigation.service';
@@ -591,6 +592,7 @@ export const signUp = async (params: SignUpParams) => {
   if (!redeemCodeObject) dispatch(planThunks.initializeThunk());
   dispatch(referralsThunks.initializeThunk());
   await trackSignUp(xUser.uuid);
+  trackLead(xUser.email, xUser.userId);
 
   return { token: xToken, user: xUser, mnemonic, newToken: xNewToken };
 };

--- a/src/views/Checkout/views/CheckoutSuccessView.tsx
+++ b/src/views/Checkout/views/CheckoutSuccessView.tsx
@@ -8,6 +8,7 @@ import { useCallback } from 'react';
 import localStorageService from 'app/core/services/local-storage.service';
 import { workspaceThunks } from 'app/store/slices/workspaces/workspacesStore';
 import { trackPaymentConversion } from 'app/analytics/impact.service';
+import { trackPurchase } from 'app/analytics/meta.service';
 
 export function removePaymentsStorage() {
   localStorageService.removeItem('subscriptionId');
@@ -33,6 +34,7 @@ const CheckoutSuccessView = (): JSX.Element => {
     }, 3000);
 
     try {
+      trackPurchase();
       await trackPaymentConversion();
       removePaymentsStorage();
     } catch (err) {


### PR DESCRIPTION
## Description
This PR implements Meta Ads tracking microstrategy to capture key business conversions with the highest possible data quality.

MetaPixelService is introduced to centralize tracking logic, and ensure all events send high-quality user parameters necessary.

Functionality implemented:
- Lead Event: Fires upon successful user registration.
- Purchase Event: Fires upon successful payment confirmation.

Also we removed one GTM container that we are not longer using

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process
Following the environment setup and ensuring all necessary configurations were complete in GTM, we proceeded to use GTM’s native Preview Mode for validation. We confirmed that the custom-built tags fire as intended: the Lead tag fires correctly upon user registration, and the Purchase tag fires successfully after a completed sale. Furthermore, both tags accurately receive all the necessary enriched values and parameters. We can therefore confirm the implementation is fully functional. Should visual proof be required, please let me know.


## Additional Notes

I will also test using the specific Preview URL  from this PR to ensure all environment variables are correctly being picked up by the application.

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
