### PR TITLE
[BR-1606]: fix/integrated checkout price when applying coupon code

### DIFF
--- a/src/views/Checkout/hooks/useCheckout.test.ts
+++ b/src/views/Checkout/hooks/useCheckout.test.ts
@@ -39,10 +39,9 @@ describe('useCheckout hook actions', () => {
     });
   });
 
-  it('When onRemoveAppliedCouponCode is called, then it dispatches SET_COUPON_CODE_DATA and SET_PROMO_CODE_NAME with undefined', () => {
+  it('When onRemoveAppliedCouponCode is called, then it dispatches SET_COUPON_CODE_DATA with undefined', () => {
     onRemoveAppliedCouponCode();
     expect(dispatch).toHaveBeenNthCalledWith(1, { type: 'SET_COUPON_CODE_DATA', payload: undefined });
-    expect(dispatch).toHaveBeenNthCalledWith(2, { type: 'SET_PROMO_CODE_NAME', payload: undefined });
   });
 
   it('When setAvatarBlob is called, then it dispatches SET_AVATAR_BLOB with the provided Blob or null', () => {

--- a/src/views/Checkout/hooks/useCheckout.ts
+++ b/src/views/Checkout/hooks/useCheckout.ts
@@ -6,11 +6,8 @@ import { DisplayPrice } from '@internxt/sdk/dist/drive/payments/types/types';
 import { PriceWithTax } from '@internxt/sdk/dist/payments/types';
 
 export const useCheckout = (dispatchReducer: Dispatch<Action>) => {
-  const setCouponCodeName = (coupon: string) => dispatchReducer({ type: 'SET_PROMO_CODE_NAME', payload: coupon });
-
   const onRemoveAppliedCouponCode = () => {
     dispatchReducer({ type: 'SET_COUPON_CODE_DATA', payload: undefined });
-    dispatchReducer({ type: 'SET_PROMO_CODE_NAME', payload: undefined });
   };
 
   const setAuthMethod = (method: AuthMethodTypes) => {
@@ -91,7 +88,6 @@ export const useCheckout = (dispatchReducer: Dispatch<Action>) => {
   return {
     setAuthMethod,
     setError,
-    setCouponCodeName,
     onRemoveAppliedCouponCode,
     setAvatarBlob,
     setIsUserPaying,

--- a/src/views/Checkout/store/checkoutReducer.test.ts
+++ b/src/views/Checkout/store/checkoutReducer.test.ts
@@ -39,11 +39,18 @@ describe('checkoutReducer', () => {
     expect(setPlanResult).not.toBe(customState);
 
     const setCurrentPlanResult = checkoutReducer(
-      { ...initialStateForCheckout, promoCodeName: 'PROMO123', seatsForBusinessSubscription: 5 },
+      {
+        ...initialStateForCheckout,
+        couponCodeData: {
+          codeId: 'code-id',
+          codeName: 'PROMO123',
+        },
+        seatsForBusinessSubscription: 5,
+      },
       { type: 'SET_CURRENT_PLAN_SELECTED', payload: mockPlan },
     );
     expect(setCurrentPlanResult.currentSelectedPlan).toEqual(mockPlan);
-    expect(setCurrentPlanResult.promoCodeName).toBe('PROMO123');
+    expect(setCurrentPlanResult.couponCodeData?.codeName).toBe('PROMO123');
     expect(setCurrentPlanResult.seatsForBusinessSubscription).toBe(5);
   });
 
@@ -86,20 +93,34 @@ describe('checkoutReducer', () => {
 
   it('tracks payment and loading status without erasing existing information', () => {
     const payingResult = checkoutReducer(
-      { ...initialStateForCheckout, country: 'ES', promoCodeName: 'EXISTING' },
+      {
+        ...initialStateForCheckout,
+        country: 'ES',
+        couponCodeData: {
+          codeId: 'code-id',
+          codeName: 'EXISTING',
+        },
+      },
       { type: 'SET_IS_PAYING', payload: true },
     );
     expect(payingResult.isPaying).toBe(true);
     expect(payingResult.country).toBe('ES');
-    expect(payingResult.promoCodeName).toBe('EXISTING');
+    expect(payingResult.couponCodeData?.codeName).toBe('EXISTING');
 
     const readyResult = checkoutReducer(
-      { ...initialStateForCheckout, isPaying: true, promoCodeName: 'WELCOME' },
+      {
+        ...initialStateForCheckout,
+        isPaying: true,
+        couponCodeData: {
+          codeId: 'code-id',
+          codeName: 'WELCOME',
+        },
+      },
       { type: 'SET_IS_CHECKOUT_READY_TO_RENDER', payload: true },
     );
     expect(readyResult.isCheckoutReadyToRender).toBe(true);
     expect(readyResult.isPaying).toBe(true);
-    expect(readyResult.promoCodeName).toBe('WELCOME');
+    expect(readyResult.couponCodeData?.codeName).toBe('WELCOME');
 
     const dialogResult = checkoutReducer(
       { ...initialStateForCheckout, isUpdatingSubscription: true, seatsForBusinessSubscription: 10 },
@@ -121,9 +142,15 @@ describe('checkoutReducer', () => {
   it('saves promo codes while keeping everything else intact', () => {
     const promoCodeResult = checkoutReducer(
       { ...initialStateForCheckout, isPaying: true, seatsForBusinessSubscription: 7 },
-      { type: 'SET_PROMO_CODE_NAME', payload: 'SUMMER2024' },
+      {
+        type: 'SET_COUPON_CODE_DATA',
+        payload: {
+          codeId: 'code-id',
+          codeName: 'SUMMER2024',
+        },
+      },
     );
-    expect(promoCodeResult.promoCodeName).toBe('SUMMER2024');
+    expect(promoCodeResult.couponCodeData?.codeName).toBe('SUMMER2024');
     expect(promoCodeResult.isPaying).toBe(true);
     expect(promoCodeResult.seatsForBusinessSubscription).toBe(7);
   });
@@ -131,11 +158,18 @@ describe('checkoutReducer', () => {
   it('handles coupons, payment settings, login method, errors, and seats without losing other details', () => {
     const mockCoupon: CouponCodeData = { codeId: 'promo_123', codeName: 'DISCOUNT20', percentOff: 20 };
     const couponResult = checkoutReducer(
-      { ...initialStateForCheckout, promoCodeName: 'EXISTING', country: 'CA' },
+      {
+        ...initialStateForCheckout,
+        couponCodeData: {
+          codeId: 'code-id',
+          codeName: 'DISCOUNT20',
+        },
+        country: 'CA',
+      },
       { type: 'SET_COUPON_CODE_DATA', payload: mockCoupon },
     );
     expect(couponResult.couponCodeData).toEqual(mockCoupon);
-    expect(couponResult.promoCodeName).toBe('EXISTING');
+    expect(couponResult.couponCodeData?.codeName).toBe('DISCOUNT20');
     expect(couponResult.country).toBe('CA');
 
     const mockOptions: StripeElementsOptions = { mode: 'payment', amount: 999, currency: 'usd' };
@@ -148,12 +182,19 @@ describe('checkoutReducer', () => {
     expect(elementsResult.authMethod).toBe('signIn');
 
     const authResult = checkoutReducer(
-      { ...initialStateForCheckout, isCheckoutReadyToRender: true, promoCodeName: 'SPECIAL' },
+      {
+        ...initialStateForCheckout,
+        isCheckoutReadyToRender: true,
+        couponCodeData: {
+          codeId: 'code-id',
+          codeName: 'SPECIAL',
+        },
+      },
       { type: 'SET_AUTH_METHOD', payload: 'signIn' },
     );
     expect(authResult.authMethod).toBe('signIn');
     expect(authResult.isCheckoutReadyToRender).toBe(true);
-    expect(authResult.promoCodeName).toBe('SPECIAL');
+    expect(authResult.couponCodeData?.codeName).toBe('SPECIAL');
 
     const mockError: PartialErrorState = { stripe: 'Payment failed', auth: 'Authentication error' };
     const errorResult = checkoutReducer(
@@ -165,11 +206,15 @@ describe('checkoutReducer', () => {
     expect(errorResult.country).toBe('MX');
 
     const seatsResult = checkoutReducer(
-      { ...initialStateForCheckout, promoCodeName: 'BUSINESS', isUpdatingSubscription: true },
+      {
+        ...initialStateForCheckout,
+        couponCodeData: { codeId: 'code-id', codeName: 'BUSINESS' },
+        isUpdatingSubscription: true,
+      },
       { type: 'SET_SEATS_FOR_BUSINESS_SUBSCRIPTION', payload: 5 },
     );
     expect(seatsResult.seatsForBusinessSubscription).toBe(5);
-    expect(seatsResult.promoCodeName).toBe('BUSINESS');
+    expect(seatsResult.couponCodeData?.codeName).toBe('BUSINESS');
     expect(seatsResult.isUpdatingSubscription).toBe(true);
   });
 

--- a/src/views/Checkout/store/checkoutReducer.ts
+++ b/src/views/Checkout/store/checkoutReducer.ts
@@ -3,7 +3,6 @@ import { Action, State } from './types';
 export const initialStateForCheckout: State = {
   plan: null,
   currentSelectedPlan: null,
-  promoCodeName: '',
   avatarBlob: null,
   isPaying: false,
   isCheckoutReadyToRender: false,
@@ -38,8 +37,6 @@ export const checkoutReducer = (state: State, action: Action): State => {
       return { ...state, country: action.payload };
     case 'SET_PRICES':
       return { ...state, prices: action.payload };
-    case 'SET_PROMO_CODE_NAME':
-      return { ...state, promoCodeName: action.payload };
     case 'SET_COUPON_CODE_DATA':
       return { ...state, couponCodeData: action.payload };
     case 'SET_ELEMENTS_OPTIONS':

--- a/src/views/Checkout/store/types.ts
+++ b/src/views/Checkout/store/types.ts
@@ -15,7 +15,6 @@ export interface State {
   country: string;
   seatsForBusinessSubscription: number;
   authMethod: AuthMethodTypes;
-  promoCodeName?: string;
   couponCodeData?: CouponCodeData;
   elementsOptions?: StripeElementsOptions;
   error?: PartialErrorState;
@@ -32,7 +31,6 @@ export type Action =
   | { type: 'SET_PRICES'; payload: DisplayPrice[] }
   | { type: 'SET_COUNTRY'; payload: string }
   | { type: 'SET_SEATS_FOR_BUSINESS_SUBSCRIPTION'; payload: number }
-  | { type: 'SET_PROMO_CODE_NAME'; payload: string | undefined }
   | { type: 'SET_COUPON_CODE_DATA'; payload: CouponCodeData | undefined }
   | { type: 'SET_ELEMENTS_OPTIONS'; payload: StripeElementsOptions }
   | { type: 'SET_AUTH_METHOD'; payload: AuthMethodTypes }

--- a/src/views/Checkout/utils/getProductAmount.test.ts
+++ b/src/views/Checkout/utils/getProductAmount.test.ts
@@ -47,4 +47,29 @@ describe('Calculating final price of a product', () => {
   it('Handles case with 0 users gracefully (should return 0)', () => {
     expect(getProductAmount(10, 0)).toBe('0');
   });
+
+  describe('When discount results in negative price', () => {
+    it('Returns 0 if amountOff discount exceeds the product price', () => {
+      const coupon: CouponCodeData = {
+        amountOff: 2000, // 20.00€ discount
+        percentOff: undefined,
+        codeId: '4',
+        codeName: 'BIGDISCOUNT',
+      };
+
+      // Product costs 10€, discount is 20€, should return 0 instead of negative
+      expect(getProductAmount(10, 1, coupon)).toBe('0.00');
+    });
+
+    it('Returns 0 if percentOff is 100% or more', () => {
+      const coupon: CouponCodeData = {
+        percentOff: 100,
+        amountOff: undefined,
+        codeId: '5',
+        codeName: 'FREE',
+      };
+
+      expect(getProductAmount(10, 2, coupon)).toBe('0.00');
+    });
+  });
 });

--- a/src/views/Checkout/utils/getProductAmount.test.ts
+++ b/src/views/Checkout/utils/getProductAmount.test.ts
@@ -51,14 +51,13 @@ describe('Calculating final price of a product', () => {
   describe('When discount results in negative price', () => {
     it('Returns 0 if amountOff discount exceeds the product price', () => {
       const coupon: CouponCodeData = {
-        amountOff: 2000, // 20.00€ discount
+        amountOff: 2000,
         percentOff: undefined,
         codeId: '4',
         codeName: 'BIGDISCOUNT',
       };
 
-      // Product costs 10€, discount is 20€, should return 0 instead of negative
-      expect(getProductAmount(10, 1, coupon)).toBe('0.00');
+      expect(getProductAmount(10, 1, coupon)).toBe('0');
     });
 
     it('Returns 0 if percentOff is 100% or more', () => {
@@ -69,7 +68,7 @@ describe('Calculating final price of a product', () => {
         codeName: 'FREE',
       };
 
-      expect(getProductAmount(10, 2, coupon)).toBe('0.00');
+      expect(getProductAmount(10, 2, coupon)).toBe('0');
     });
   });
 });

--- a/src/views/Checkout/utils/getProductAmount.ts
+++ b/src/views/Checkout/utils/getProductAmount.ts
@@ -18,5 +18,6 @@ export const getProductAmount = (
     finalAmount = amount * users;
   }
 
-  return formatPrice(finalAmount);
+  const positiveAmount = Math.max(0, finalAmount);
+  return formatPrice(positiveAmount);
 };

--- a/src/views/Checkout/views/CheckoutViewWrapper.tsx
+++ b/src/views/Checkout/views/CheckoutViewWrapper.tsx
@@ -102,7 +102,6 @@ const CheckoutViewWrapper = () => {
     onRemoveAppliedCouponCode,
     setAuthMethod,
     setAvatarBlob,
-    setCouponCodeName,
     setError,
     setIsUserPaying,
     setPromoCodeData,
@@ -121,7 +120,6 @@ const CheckoutViewWrapper = () => {
     avatarBlob,
     couponCodeData,
     elementsOptions,
-    promoCodeName,
     seatsForBusinessSubscription,
     isCheckoutReadyToRender,
     isUpdateSubscriptionDialogOpen,
@@ -183,7 +181,7 @@ const CheckoutViewWrapper = () => {
       recalculatePrice(
         currentSelectedPlan.price.id,
         currentSelectedPlan.price.currency,
-        promoCodeName,
+        couponCodeData?.codeName,
         address.postal_code,
         address.country,
       );
@@ -207,7 +205,6 @@ const CheckoutViewWrapper = () => {
 
     try {
       if (promoCodeName) {
-        setCouponCodeName(promoCodeName);
         await handleFetchPromotionCode(currentSelectedPlan.price.id, promoCodeName);
       }
     } catch (error) {

--- a/src/views/NewSettings/components/Sections/Account/Security/components/EnterPassword.tsx
+++ b/src/views/NewSettings/components/Sections/Account/Security/components/EnterPassword.tsx
@@ -43,7 +43,13 @@ const EnterPassword = ({
   };
 
   return (
-    <div className="flex w-full justify-center" title={translate('views.account.tabs.security.label')}>
+    <div
+      className="flex w-full justify-center"
+      title={translate('views.account.tabs.security.label')}
+      onMouseDown={(e) => {
+        e.stopPropagation();
+      }}
+    >
       <Card className="w-2/3 space-y-3">
         <h1 className="text-lg font-medium text-gray-80">{translate('views.account.tabs.security.lock.title')}</h1>
         <p className="text-gray-80">{translate('views.account.tabs.security.lock.description')}</p>

--- a/src/views/NewSettings/components/Sections/Account/Security/components/EnterPassword.tsx
+++ b/src/views/NewSettings/components/Sections/Account/Security/components/EnterPassword.tsx
@@ -46,6 +46,7 @@ const EnterPassword = ({
     <div
       className="flex w-full justify-center"
       title={translate('views.account.tabs.security.label')}
+      role="button"
       onMouseDown={(e) => {
         // This prevents to closing the dialog when the user wants to reveal the password by clicking in the "Eye" icon
         // Do not remove!

--- a/src/views/NewSettings/components/Sections/Account/Security/components/EnterPassword.tsx
+++ b/src/views/NewSettings/components/Sections/Account/Security/components/EnterPassword.tsx
@@ -46,7 +46,6 @@ const EnterPassword = ({
     <div
       className="flex w-full justify-center"
       title={translate('views.account.tabs.security.label')}
-      role="button"
       onMouseDown={(e) => {
         // This prevents to closing the dialog when the user wants to reveal the password by clicking in the "Eye" icon
         // Do not remove!

--- a/src/views/NewSettings/components/Sections/Account/Security/components/EnterPassword.tsx
+++ b/src/views/NewSettings/components/Sections/Account/Security/components/EnterPassword.tsx
@@ -47,6 +47,8 @@ const EnterPassword = ({
       className="flex w-full justify-center"
       title={translate('views.account.tabs.security.label')}
       onMouseDown={(e) => {
+        // This prevents to closing the dialog when the user wants to reveal the password by clicking in the "Eye" icon
+        // Do not remove!
         e.stopPropagation();
       }}
     >


### PR DESCRIPTION
## Description

This PR addresses some issues in the integrated checkout flow and in the Security section of the Preferences dialog.
**Integrated Checkout:**
- The coupon code is now correctly preserved even when updating the country and postal code. Previously, when recalculating prices due to a mismatch between the user’s initial location and the updated shipping address, the discount was removed, leading to user confusion.
- When a coupon discount exceeds the product price, the final amount is now correctly shown as €0, instead of displaying the full price alongside a negative “Amount to pay now”.

**Preferences Dialog (Security):**
- When entering a password, the user can now toggle visibility using the “eye” icon without the dialog closing unexpectedly.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [x] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
