### PR TITLE
[_]: chore/add captcha token to public key precreation call

### DIFF
--- a/src/app/core/factory/sdk/index.ts
+++ b/src/app/core/factory/sdk/index.ts
@@ -80,9 +80,11 @@ export class SdkFactory {
     return Trash.client(apiUrl, appDetails, apiSecurity);
   }
 
-  public createUsersClient(): Users {
+  public createUsersClient(captchaToken?: string): Users {
+    const customHeaders = this.buildCustomHeaders({ captchaToken });
+
     const apiUrl = this.getApiUrl();
-    const appDetails = SdkFactory.getAppDetails();
+    const appDetails = SdkFactory.getAppDetails(customHeaders);
     const apiSecurity = this.getNewApiSecurity();
     return Users.client(apiUrl, appDetails, apiSecurity);
   }
@@ -143,10 +145,11 @@ export class SdkFactory {
     return this.apiUrl;
   }
 
-  private static getAppDetails(): AppDetails {
+  private static getAppDetails(customerHeaders?: Record<string, string>): AppDetails {
     return {
       clientName: packageJson.name,
       clientVersion: packageJson.version,
+      ...customerHeaders,
     };
   }
 
@@ -155,14 +158,6 @@ export class SdkFactory {
       clientName: 'drive-desktop',
       clientVersion: packageJson.version,
     };
-  }
-
-  private getToken(workspace: string): Token {
-    const tokenByWorkspace: { [key in Workspace]: string } = {
-      [Workspace.Individuals]: SdkFactory.sdk.localStorage.get('xToken') || '',
-      [Workspace.Business]: SdkFactory.sdk.localStorage.get('xTokenTeam') || '',
-    };
-    return tokenByWorkspace[workspace];
   }
 
   private getNewToken(workspace: string): Token {
@@ -185,5 +180,15 @@ export class SdkFactory {
       }
     }
     return token;
+  }
+
+  private buildCustomHeaders(options?: { captchaToken?: string }): Record<string, string> {
+    const headers: Record<string, string> = {};
+
+    if (options?.captchaToken) {
+      headers['x-internxt-captcha'] = options.captchaToken;
+    }
+
+    return headers;
   }
 }

--- a/src/app/store/slices/sharedLinks/index.test.ts
+++ b/src/app/store/slices/sharedLinks/index.test.ts
@@ -33,6 +33,9 @@ describe('Encryption and Decryption', () => {
         getPublicKeyWithPrecreation: vi.fn(),
       },
     }));
+    vi.mock('utils', () => ({
+      generateCaptchaToken: vi.fn().mockResolvedValue('mock-captcha-token'),
+    }));
 
     vi.mock('services/error.service', () => ({
       default: {

--- a/src/app/store/slices/sharedLinks/index.ts
+++ b/src/app/store/slices/sharedLinks/index.ts
@@ -11,6 +11,7 @@ import { UserRoles } from 'app/share/types';
 import { t } from 'i18next';
 import userService from 'services/user.service';
 import { hybridEncryptMessageWithPublicKey } from '../../../crypto/services/pgp.service';
+import { generateCaptchaToken } from 'utils';
 
 export const HYBRID_ALGORITHM = 'hybrid';
 export const STANDARD_ALGORITHM = 'ed25519';
@@ -54,7 +55,8 @@ const shareItemWithUser = createAsyncThunk<string | void, ShareFileWithUserPaylo
       }
       const { mnemonic } = user;
 
-      const publicKeyResponse = await userService.getPublicKeyWithPrecreation(payload.sharedWith);
+      const captchaToken = await generateCaptchaToken();
+      const publicKeyResponse = await userService.getPublicKeyWithPrecreation(payload.sharedWith, captchaToken);
 
       const publicKey = publicKeyResponse.publicKey;
       const publicKyberKey = publicKeyResponse?.publicKyberKey ?? '';

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -67,8 +67,11 @@ const getPublicKeyByEmail = (email: string): Promise<UserPublicKeyResponse> => {
   return usersClient.getPublicKeyByEmail({ email });
 };
 
-const getPublicKeyWithPrecreation = (email: string): Promise<UserPublicKeyWithCreationResponse> => {
-  const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
+const getPublicKeyWithPrecreation = (
+  email: string,
+  captchaToken: string,
+): Promise<UserPublicKeyWithCreationResponse> => {
+  const usersClient = SdkFactory.getNewApiInstance().createUsersClient(captchaToken);
   return usersClient.getPublicKeyWithPrecreation({ email });
 };
 


### PR DESCRIPTION
## Description

Send the captcha token using the x-internxt-captcha header when making the call to obtain the public key of a previously created user.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [ ] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
