### PR TITLE
[PB-1053]: fix/prevent default extension for files that does not have extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react": "^18.2.0",
     "react-avatar-editor": "^13.0.2",
     "react-bootstrap": "^2.9.0",
-    "react-device-detect": "^1.15.0",
+    "react-device-detect": "^2.2.3",
     "react-dnd": "14.0.5",
     "react-dnd-html5-backend": "^14.0.0",
     "react-dom": "^18.2.0",

--- a/public/streamsaver/stream-saver.js
+++ b/public/streamsaver/stream-saver.js
@@ -80,7 +80,6 @@ self.onfetch = (event) => {
 
   const responseHeaders = new Headers({
     'Content-Type': 'application/octet-stream; charset=utf-8',
-    DefaultType: 'None',
     'Content-Security-Policy': "default-src 'none'",
     'X-Content-Security-Policy': "default-src 'none'",
     'X-WebKit-CSP': "default-src 'none'",

--- a/public/streamsaver/stream-saver.js
+++ b/public/streamsaver/stream-saver.js
@@ -80,6 +80,7 @@ self.onfetch = (event) => {
 
   const responseHeaders = new Headers({
     'Content-Type': 'application/octet-stream; charset=utf-8',
+    DefaultType: 'None',
     'Content-Security-Policy': "default-src 'none'",
     'X-Content-Security-Policy': "default-src 'none'",
     'X-WebKit-CSP': "default-src 'none'",

--- a/src/app/drive/services/downloadManager.service.test.ts
+++ b/src/app/drive/services/downloadManager.service.test.ts
@@ -32,6 +32,7 @@ import { DriveItemBlobData } from 'app/database/services/database.service';
 import { ConnectionLostError } from 'app/network/requests';
 import { downloadFile } from 'app/network/download';
 import { downloadWorkerHandler } from './worker.service/downloadWorkerHandler';
+import deviceService from 'services/device.service';
 
 vi.mock('./../../network/requests', () => ({ ConnectionLostError: vi.fn(), NetworkCredentials: {} }));
 vi.mock('app/tasks/services/tasks.service', () => ({
@@ -897,12 +898,7 @@ describe('downloadManagerService', () => {
     describe('Safari downloads', () => {
       beforeEach(() => {
         vi.clearAllMocks();
-
-        Object.defineProperty(window.navigator, 'userAgent', {
-          value:
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
-          configurable: true,
-        });
+        vi.spyOn(deviceService, 'isSafari').mockReturnValue(true);
       });
 
       afterEach(() => {

--- a/src/app/drive/services/downloadManager.service.ts
+++ b/src/app/drive/services/downloadManager.service.ts
@@ -30,6 +30,7 @@ import {
 } from '../types/download-types';
 import { downloadWorkerHandler } from './worker.service/downloadWorkerHandler';
 import { isFileEmpty } from 'utils/isFileEmpty';
+import deviceService from 'services/device.service';
 
 export type DownloadCredentials = {
   credentials: NetworkCredentials;
@@ -510,7 +511,7 @@ export class DownloadManagerService {
   }) => {
     const shouldDownloadUsingBlob =
       !!(navigator.brave && (await navigator.brave.isBrave())) ||
-      (navigator.userAgent.includes('Safari') && payload.file.type === null);
+      (deviceService.isSafari() && payload.file.type === null);
 
     const worker: Worker = downloadWorkerHandler.getWorker();
 

--- a/src/app/drive/services/downloadManager.service.ts
+++ b/src/app/drive/services/downloadManager.service.ts
@@ -508,7 +508,9 @@ export class DownloadManagerService {
     abortController?: AbortController;
     sharingOptions: { credentials: { user: string; pass: string }; mnemonic: string };
   }) => {
-    const isBrave = !!(navigator.brave && (await navigator.brave.isBrave()));
+    const shouldDownloadUsingBlob =
+      !!(navigator.brave && (await navigator.brave.isBrave())) ||
+      (navigator.userAgent.includes('Safari') && payload.file.type === null);
 
     const worker: Worker = downloadWorkerHandler.getWorker();
 
@@ -516,7 +518,7 @@ export class DownloadManagerService {
       file: payload.file,
       isWorkspace: payload.isWorkspace,
       credentials: payload.sharingOptions,
-      isBrave,
+      shouldDownloadUsingBlob,
     };
 
     worker.postMessage({ type: 'download', params: workerPayload });

--- a/src/app/i18n/locales/es.json
+++ b/src/app/i18n/locales/es.json
@@ -1352,7 +1352,7 @@
     },
     "generalErrorMessages": {
       "retryUploadFailed": "Algo salió mal al reintentar la subida. Intenta subirlo de nuevo",
-      "retryDownloadFailed": "Algo salió mal al reintentar la subida. Intenta la descarga de nuevo",
+      "retryDownloadFailed": "Algo salió mal al reintentar la descarga. Intenta la descarga de nuevo",
       "openUploadedFileFailed": "Algo salió mal al intentar abrir el archivo",
       "openUploadedFolderFailed": "Algo salió mal al intentar navegar hasta la carpeta"
     }

--- a/src/app/workers/downloadWorker.test.ts
+++ b/src/app/workers/downloadWorker.test.ts
@@ -32,7 +32,7 @@ describe('Download Worker', () => {
   const mockParams = {
     file: mockFile,
     isWorkspace: false,
-    isBrave: false,
+    shouldDownloadUsingBlob: false,
     credentials: { user: 'test', pass: 'test' },
   } as DownloadFilePayload;
 
@@ -142,7 +142,7 @@ describe('Download Worker', () => {
     });
 
     test('When downloading a file for Brave browser, then it should use blob', async () => {
-      const braveParams = { ...mockParams, isBrave: true };
+      const braveParams = { ...mockParams, shouldDownloadUsingBlob: true };
       const mockedChunks = [new Uint8Array([1, 2, 3])];
       const mockedBlob = new Blob(mockedChunks, { type: mockFile.type });
       const mockReader = {
@@ -274,7 +274,7 @@ describe('Download Worker', () => {
     });
 
     test('When downloading as blob, then a single blob is created from the stream', async () => {
-      const braveParams = { ...mockParams, isBrave: true };
+      const braveParams = { ...mockParams, shouldDownloadUsingBlob: true };
       const mockedBlob = new Blob([new Uint8Array([1, 2, 3, 4, 5, 6])], { type: mockFile.type });
 
       const mockStream = {

--- a/src/app/workers/downloadWorker.ts
+++ b/src/app/workers/downloadWorker.ts
@@ -12,7 +12,7 @@ export class DownloadWorker {
   private constructor() {}
 
   async downloadFile(params: DownloadFilePayload, callbacks: DownloadFileCallback, abortController?: AbortController) {
-    const { file, isWorkspace, isBrave, credentials } = params;
+    const { file, isWorkspace, shouldDownloadUsingBlob, credentials } = params;
     this.abortController = abortController ?? new AbortController();
 
     let streamReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
@@ -41,7 +41,7 @@ export class DownloadWorker {
 
       this.abortController.signal.addEventListener('abort', abortHandler);
 
-      if (isBrave) {
+      if (shouldDownloadUsingBlob) {
         const blob = await binaryStreamToBlob(downloadedFile, file.type);
         callbacks.onBlob(blob);
       } else {

--- a/src/app/workers/types/download.ts
+++ b/src/app/workers/types/download.ts
@@ -3,7 +3,7 @@ import { DriveFileData } from 'app/drive/types';
 export interface DownloadFilePayload {
   file: DriveFileData;
   isWorkspace: boolean;
-  isBrave: boolean;
+  shouldDownloadUsingBlob: boolean;
   credentials: any;
 }
 

--- a/src/download.worker.ts
+++ b/src/download.worker.ts
@@ -25,7 +25,12 @@ const handleMessage = async (event: MessageEvent) => {
 
 self.addEventListener('message', handleMessage);
 
-const handleDownload = async (params: { file: any; isWorkspace: boolean; isBrave: boolean; credentials: any }) => {
+const handleDownload = async (params: {
+  file: any;
+  isWorkspace: boolean;
+  shouldDownloadUsingBlob: boolean;
+  credentials: any;
+}) => {
   abortRequested = false;
   abortController = new AbortController();
 

--- a/src/services/device.service.ts
+++ b/src/services/device.service.ts
@@ -1,4 +1,4 @@
-import { isMobile, isAndroid, isIOS } from 'react-device-detect';
+import { isMobile, isAndroid, isIOS, isSafari } from 'react-device-detect';
 
 const deviceService = {
   isMobile(): boolean {
@@ -12,6 +12,9 @@ const deviceService = {
         globalThis.location.href = 'https://apps.apple.com/us/app/internxt-drive-secure-file-storage/id1465869889';
       }
     }
+  },
+  isSafari(): boolean {
+    return isSafari;
   },
 };
 

--- a/src/services/stream.service.test.ts
+++ b/src/services/stream.service.test.ts
@@ -7,6 +7,7 @@ import {
   binaryStreamToUint8Array,
   buildProgressStream,
   joinReadableBinaryStreams,
+  DEFAULT_BLOB_MIME_TYPE,
 } from './stream.service';
 import { getDecryptedStream } from 'app/network/download';
 
@@ -44,7 +45,7 @@ describe('Stream service', () => {
   });
 
   describe('binaryStreamToBlob', () => {
-    it('should convert a binary stream to a blob without mime type', async () => {
+    it('should convert a binary stream to a blob with the default mime type', async () => {
       const mockData = [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])];
       const stream = new ReadableStream<Uint8Array>({
         start(controller) {
@@ -59,7 +60,7 @@ describe('Stream service', () => {
 
       expect(blob).toBeInstanceOf(Blob);
       expect(blob.size).toBe(6);
-      expect(blob.type).toBe('');
+      expect(blob.type).toStrictEqual(DEFAULT_BLOB_MIME_TYPE);
     });
 
     it('should convert a binary stream to a blob with mime type', async () => {

--- a/src/services/stream.service.ts
+++ b/src/services/stream.service.ts
@@ -21,7 +21,7 @@ export async function binaryStreamToBlob(stream: BinaryStream, mimeType?: string
     finish = done;
   }
 
-  return new Blob(slices as BlobPart[], mimeType ? { type: mimeType } : { type: DEFAULT_BLOB_MIME_TYPE });
+  return new Blob(slices as BlobPart[], { type: mimeType ?? DEFAULT_BLOB_MIME_TYPE });
 }
 
 export async function binaryStreamToUint8Array(

--- a/src/services/stream.service.ts
+++ b/src/services/stream.service.ts
@@ -3,6 +3,8 @@ import crypto, { Decipher } from 'crypto';
 
 type BinaryStream = ReadableStream<Uint8Array>;
 
+export const DEFAULT_BLOB_MIME_TYPE = 'application/octet-stream';
+
 export async function binaryStreamToBlob(stream: BinaryStream, mimeType?: string): Promise<Blob> {
   const reader = stream.getReader();
   const slices: Uint8Array[] = [];
@@ -19,7 +21,7 @@ export async function binaryStreamToBlob(stream: BinaryStream, mimeType?: string
     finish = done;
   }
 
-  return new Blob(slices as BlobPart[], mimeType ? { type: mimeType } : {});
+  return new Blob(slices as BlobPart[], mimeType ? { type: mimeType } : { type: DEFAULT_BLOB_MIME_TYPE });
 }
 
 export async function binaryStreamToUint8Array(

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,5 +1,5 @@
-import { dirname, resolve } from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineWorkspace } from 'vitest/config';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/yarn.lock
+++ b/yarn.lock
@@ -7953,12 +7953,12 @@ react-bootstrap@^2.9.0:
     uncontrollable "^7.2.1"
     warning "^4.0.3"
 
-react-device-detect@^1.15.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-1.17.0.tgz#a00b4fd6880cebfab3fd8a42a79dc0290cdddca9"
-  integrity sha512-bBblIStwpHmoS281JFIVqeimcN3LhpoP5YKDWzxQdBIUP8S2xPvHDgizLDhUq2ScguLfVPmwfF5y268EEQR60w==
+react-device-detect@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-2.2.3.tgz#97a7ae767cdd004e7c3578260f48cf70c036e7ca"
+  integrity sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==
   dependencies:
-    ua-parser-js "^0.7.24"
+    ua-parser-js "^1.0.33"
 
 react-dnd-html5-backend@^14.0.0:
   version "14.1.0"
@@ -9313,10 +9313,10 @@ typescript@^4.4.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-ua-parser-js@^0.7.24:
-  version "0.7.36"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.36.tgz#382c5d6fc09141b6541be2cae446ecfcec284db2"
-  integrity sha512-CPPLoCts2p7D8VbybttE3P2ylv0OBZEAy7a12DsulIEcAiMtWJy+PBgMXgWDI80D5UwqE8oQPHYnk13tm38M2Q==
+ua-parser-js@^1.0.33:
+  version "1.0.41"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.41.tgz#bd04dc9ec830fcf9e4fad35cf22dcedd2e3b4e9c"
+  integrity sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==
 
 uncontrollable@^7.2.1:
   version "7.2.1"


### PR DESCRIPTION
## Description

Fixed an issue where browsers were adding a random file extension when downloading files without an extension. For StreamSaver-based downloads, the `DefaultType: none` header is now used, and for Blob-based downloads, the Blob is created with type: `application/octet-stream`.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [x] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
