### PR TITLE
[_]: fix/fetch price without coupon if it does not exists

### DIFF
--- a/src/views/Checkout/views/CheckoutViewWrapper.tsx
+++ b/src/views/Checkout/views/CheckoutViewWrapper.tsx
@@ -62,18 +62,18 @@ const CheckoutViewWrapper = () => {
   const { planId, promotionCode, currency, paramMobileToken, gclid } = useCheckoutQueryParams();
   const { location: userLocationData } = useUserLocation();
 
+  const { couponError, promoCodeData, onPromoCodeError, removeCouponCode, fetchPromotionCode } = usePromotionalCode({
+    priceId: planId,
+    promoCodeName: promotionCode,
+  });
+
   const { selectedPlan, businessSeats, fetchSelectedPlan } = useProducts({
     currency: currency ?? 'eur',
     translate,
     planId,
-    promotionCode: promotionCode ?? undefined,
+    promotionCode: promoCodeData?.codeName ?? undefined,
     userLocation: userLocationData?.location,
     userAddress: userLocationData?.ip,
-  });
-
-  const { couponError, promoCodeData, onPromoCodeError, removeCouponCode, fetchPromotionCode } = usePromotionalCode({
-    priceId: planId,
-    promoCodeName: promotionCode,
   });
 
   const { isCheckoutReady, stripeElementsOptions, availableCryptoCurrencies, stripeSdk } = useInitializeCheckout({


### PR DESCRIPTION
## Description

The problem is that we need the coupon code to calculate taxes, so we etch the price by ID and coupon code. If the coupon code does not exist, then the price is not fetched correctly. It causes some problems - the checkout was not loading - when the coupon, for example, has been removed and the user comes from the website.

Now, we fetch the promotional code before so we can check if it exists. If so, then we use the fetched coupon data to fetch the price with that coupon.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [ ] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
