### PR TITLE
[BR-1819]: fix/uploading files to workspaces

### DIFF
--- a/src/app/drive/services/file.service/uploadFile.test.ts
+++ b/src/app/drive/services/file.service/uploadFile.test.ts
@@ -60,7 +60,7 @@ describe('Create File Entry', () => {
     const bucketId = 'bucket-123';
     const fileId = 'file-id-123';
     const workspaceId = 'workspace-456';
-    const resourcesToken = 'resources-token';
+    const resourcesToken = undefined;
 
     const expectedResponse = { id: 'created-file-id', name: file.name } as unknown as DriveFileData;
     const workspaceServiceSpy = vi.spyOn(workspacesService, 'createFileEntry').mockResolvedValue(expectedResponse);
@@ -158,6 +158,104 @@ describe('Create File Entry', () => {
 describe('Uploading a file', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  test('When uploading a workspace file with resources token, then should be used to create a file entry', async () => {
+    const file: FileToUpload = {
+      name: 'test-file',
+      size: 1024,
+      type: 'pdf',
+      content: new File(['content'], 'test-file.pdf'),
+      parentFolderId: 'folder-uuid-123',
+    };
+    const bucketId = 'bucket-123';
+    const resourcesToken = 'actual-resources-token';
+    const workspacesToken = 'workspaces-token';
+    const workspaceId = 'workspace-123';
+
+    const expectedResponse = { id: 'file-id', name: file.name, uuid: 'uuid-123', thumbnails: [] };
+    const workspaceServiceSpy = vi
+      .spyOn(workspacesService, 'createFileEntry')
+      .mockResolvedValue(expectedResponse as unknown as DriveFileData);
+
+    const mockUploadFile = vi.fn().mockReturnValue([Promise.resolve('file-id-123'), { abort: vi.fn() }]);
+    mockNetwork.mockImplementation(
+      () =>
+        ({
+          uploadFile: mockUploadFile,
+        }) as any,
+    );
+
+    await uploadFile(
+      'user@test',
+      file,
+      vi.fn(),
+      {
+        isTeam: false,
+        ownerUserAuthenticationData: {
+          bridgePass: 'pass',
+          bridgeUser: 'user',
+          encryptionKey: 'key',
+          bucketId,
+          token: 'token',
+          resourcesToken,
+          workspaceId,
+          workspacesToken,
+        },
+      },
+      { taskId: 'task-1', isPaused: false, isRetriedUpload: false },
+    );
+
+    expect(workspaceServiceSpy).toHaveBeenCalledWith(expect.any(Object), workspaceId, resourcesToken);
+  });
+
+  test('When uploading a workspace file without resources token, then it should not be used to create a file entry', async () => {
+    const file: FileToUpload = {
+      name: 'test-file',
+      size: 1024,
+      type: 'pdf',
+      content: new File(['content'], 'test-file.pdf'),
+      parentFolderId: 'folder-uuid-123',
+    };
+    const bucketId = 'bucket-123';
+    const resourcesToken = undefined;
+    const workspaceId = 'workspace-123';
+    const workspacesToken = 'workspaces-token';
+
+    const expectedResponse = { id: 'file-id', name: file.name, uuid: 'uuid-123', thumbnails: [] };
+    const workspaceServiceSpy = vi
+      .spyOn(workspacesService, 'createFileEntry')
+      .mockResolvedValue(expectedResponse as unknown as DriveFileData);
+
+    const mockUploadFile = vi.fn().mockReturnValue([Promise.resolve('file-id-123'), { abort: vi.fn() }]);
+    mockNetwork.mockImplementation(
+      () =>
+        ({
+          uploadFile: mockUploadFile,
+        }) as any,
+    );
+
+    await uploadFile(
+      'user@test',
+      file,
+      vi.fn(),
+      {
+        isTeam: false,
+        ownerUserAuthenticationData: {
+          bridgePass: 'pass',
+          bridgeUser: 'user',
+          encryptionKey: 'key',
+          bucketId,
+          token: 'token',
+          resourcesToken,
+          workspaceId,
+          workspacesToken,
+        },
+      },
+      { taskId: 'task-1', isPaused: false, isRetriedUpload: false },
+    );
+
+    expect(workspaceServiceSpy).toHaveBeenCalledWith(expect.any(Object), workspaceId, resourcesToken);
   });
 
   test('When uploading a file with size 0 and no workspace, then it should create file entry directly without uploading', async () => {

--- a/src/app/drive/services/file.service/uploadFile.ts
+++ b/src/app/drive/services/file.service/uploadFile.ts
@@ -10,10 +10,10 @@ import { getEnvironmentConfig } from '../network.service';
 import { generateThumbnailFromFile } from '../thumbnail.service';
 import { OwnerUserAuthenticationData } from 'app/network/types';
 import { FileToUpload } from './types';
-import { FileEntry } from '@internxt/sdk/dist/workspaces';
 import { DriveFileData } from '@internxt/sdk/dist/drive/storage/types';
 import { BucketNotFoundError, FileIdRequiredError } from './upload.errors';
 import { isFileEmpty } from 'utils/isFileEmpty';
+import { FileEntry } from '@internxt/sdk/dist/workspaces';
 
 export interface FileUploadOptions {
   isTeam: boolean;
@@ -104,7 +104,7 @@ export async function uploadFile(
     return createFileEntry({
       bucketId: bucketId,
       file,
-      resourcesToken: resourcesToken ?? workspacesToken,
+      resourcesToken: resourcesToken,
       workspaceId: workspaceId,
       ownerToken: workspacesToken,
     });
@@ -141,7 +141,7 @@ export async function uploadFile(
     fileId: fileId,
     file,
     isWorkspaceUpload: !!isWorkspacesUpload,
-    resourcesToken: resourcesToken ?? workspacesToken,
+    resourcesToken: resourcesToken,
     workspaceId: workspaceId,
     ownerToken: workspacesToken,
   });

--- a/src/app/network/types/index.ts
+++ b/src/app/network/types/index.ts
@@ -43,5 +43,5 @@ export interface OwnerUserAuthenticationData {
   // to manage B2B workspaces
   workspaceId?: string;
   workspacesToken?: string;
-  resourcesToken: string;
+  resourcesToken?: string;
 }


### PR DESCRIPTION
## Description

Use the resources token exclusively for file uploads to workspaces, and avoid using the workspace token as a resources token.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
