### PR TITLE
[_]: chore/captcha token for some API calls

### DIFF
--- a/src/app/core/factory/sdk/index.ts
+++ b/src/app/core/factory/sdk/index.ts
@@ -38,9 +38,9 @@ export class SdkFactory {
     return this.sdk.newApiInstance;
   }
 
-  public createAuthClient(options?: { unauthorizedCallback?: () => void }): Auth {
+  public createAuthClient(options?: { captchaToken?: string; unauthorizedCallback?: () => void }): Auth {
     const apiUrl = this.getApiUrl();
-    const appDetails = SdkFactory.getAppDetails();
+    const appDetails = this.getAppDetailsWithHeaders(options?.captchaToken);
     const apiSecurity = this.getNewApiSecurity(options?.unauthorizedCallback);
     return Auth.client(apiUrl, appDetails, apiSecurity);
   }
@@ -67,10 +67,8 @@ export class SdkFactory {
   }
 
   public createShareClient(captchaToken?: string): Share {
-    const customHeaders = this.buildCustomHeaders({ captchaToken });
-
     const apiUrl = this.getApiUrl();
-    const appDetails = SdkFactory.getAppDetails(customHeaders);
+    const appDetails = this.getAppDetailsWithHeaders(captchaToken);
     const apiSecurity = this.getNewApiSecurity();
     return Share.client(apiUrl, appDetails, apiSecurity);
   }
@@ -83,10 +81,8 @@ export class SdkFactory {
   }
 
   public createUsersClient(captchaToken?: string): Users {
-    const customHeaders = this.buildCustomHeaders({ captchaToken });
-
     const apiUrl = this.getApiUrl();
-    const appDetails = SdkFactory.getAppDetails(customHeaders);
+    const appDetails = this.getAppDetailsWithHeaders(captchaToken);
     const apiSecurity = this.getNewApiSecurity();
     return Users.client(apiUrl, appDetails, apiSecurity);
   }
@@ -153,6 +149,11 @@ export class SdkFactory {
       clientVersion: packageJson.version,
       customHeaders,
     };
+  }
+
+  private getAppDetailsWithHeaders(captchaToken?: string): AppDetails {
+    const customHeaders = captchaToken ? this.buildCustomHeaders({ captchaToken }) : undefined;
+    return SdkFactory.getAppDetails(customHeaders);
   }
 
   private static getDesktopAppDetails(): AppDetails {

--- a/src/services/auth.service.test.ts
+++ b/src/services/auth.service.test.ts
@@ -128,6 +128,9 @@ beforeAll(() => {
       generateMnemonic: vi.fn(),
     };
   });
+  vi.mock('utils', () => ({
+    generateCaptchaToken: vi.fn(),
+  }));
 });
 
 beforeEach(() => {

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -43,6 +43,7 @@ import { generateMnemonic, validateMnemonic } from 'bip39';
 import { SdkFactory } from 'app/core/factory/sdk';
 import errorService from 'services/error.service';
 import vpnAuthService from './vpnAuth.service';
+import { generateCaptchaToken } from 'utils';
 
 type ProfileInfo = {
   user: UserSettings;
@@ -535,13 +536,15 @@ const extractOneUseCredentialsForAutoSubmit = (
   }
 };
 
-const sendChangePasswordEmail = (email: string): Promise<void> => {
-  const authClient = SdkFactory.getNewApiInstance().createAuthClient();
+const sendChangePasswordEmail = async (email: string): Promise<void> => {
+  const captchaToken = await generateCaptchaToken();
+  const authClient = SdkFactory.getNewApiInstance().createAuthClient({ captchaToken });
   return authClient.sendChangePasswordEmail(email);
 };
 
-export const requestUnblockAccount = (email: string): Promise<void> => {
-  const authClient = SdkFactory.getNewApiInstance().createAuthClient();
+export const requestUnblockAccount = async (email: string): Promise<void> => {
+  const captchaToken = await generateCaptchaToken();
+  const authClient = SdkFactory.getNewApiInstance().createAuthClient({ captchaToken });
   return authClient.requestUnblockAccount(email);
 };
 

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -57,8 +57,9 @@ const deleteUserAvatar = (): Promise<void> => {
   return usersClient.deleteUserAvatar(token);
 };
 
-const sendVerificationEmail = (): Promise<void> => {
-  const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
+const sendVerificationEmail = async (): Promise<void> => {
+  const captchaToken = await generateCaptchaToken();
+  const usersClient = SdkFactory.getNewApiInstance().createUsersClient(captchaToken);
   const token = localStorageService.get('xNewToken') ?? undefined;
   return usersClient.sendVerificationEmail(token);
 };
@@ -74,8 +75,9 @@ const getPublicKeyWithPrecreation = async (email: string): Promise<UserPublicKey
   return usersClient.getPublicKeyWithPrecreation({ email });
 };
 
-const changeEmail = (newEmail: string): Promise<void> => {
-  const authClient = SdkFactory.getNewApiInstance().createUsersClient();
+const changeEmail = async (newEmail: string): Promise<void> => {
+  const captchaToken = await generateCaptchaToken();
+  const authClient = SdkFactory.getNewApiInstance().createUsersClient(captchaToken);
   return authClient.changeUserEmail(newEmail);
 };
 

--- a/src/views/Signup/hooks/useSignup.test.ts
+++ b/src/views/Signup/hooks/useSignup.test.ts
@@ -4,6 +4,10 @@ import * as bip39 from 'bip39';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useSignUp } from './useSignup';
 
+vi.mock('utils', () => ({
+  generateCaptchaToken: vi.fn(),
+}));
+
 vi.mock('@internxt/lib', () => ({
   aes: {
     encrypt: vi.fn().mockReturnValue('mock-encrypted'),

--- a/src/views/Signup/hooks/useSignup.ts
+++ b/src/views/Signup/hooks/useSignup.ts
@@ -6,6 +6,7 @@ import { readReferalCookie, RegisterFunction } from 'services/auth.service';
 import { SdkFactory } from '../../../app/core/factory/sdk';
 import { getKeys } from '../../../app/crypto/services/keys.service';
 import { decryptTextWithKey, encryptText, encryptTextWithKey, passToHash } from '../../../app/crypto/services/utils';
+import { generateCaptchaToken } from 'utils';
 
 type RegisterPreCreatedUser = (
   email: string,
@@ -100,7 +101,10 @@ export function useSignUp(referrer?: string): {
   };
 
   const doRegisterPreCreatedUser = async (email: string, password: string, invitationId: string, captcha: string) => {
-    const authClient = SdkFactory.getNewApiInstance().createAuthClient();
+    const captchaToken = await generateCaptchaToken();
+    const authClient = SdkFactory.getNewApiInstance().createAuthClient({
+      captchaToken,
+    });
 
     const registerDetails = await generateRegisterDetails(email, password, captcha);
 


### PR DESCRIPTION
## Description

Adding captcha token for some API calls related to auth and users. The modified functions are:
- `sendChangePasswordEmail`
- `requestUnblockAccount`
- `sendVerificationEmail`
- `changeEmail`
- `doRegisterPreCreatedUser`

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
