### PR TITLE
[PB-5542]: add unit tests for Redux file versions slice and version item actions hook

### DIFF
--- a/src/app/store/slices/fileVersions/index.test.ts
+++ b/src/app/store/slices/fileVersions/index.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FileVersion, FileLimitsResponse } from '@internxt/sdk/dist/drive/storage/types';
+import fileVersionService from 'views/Drive/components/VersionHistory/services/fileVersion.service';
+import { fileVersionsActions, fileVersionsReducer, fetchFileVersionsThunk, fetchVersionLimitsThunk } from './index';
+import { RootState } from '../..';
+
+vi.mock('views/Drive/components/VersionHistory/services/fileVersion.service', () => ({
+  default: {
+    getFileVersions: vi.fn(),
+    getLimits: vi.fn(),
+  },
+}));
+
+describe('fileVersions slice', () => {
+  const fileUuid = 'file-uuid';
+  const versions: FileVersion[] = [
+    { id: 'v1', fileId: fileUuid } as FileVersion,
+    { id: 'v2', fileId: fileUuid } as FileVersion,
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('thunks', () => {
+    it('fetch file versions succeeds', async () => {
+      const getFileVersionsSpy = vi.spyOn(fileVersionService, 'getFileVersions').mockResolvedValueOnce(versions);
+      const dispatch = vi.fn();
+
+      const action = await fetchFileVersionsThunk(fileUuid)(dispatch, () => ({}) as RootState, undefined);
+
+      expect(getFileVersionsSpy).toHaveBeenCalledWith(fileUuid);
+      expect(action.meta.requestStatus).toBe('fulfilled');
+      expect(action.payload).toEqual({ fileUuid, versions });
+    });
+
+    it('fetch file versions surfaces the error message', async () => {
+      const getFileVersionsSpy = vi
+        .spyOn(fileVersionService, 'getFileVersions')
+        .mockRejectedValueOnce(new Error('failed to fetch'));
+      const dispatch = vi.fn();
+
+      const action = await fetchFileVersionsThunk(fileUuid)(dispatch, () => ({}) as RootState, undefined);
+
+      expect(getFileVersionsSpy).toHaveBeenCalledWith(fileUuid);
+      expect(action.meta.requestStatus).toBe('rejected');
+      expect(action.payload).toBe('failed to fetch');
+    });
+
+    it('fetch version limits succeeds', async () => {
+      const limits: FileLimitsResponse = {
+        versioning: { enabled: true, maxFileSize: 0, retentionDays: 0, maxVersions: 0 },
+      };
+      const getLimitsSpy = vi.spyOn(fileVersionService, 'getLimits').mockResolvedValueOnce(limits);
+      const dispatch = vi.fn();
+
+      const action = await fetchVersionLimitsThunk()(dispatch, () => ({}) as RootState, undefined);
+
+      expect(getLimitsSpy).toHaveBeenCalled();
+      expect(action.meta.requestStatus).toBe('fulfilled');
+      expect(action.payload).toBe(limits);
+    });
+
+    it('fetch version limits surfaces the error message', async () => {
+      const getLimitsSpy = vi
+        .spyOn(fileVersionService, 'getLimits')
+        .mockRejectedValueOnce(new Error('limits unavailable'));
+      const dispatch = vi.fn();
+
+      const action = await fetchVersionLimitsThunk()(dispatch, () => ({}) as RootState, undefined);
+
+      expect(getLimitsSpy).toHaveBeenCalled();
+      expect(action.meta.requestStatus).toBe('rejected');
+      expect(action.payload).toBe('limits unavailable');
+    });
+  });
+
+  describe('reducers', () => {
+    it('marks loading and error state while fetching versions', () => {
+      const pendingState = fileVersionsReducer(undefined, fetchFileVersionsThunk.pending('', fileUuid));
+
+      expect(pendingState.isLoadingByFileId[fileUuid]).toBe(true);
+      expect(pendingState.errorsByFileId[fileUuid]).toBeNull();
+
+      const rejectedState = fileVersionsReducer(pendingState, {
+        type: fetchFileVersionsThunk.rejected.type,
+        meta: { arg: fileUuid },
+        payload: 'problem',
+      } as any);
+
+      expect(rejectedState.isLoadingByFileId[fileUuid]).toBe(false);
+      expect(rejectedState.errorsByFileId[fileUuid]).toBe('problem');
+
+      const fulfilledState = fileVersionsReducer(
+        rejectedState,
+        fetchFileVersionsThunk.fulfilled({ fileUuid, versions }, '', fileUuid),
+      );
+
+      expect(fulfilledState.isLoadingByFileId[fileUuid]).toBe(false);
+      expect(fulfilledState.versionsByFileId[fileUuid]).toEqual(versions);
+    });
+
+    it('clears caches selectively and globally', () => {
+      const populatedState = {
+        versionsByFileId: { [fileUuid]: versions },
+        isLoadingByFileId: { [fileUuid]: false },
+        errorsByFileId: { [fileUuid]: 'error' },
+        limits: null,
+        isLimitsLoading: false,
+      };
+
+      const afterInvalidate = fileVersionsReducer(populatedState as any, fileVersionsActions.invalidateCache(fileUuid));
+      expect(afterInvalidate.versionsByFileId[fileUuid]).toBeUndefined();
+      expect(afterInvalidate.isLoadingByFileId[fileUuid]).toBeUndefined();
+      expect(afterInvalidate.errorsByFileId[fileUuid]).toBeUndefined();
+
+      const afterClearAll = fileVersionsReducer(populatedState as any, fileVersionsActions.clearAllCache());
+      expect(afterClearAll.versionsByFileId).toEqual({});
+      expect(afterClearAll.isLoadingByFileId).toEqual({});
+      expect(afterClearAll.errorsByFileId).toEqual({});
+    });
+
+    it('removes deleted versions from the cached list', () => {
+      const state = {
+        versionsByFileId: { [fileUuid]: versions },
+        isLoadingByFileId: {},
+        errorsByFileId: {},
+        limits: null,
+        isLimitsLoading: false,
+      };
+
+      const updatedState = fileVersionsReducer(
+        state as any,
+        fileVersionsActions.updateVersionsAfterDelete({ fileUuid, versionId: 'v1' }),
+      );
+
+      expect(updatedState.versionsByFileId[fileUuid]).toEqual([versions[1]]);
+    });
+
+    it('tracks loading state for fetching limits', () => {
+      const pendingState = fileVersionsReducer(undefined, fetchVersionLimitsThunk.pending('', undefined));
+      expect(pendingState.isLimitsLoading).toBe(true);
+
+      const limits: FileLimitsResponse = {
+        versioning: { enabled: true, maxFileSize: 0, retentionDays: 0, maxVersions: 0 },
+      };
+      const fulfilledState = fileVersionsReducer(
+        pendingState,
+        fetchVersionLimitsThunk.fulfilled(limits, '', undefined),
+      );
+      expect(fulfilledState.isLimitsLoading).toBe(false);
+      expect(fulfilledState.limits).toBe(limits);
+
+      const rejectedState = fileVersionsReducer(
+        pendingState,
+        fetchVersionLimitsThunk.rejected(new Error('err'), '', undefined),
+      );
+      expect(rejectedState.isLimitsLoading).toBe(false);
+    });
+  });
+});

--- a/src/app/store/slices/fileVersions/index.test.ts
+++ b/src/app/store/slices/fileVersions/index.test.ts
@@ -11,7 +11,7 @@ vi.mock('views/Drive/components/VersionHistory/services/fileVersion.service', ()
   },
 }));
 
-describe('fileVersions slice', () => {
+describe('File history state', () => {
   const fileUuid = 'file-uuid';
   const versions: FileVersion[] = [
     { id: 'v1', fileId: fileUuid } as FileVersion,
@@ -22,8 +22,8 @@ describe('fileVersions slice', () => {
     vi.clearAllMocks();
   });
 
-  describe('thunks', () => {
-    it('should load file versions successfully', async () => {
+  describe('Loading file history', () => {
+    it('when file history is requested, then the versions load successfully', async () => {
       const getFileVersionsSpy = vi.spyOn(fileVersionService, 'getFileVersions').mockResolvedValueOnce(versions);
       const dispatch = vi.fn();
 
@@ -34,7 +34,7 @@ describe('fileVersions slice', () => {
       expect(action.payload).toEqual({ fileUuid, versions });
     });
 
-    it('should handle errors when loading file versions', async () => {
+    it('when file history fails to load, then the error is reported', async () => {
       const getFileVersionsSpy = vi
         .spyOn(fileVersionService, 'getFileVersions')
         .mockRejectedValueOnce(new Error('failed to fetch'));
@@ -47,7 +47,7 @@ describe('fileVersions slice', () => {
       expect(action.payload).toBe('failed to fetch');
     });
 
-    it('should load version limits successfully', async () => {
+    it('when version limits are requested, then the limits load successfully', async () => {
       const limits: FileLimitsResponse = {
         versioning: { enabled: true, maxFileSize: 0, retentionDays: 0, maxVersions: 0 },
       };
@@ -61,7 +61,7 @@ describe('fileVersions slice', () => {
       expect(action.payload).toBe(limits);
     });
 
-    it('should handle errors when loading version limits', async () => {
+    it('when version limits fail to load, then the error is reported', async () => {
       const getLimitsSpy = vi
         .spyOn(fileVersionService, 'getLimits')
         .mockRejectedValueOnce(new Error('limits unavailable'));
@@ -75,8 +75,8 @@ describe('fileVersions slice', () => {
     });
   });
 
-  describe('reducers', () => {
-    it('should update loading and error states when loading versions', () => {
+  describe('Updating stored history', () => {
+    it('when history starts loading, then loading and error states update', () => {
       const pendingState = fileVersionsReducer(undefined, fetchFileVersionsThunk.pending('', fileUuid));
 
       expect(pendingState.isLoadingByFileId[fileUuid]).toBe(true);
@@ -100,7 +100,7 @@ describe('fileVersions slice', () => {
       expect(fulfilledState.versionsByFileId[fileUuid]).toEqual(versions);
     });
 
-    it('should clear cache for a specific file or all files', () => {
+    it('when cached history is cleared for a file or all files, then entries are removed', () => {
       const populatedState = {
         versionsByFileId: { [fileUuid]: versions },
         isLoadingByFileId: { [fileUuid]: false },
@@ -120,7 +120,7 @@ describe('fileVersions slice', () => {
       expect(afterClearAll.errorsByFileId).toEqual({});
     });
 
-    it('should remove a deleted version from the list', () => {
+    it('when a version is deleted, then it is removed from the list', () => {
       const state = {
         versionsByFileId: { [fileUuid]: versions },
         isLoadingByFileId: {},
@@ -137,7 +137,7 @@ describe('fileVersions slice', () => {
       expect(updatedState.versionsByFileId[fileUuid]).toEqual([versions[1]]);
     });
 
-    it('should update loading state when loading limits', () => {
+    it('when limits are loading or finished, then the loading state updates', () => {
       const pendingState = fileVersionsReducer(undefined, fetchVersionLimitsThunk.pending('', undefined));
       expect(pendingState.isLimitsLoading).toBe(true);
 

--- a/src/app/store/slices/fileVersions/index.test.ts
+++ b/src/app/store/slices/fileVersions/index.test.ts
@@ -23,7 +23,7 @@ describe('fileVersions slice', () => {
   });
 
   describe('thunks', () => {
-    it('fetch file versions succeeds', async () => {
+    it('should load file versions successfully', async () => {
       const getFileVersionsSpy = vi.spyOn(fileVersionService, 'getFileVersions').mockResolvedValueOnce(versions);
       const dispatch = vi.fn();
 
@@ -34,7 +34,7 @@ describe('fileVersions slice', () => {
       expect(action.payload).toEqual({ fileUuid, versions });
     });
 
-    it('fetch file versions surfaces the error message', async () => {
+    it('should handle errors when loading file versions', async () => {
       const getFileVersionsSpy = vi
         .spyOn(fileVersionService, 'getFileVersions')
         .mockRejectedValueOnce(new Error('failed to fetch'));
@@ -47,7 +47,7 @@ describe('fileVersions slice', () => {
       expect(action.payload).toBe('failed to fetch');
     });
 
-    it('fetch version limits succeeds', async () => {
+    it('should load version limits successfully', async () => {
       const limits: FileLimitsResponse = {
         versioning: { enabled: true, maxFileSize: 0, retentionDays: 0, maxVersions: 0 },
       };
@@ -61,7 +61,7 @@ describe('fileVersions slice', () => {
       expect(action.payload).toBe(limits);
     });
 
-    it('fetch version limits surfaces the error message', async () => {
+    it('should handle errors when loading version limits', async () => {
       const getLimitsSpy = vi
         .spyOn(fileVersionService, 'getLimits')
         .mockRejectedValueOnce(new Error('limits unavailable'));
@@ -76,7 +76,7 @@ describe('fileVersions slice', () => {
   });
 
   describe('reducers', () => {
-    it('marks loading and error state while fetching versions', () => {
+    it('should update loading and error states when loading versions', () => {
       const pendingState = fileVersionsReducer(undefined, fetchFileVersionsThunk.pending('', fileUuid));
 
       expect(pendingState.isLoadingByFileId[fileUuid]).toBe(true);
@@ -100,7 +100,7 @@ describe('fileVersions slice', () => {
       expect(fulfilledState.versionsByFileId[fileUuid]).toEqual(versions);
     });
 
-    it('clears caches selectively and globally', () => {
+    it('should clear cache for a specific file or all files', () => {
       const populatedState = {
         versionsByFileId: { [fileUuid]: versions },
         isLoadingByFileId: { [fileUuid]: false },
@@ -120,7 +120,7 @@ describe('fileVersions slice', () => {
       expect(afterClearAll.errorsByFileId).toEqual({});
     });
 
-    it('removes deleted versions from the cached list', () => {
+    it('should remove a deleted version from the list', () => {
       const state = {
         versionsByFileId: { [fileUuid]: versions },
         isLoadingByFileId: {},
@@ -137,7 +137,7 @@ describe('fileVersions slice', () => {
       expect(updatedState.versionsByFileId[fileUuid]).toEqual([versions[1]]);
     });
 
-    it('tracks loading state for fetching limits', () => {
+    it('should update loading state when loading limits', () => {
       const pendingState = fileVersionsReducer(undefined, fetchVersionLimitsThunk.pending('', undefined));
       expect(pendingState.isLimitsLoading).toBe(true);
 

--- a/src/views/Drive/components/VersionHistory/hooks/useVersionItemActions.test.ts
+++ b/src/views/Drive/components/VersionHistory/hooks/useVersionItemActions.test.ts
@@ -1,0 +1,165 @@
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi, Mock } from 'vitest';
+import { Trash, ClockCounterClockwise, DownloadSimple } from '@phosphor-icons/react';
+import { useVersionItemActions } from './useVersionItemActions';
+import fileVersionService from '../services/fileVersion.service';
+import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
+import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
+import { useAppDispatch, useAppSelector } from 'app/store/hooks';
+import { FileVersion } from '@internxt/sdk/dist/drive/storage/types';
+import { WorkspaceData } from '@internxt/sdk/dist/workspaces';
+import { RootState } from 'app/store';
+import { MenuItemType } from '@internxt/ui';
+
+vi.mock('app/i18n/provider/TranslationProvider', () => ({
+  useTranslationContext: vi.fn(),
+}));
+
+vi.mock('app/store/hooks', () => ({
+  useAppDispatch: vi.fn(),
+  useAppSelector: vi.fn(),
+}));
+
+vi.mock('views/Drive/components/VersionHistory/services/fileVersion.service', () => ({
+  default: {
+    downloadVersion: vi.fn(),
+  },
+}));
+
+vi.mock('app/notifications/services/notifications.service', () => ({
+  default: {
+    show: vi.fn(),
+  },
+  ToastType: {
+    Error: 'error',
+  },
+}));
+
+const mockSetVersionToRestore = vi.hoisted(() => vi.fn((payload) => ({ type: 'setVersionToRestore', payload })));
+const mockSetIsRestoreVersionDialogOpen = vi.hoisted(() =>
+  vi.fn((payload) => ({ type: 'setIsRestoreVersionDialogOpen', payload })),
+);
+const mockSetVersionToDelete = vi.hoisted(() => vi.fn((payload) => ({ type: 'setVersionToDelete', payload })));
+const mockSetIsDeleteVersionDialogOpen = vi.hoisted(() =>
+  vi.fn((payload) => ({ type: 'setIsDeleteVersionDialogOpen', payload })),
+);
+
+vi.mock('app/store/slices/ui', () => ({
+  uiActions: {
+    setVersionToRestore: mockSetVersionToRestore,
+    setIsRestoreVersionDialogOpen: mockSetIsRestoreVersionDialogOpen,
+    setVersionToDelete: mockSetVersionToDelete,
+    setIsDeleteVersionDialogOpen: mockSetIsDeleteVersionDialogOpen,
+  },
+}));
+
+describe('useVersionItemActions', () => {
+  const translateMock = vi.fn((key: string) => key);
+  const version = {
+    id: 'version-id',
+    fileId: 'file-uuid',
+    networkFileId: 'network-file-id',
+    size: '5',
+  } as FileVersion;
+  const fileItem = {
+    id: 'file-id',
+    name: 'fallback-name',
+    plainName: 'pretty-name',
+    fileId: 'file-id',
+  } as any;
+  const selectedWorkspace = { workspace: { id: 'workspace-id' } } as WorkspaceData;
+  const workspaceCredentials = { workspaceId: 'workspace-id', token: 'token' } as any;
+  const baseState = {
+    ui: { versionHistoryItem: fileItem },
+    workspaces: { selectedWorkspace, workspaceCredentials },
+  } as unknown as RootState;
+
+  const mockDispatch = vi.fn();
+  const mockUseAppDispatch = useAppDispatch as unknown as Mock;
+  const mockUseAppSelector = useAppSelector as unknown as Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAppDispatch.mockReturnValue(mockDispatch);
+    (useTranslationContext as Mock).mockReturnValue({ translate: translateMock });
+    mockUseAppSelector.mockImplementation((selector: (state: RootState) => unknown) => selector(baseState));
+  });
+
+  const getMenuActionByIcon = (items: Array<MenuItemType<FileVersion>>, icon: any) => {
+    const item = items.find((item) => 'icon' in item && item.icon === icon);
+    return item && 'action' in item ? (item as any).action : undefined;
+  };
+
+  it('opens the restore dialog when restore is chosen', () => {
+    const onDropdownClose = vi.fn();
+    const { result } = renderHook(() => useVersionItemActions({ version, onDropdownClose }));
+    const restoreAction = getMenuActionByIcon(result.current.menuItems, ClockCounterClockwise);
+
+    act(() => {
+      restoreAction();
+    });
+
+    expect(onDropdownClose).toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'setVersionToRestore', payload: version });
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'setIsRestoreVersionDialogOpen', payload: true });
+  });
+
+  it('shows a toast when there is nothing selected to download', async () => {
+    const onDropdownClose = vi.fn();
+    mockUseAppSelector.mockImplementation((selector: (state: RootState) => unknown) =>
+      selector({
+        ui: { versionHistoryItem: null },
+        workspaces: { selectedWorkspace: null, workspaceCredentials: null },
+      } as unknown as RootState),
+    );
+    const showSpy = vi.spyOn(notificationsService, 'show');
+    const { result } = renderHook(() => useVersionItemActions({ version, onDropdownClose }));
+    const downloadAction = getMenuActionByIcon(result.current.menuItems, DownloadSimple);
+
+    await act(async () => {
+      await downloadAction();
+    });
+
+    expect(onDropdownClose).toHaveBeenCalled();
+    expect(showSpy).toHaveBeenCalledWith({
+      text: 'modals.versionHistory.downloadError',
+      type: ToastType.Error,
+    });
+    expect(fileVersionService.downloadVersion).not.toHaveBeenCalled();
+  });
+
+  it('downloads a version with the readable filename and workspace data', async () => {
+    const onDropdownClose = vi.fn();
+    const downloadVersionSpy = vi.spyOn(fileVersionService, 'downloadVersion').mockResolvedValue(undefined as any);
+    const { result } = renderHook(() => useVersionItemActions({ version, onDropdownClose }));
+    const downloadAction = getMenuActionByIcon(result.current.menuItems, DownloadSimple);
+
+    await act(async () => {
+      await downloadAction();
+    });
+
+    expect(onDropdownClose).toHaveBeenCalled();
+    expect(downloadVersionSpy).toHaveBeenCalledWith(
+      version,
+      fileItem,
+      fileItem.plainName,
+      selectedWorkspace,
+      workspaceCredentials,
+    );
+    expect(notificationsService.show).not.toHaveBeenCalled();
+  });
+
+  it('opens the delete dialog when delete is chosen', () => {
+    const onDropdownClose = vi.fn();
+    const { result } = renderHook(() => useVersionItemActions({ version, onDropdownClose }));
+    const deleteAction = getMenuActionByIcon(result.current.menuItems, Trash);
+
+    act(() => {
+      deleteAction();
+    });
+
+    expect(onDropdownClose).toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'setVersionToDelete', payload: version });
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'setIsDeleteVersionDialogOpen', payload: true });
+  });
+});

--- a/src/views/Drive/components/VersionHistory/hooks/useVersionItemActions.test.ts
+++ b/src/views/Drive/components/VersionHistory/hooks/useVersionItemActions.test.ts
@@ -53,7 +53,7 @@ vi.mock('app/store/slices/ui', () => ({
   },
 }));
 
-describe('useVersionItemActions', () => {
+describe('Version item menu', () => {
   const translateMock = vi.fn((key: string) => key);
   const version = {
     id: 'version-id',
@@ -90,7 +90,7 @@ describe('useVersionItemActions', () => {
     return item && 'action' in item ? (item as any).action : undefined;
   };
 
-  it('opens the restore dialog when restore is chosen', () => {
+  it('when restore is chosen, then the restore dialog opens', () => {
     const onDropdownClose = vi.fn();
     const { result } = renderHook(() => useVersionItemActions({ version, onDropdownClose }));
     const restoreAction = getMenuActionByIcon(result.current.menuItems, ClockCounterClockwise);
@@ -104,7 +104,7 @@ describe('useVersionItemActions', () => {
     expect(mockDispatch).toHaveBeenCalledWith({ type: 'setIsRestoreVersionDialogOpen', payload: true });
   });
 
-  it('shows a toast when there is nothing selected to download', async () => {
+  it('when nothing is selected to download, then an error toast is shown', async () => {
     const onDropdownClose = vi.fn();
     mockUseAppSelector.mockImplementation((selector: (state: RootState) => unknown) =>
       selector({
@@ -128,7 +128,7 @@ describe('useVersionItemActions', () => {
     expect(fileVersionService.downloadVersion).not.toHaveBeenCalled();
   });
 
-  it('downloads a version with the readable filename and workspace data', async () => {
+  it('when a previous version is downloaded, then it uses the readable name and workspace data', async () => {
     const onDropdownClose = vi.fn();
     const downloadVersionSpy = vi.spyOn(fileVersionService, 'downloadVersion').mockResolvedValue(undefined as any);
     const { result } = renderHook(() => useVersionItemActions({ version, onDropdownClose }));
@@ -149,7 +149,7 @@ describe('useVersionItemActions', () => {
     expect(notificationsService.show).not.toHaveBeenCalled();
   });
 
-  it('opens the delete dialog when delete is chosen', () => {
+  it('when delete is chosen, then the delete dialog opens', () => {
     const onDropdownClose = vi.fn();
     const { result } = renderHook(() => useVersionItemActions({ version, onDropdownClose }));
     const deleteAction = getMenuActionByIcon(result.current.menuItems, Trash);


### PR DESCRIPTION
## Description

Add comprehensive test coverage for fileVersions Redux slice and useVersionItemActions hook. Tests include thunk operations (fetch versions, fetch limits), reducer state management (loading, errors, cache invalidation), and menu action handlers (restore, download, delete). Uses icon-based menu item selection for robust, maintainable tests.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
