### PR TITLE
[_]: fix/progress bar while loading video stream

### DIFF
--- a/public/video-streaming.js
+++ b/public/video-streaming.js
@@ -13,7 +13,7 @@ const MESSAGE_TYPES = {
   CLEAR_SESSIONS: 'CLEAR_SESSIONS',
 };
 const DEFAULT_CHUNK_SIZE = 5 * 1024 * 1024;
-const CHUNK_REQUEST_TIMEOUT = 2 * 60 * 1000; // 2 minutes for slow connections
+const CHUNK_REQUEST_TIMEOUT = 10000;
 
 /**
  * Waiting until the Service Worker is installed

--- a/src/app/drive/components/FileViewer/FileViewer.tsx
+++ b/src/app/drive/components/FileViewer/FileViewer.tsx
@@ -100,7 +100,8 @@ const FileViewer = ({
   const isLastItemOrShareView = (totalFolderIndex && fileIndex === totalFolderIndex - 1) || isShareView;
   const isItemValidToPreview = isTypeAllowed && isPreviewAvailable;
   const isVideo = fileExtensionGroup === FileExtensionGroup['Video'];
-  const isVideoStreaming = isVideo && !disableVideoStream;
+  const isSafari = navigator.userAgent.includes('Safari') && !navigator.userAgent.includes('Chrome');
+  const isVideoStreaming = isVideo && !disableVideoStream && (!isSafari || isFileSizePreviewable(file.size));
 
   const shouldRenderThePreview = isTypeAllowed && (isVideoStreaming || isFileSizePreviewable(file.size));
 

--- a/src/app/drive/services/video-streaming.service/VideoStreamingSession.test.ts
+++ b/src/app/drive/services/video-streaming.service/VideoStreamingSession.test.ts
@@ -27,7 +27,6 @@ const createMockConfig = (overrides?: Partial<VideoStreamingSessionConfig>): Vid
   fileType: 'mp4',
   mnemonic: 'test-mnemonic',
   credentials: { user: 'test-user', pass: 'test-pass' },
-  onProgress: vi.fn(),
   ...overrides,
 });
 

--- a/src/app/drive/services/video-streaming.service/VideoStreamingSession.ts
+++ b/src/app/drive/services/video-streaming.service/VideoStreamingSession.ts
@@ -13,7 +13,6 @@ export interface VideoStreamingSessionConfig {
     user: string;
     pass: string;
   };
-  onProgress?: (progress: number) => void;
 }
 
 const CACHE_SIZE_LIMIT = 20;
@@ -116,13 +115,7 @@ export class VideoStreamingSession {
         },
       });
 
-      const result = await binaryStreamToUint8Array(stream, (bytes) => {
-        const progress = bytes / (end - start);
-        if (this.chunkCache.size === 0 && this.config.onProgress) {
-          const currentProgress = progress >= 1 ? 0.95 : progress;
-          this.config.onProgress(currentProgress);
-        }
-      });
+      const result = await binaryStreamToUint8Array(stream);
 
       if (this.isDestroyed) {
         throw new Error('Session destroyed during download');


### PR DESCRIPTION
## Description

The fake progress has been enhanced by increasing it a 20% each 500 ms. Also, the video streaming for big files in Safari has been disabled.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [ ] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
