### PR TITLE
[_]: chore/add captcha when inviting a user to a shared item

### DIFF
--- a/src/app/core/factory/sdk/index.test.ts
+++ b/src/app/core/factory/sdk/index.test.ts
@@ -195,6 +195,7 @@ describe('SdkFactory', () => {
           {
             clientName: packageJson.name,
             clientVersion: packageJson.version,
+            customHeaders: {},
           },
           expect.any(Object),
         );
@@ -219,7 +220,9 @@ describe('SdkFactory', () => {
           {
             clientName: packageJson.name,
             clientVersion: packageJson.version,
-            'x-internxt-captcha': captchaToken,
+            customHeaders: {
+              'x-internxt-captcha': captchaToken,
+            },
           },
           expect.any(Object),
         );
@@ -245,6 +248,7 @@ describe('SdkFactory', () => {
           {
             clientName: packageJson.name,
             clientVersion: packageJson.version,
+            customHeaders: {},
           },
           expect.any(Object),
         );
@@ -269,7 +273,9 @@ describe('SdkFactory', () => {
           {
             clientName: packageJson.name,
             clientVersion: packageJson.version,
-            'x-internxt-captcha': captchaToken,
+            customHeaders: {
+              'x-internxt-captcha': captchaToken,
+            },
           },
           expect.any(Object),
         );

--- a/src/app/core/factory/sdk/index.test.ts
+++ b/src/app/core/factory/sdk/index.test.ts
@@ -4,7 +4,7 @@ import { LocalStorageService } from 'services/local-storage.service';
 import { userThunks } from '../../../store/slices/user';
 import { Workspace } from '../../types';
 import { STORAGE_KEYS } from 'services/storage-keys';
-import { Users } from '@internxt/sdk/dist/drive';
+import { Share, Users } from '@internxt/sdk/dist/drive';
 import packageJson from '../../../../../package.json';
 
 const MOCKED_NEW_API = 'https://api.internxt.com';
@@ -12,6 +12,9 @@ const MOCKED_PAYMENTS = 'https://payments.internxt.com';
 
 vi.mock('@internxt/sdk/dist/drive', () => ({
   Users: {
+    client: vi.fn(),
+  },
+  Share: {
     client: vi.fn(),
   },
 }));
@@ -212,6 +215,56 @@ describe('SdkFactory', () => {
         instance.createUsersClient(captchaToken);
 
         expect(Users.client).toHaveBeenCalledWith(
+          MOCKED_NEW_API,
+          {
+            clientName: packageJson.name,
+            clientVersion: packageJson.version,
+            'x-internxt-captcha': captchaToken,
+          },
+          expect.any(Object),
+        );
+      });
+    });
+
+    describe('Creating the share client', () => {
+      test('When the Share creates the client without captcha, then the app details are the defined by default', () => {
+        const mockToken = 'test-token';
+        const mockWorkspace = Workspace.Individuals;
+
+        vi.spyOn(mockLocalStorage, 'getWorkspace').mockReturnValue(mockWorkspace);
+        vi.spyOn(mockLocalStorage, 'get').mockImplementation((key: string) => {
+          if (key === 'xNewToken') return mockToken;
+          return null;
+        });
+
+        const instance = SdkFactory.getNewApiInstance();
+        instance.createShareClient();
+
+        expect(Share.client).toHaveBeenCalledWith(
+          MOCKED_NEW_API,
+          {
+            clientName: packageJson.name,
+            clientVersion: packageJson.version,
+          },
+          expect.any(Object),
+        );
+      });
+
+      test('When the Share creates the client with captcha, then the app details include the captcha header', () => {
+        const mockToken = 'test-token';
+        const mockWorkspace = Workspace.Individuals;
+        const captchaToken = 'captcha-token-123';
+
+        vi.spyOn(mockLocalStorage, 'getWorkspace').mockReturnValue(mockWorkspace);
+        vi.spyOn(mockLocalStorage, 'get').mockImplementation((key: string) => {
+          if (key === 'xNewToken') return mockToken;
+          return null;
+        });
+
+        const instance = SdkFactory.getNewApiInstance();
+        instance.createShareClient(captchaToken);
+
+        expect(Share.client).toHaveBeenCalledWith(
           MOCKED_NEW_API,
           {
             clientName: packageJson.name,

--- a/src/app/core/factory/sdk/index.ts
+++ b/src/app/core/factory/sdk/index.ts
@@ -66,9 +66,11 @@ export class SdkFactory {
     return Workspaces.client(apiUrl, appDetails, apiSecurity);
   }
 
-  public createShareClient(): Share {
+  public createShareClient(captchaToken?: string): Share {
+    const customHeaders = this.buildCustomHeaders({ captchaToken });
+
     const apiUrl = this.getApiUrl();
-    const appDetails = SdkFactory.getAppDetails();
+    const appDetails = SdkFactory.getAppDetails(customHeaders);
     const apiSecurity = this.getNewApiSecurity();
     return Share.client(apiUrl, appDetails, apiSecurity);
   }

--- a/src/app/core/factory/sdk/index.ts
+++ b/src/app/core/factory/sdk/index.ts
@@ -147,11 +147,11 @@ export class SdkFactory {
     return this.apiUrl;
   }
 
-  private static getAppDetails(customerHeaders?: Record<string, string>): AppDetails {
+  private static getAppDetails(customHeaders?: Record<string, string>): AppDetails {
     return {
       clientName: packageJson.name,
       clientVersion: packageJson.version,
-      ...customerHeaders,
+      customHeaders,
     };
   }
 

--- a/src/app/share/services/share.service.ts
+++ b/src/app/share/services/share.service.ts
@@ -36,6 +36,7 @@ import { DownloadManager } from '../../network/DownloadManager';
 import notificationsService, { ToastType } from '../../notifications/services/notifications.service';
 import { AdvancedSharedItem } from '../types';
 import { domainManager } from './DomainManager';
+import { generateCaptchaToken } from 'utils';
 
 interface CreateShareResponse {
   created: boolean;
@@ -158,8 +159,9 @@ export function getSharingRoles(): Promise<Role[]> {
   });
 }
 
-export function inviteUserToSharedFolder(props: ShareFolderWithUserPayload): Promise<SharingInvite> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+export async function inviteUserToSharedFolder(props: ShareFolderWithUserPayload): Promise<SharingInvite> {
+  const captchaToken = await generateCaptchaToken();
+  const shareClient = SdkFactory.getNewApiInstance().createShareClient(captchaToken);
   return shareClient.inviteUserToSharedFolder({ ...props }).catch((error) => {
     throw errorService.castError(error);
   });

--- a/src/app/store/slices/sharedLinks/index.ts
+++ b/src/app/store/slices/sharedLinks/index.ts
@@ -11,7 +11,6 @@ import { UserRoles } from 'app/share/types';
 import { t } from 'i18next';
 import userService from 'services/user.service';
 import { hybridEncryptMessageWithPublicKey } from '../../../crypto/services/pgp.service';
-import { generateCaptchaToken } from 'utils';
 
 export const HYBRID_ALGORITHM = 'hybrid';
 export const STANDARD_ALGORITHM = 'ed25519';
@@ -55,8 +54,7 @@ const shareItemWithUser = createAsyncThunk<string | void, ShareFileWithUserPaylo
       }
       const { mnemonic } = user;
 
-      const captchaToken = await generateCaptchaToken();
-      const publicKeyResponse = await userService.getPublicKeyWithPrecreation(payload.sharedWith, captchaToken);
+      const publicKeyResponse = await userService.getPublicKeyWithPrecreation(payload.sharedWith);
 
       const publicKey = publicKeyResponse.publicKey;
       const publicKyberKey = publicKeyResponse?.publicKyberKey ?? '';

--- a/src/services/user.service.test.ts
+++ b/src/services/user.service.test.ts
@@ -41,6 +41,10 @@ vi.mock('../app/core/factory/sdk', () => ({
   },
 }));
 
+vi.mock('utils', () => ({
+  generateCaptchaToken: vi.fn().mockResolvedValue('mocked-captcha-token'),
+}));
+
 describe('userService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -123,6 +127,7 @@ describe('userService', () => {
       publicKey: 'key123',
       publicKyberKey: 'kyberKey456',
     };
+    const captchaToken = 'mocked-captcha-token';
     usersClientMock.getPublicKeyWithPrecreation.mockResolvedValue(mockResponse);
 
     const result = await userService.getPublicKeyWithPrecreation(testEmail);

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -9,6 +9,7 @@ import {
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import localStorageService from 'services/local-storage.service';
 import { SdkFactory } from 'app/core/factory/sdk';
+import { generateCaptchaToken } from 'utils';
 
 export const sendDeactivationEmail = (): Promise<void> => {
   const authClient = SdkFactory.getNewApiInstance().createAuthClient();
@@ -67,10 +68,8 @@ const getPublicKeyByEmail = (email: string): Promise<UserPublicKeyResponse> => {
   return usersClient.getPublicKeyByEmail({ email });
 };
 
-const getPublicKeyWithPrecreation = (
-  email: string,
-  captchaToken: string,
-): Promise<UserPublicKeyWithCreationResponse> => {
+const getPublicKeyWithPrecreation = async (email: string): Promise<UserPublicKeyWithCreationResponse> => {
+  const captchaToken = await generateCaptchaToken();
   const usersClient = SdkFactory.getNewApiInstance().createUsersClient(captchaToken);
   return usersClient.getPublicKeyWithPrecreation({ email });
 };


### PR DESCRIPTION
## Description

Adding the captcha token when inviting a user to a Shared item. The captcha token is generated and added to the Shared client so we can send it via headers.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [ ] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
