### PR TITLE
[_]: fix/fetch folder items after sending items to trash

### DIFF
--- a/src/views/Drive/components/DriveExplorer/components/DriveExplorerList.tsx
+++ b/src/views/Drive/components/DriveExplorer/components/DriveExplorerList.tsx
@@ -270,16 +270,14 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
   );
 
   const moveToTrash = useCallback(
-    (item: ContextMenuDriveItem) => {
-      const driveItem = item as DriveItemData;
-
+    (items: ContextMenuDriveItem[]) => {
       if (isSelectedSharedItem) {
         props.onOpenStopSharingAndMoveToTrashDialog();
       } else {
-        moveItemsToTrash([driveItem]);
+        moveItemsToTrash(items as DriveItemData[], () => dispatch(fetchSortedFolderContentThunk(currentFolderId)));
       }
     },
-    [isSelectedSharedItem, props.onOpenStopSharingAndMoveToTrashDialog, moveItemsToTrash],
+    [isSelectedSharedItem, props.onOpenStopSharingAndMoveToTrashDialog, moveItemsToTrash, dispatch],
   );
 
   const selectedItemsContextMenu = contextMenuSelectedItems({
@@ -295,9 +293,7 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
         workspaceCredentials,
       });
     },
-    moveToTrash: () => {
-      isSelectedSharedItems ? props.onOpenStopSharingAndMoveToTrashDialog() : moveItemsToTrash(props.selectedItems);
-    },
+    moveToTrash: () => moveToTrash(props.selectedItems),
   });
 
   const multipleSelectedTrashItemsContextMenu = contextMenuMultipleSelectedTrashItems({
@@ -354,7 +350,7 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
     renameItem: renameItem,
     moveItem: moveItem,
     downloadItem: downloadItem,
-    moveToTrash: moveToTrash,
+    moveToTrash: () => moveToTrash(props.selectedItems),
   });
 
   const selectedFileMenu = contextMenuDriveNotSharedLink({
@@ -365,7 +361,7 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
     renameItem: renameItem,
     moveItem: moveItem,
     downloadItem: downloadItem,
-    moveToTrash: moveToTrash,
+    moveToTrash: () => moveToTrash(props.selectedItems),
   });
 
   const shareWithTeam = () => {
@@ -381,7 +377,7 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
     renameItem: renameItem,
     moveItem: moveItem,
     downloadItem: downloadItem,
-    moveToTrash: moveToTrash,
+    moveToTrash: () => moveToTrash(props.selectedItems),
   });
 
   const workspaceFolderMenu = contextMenuWorkspaceFolder({
@@ -392,7 +388,7 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
     renameItem: renameItem,
     moveItem: moveItem,
     downloadItem: downloadItem,
-    moveToTrash: moveToTrash,
+    moveToTrash: () => moveToTrash(props.selectedItems),
   });
 
   const getContextMenu = () => {
@@ -502,9 +498,7 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
           keyBoardShortcutActions={{
             onBackspaceKeyPressed: () => {
               if (props.selectedItems.length) {
-                isSelectedSharedItems
-                  ? props.onOpenStopSharingAndMoveToTrashDialog()
-                  : moveItemsToTrash(props.selectedItems);
+                moveToTrash(props.selectedItems);
               }
             },
             onRKeyPressed: () => {

--- a/src/views/Drive/components/DriveExplorer/components/DriveExplorerList.tsx
+++ b/src/views/Drive/components/DriveExplorer/components/DriveExplorerList.tsx
@@ -277,7 +277,7 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
         moveItemsToTrash(items as DriveItemData[], () => dispatch(fetchSortedFolderContentThunk(currentFolderId)));
       }
     },
-    [isSelectedSharedItems, props.onOpenStopSharingAndMoveToTrashDialog, moveItemsToTrash, dispatch],
+    [isSelectedSharedItems, props.onOpenStopSharingAndMoveToTrashDialog, moveItemsToTrash, dispatch, currentFolderId],
   );
 
   const selectedItemsContextMenu = contextMenuSelectedItems({

--- a/src/views/Drive/components/DriveExplorer/components/DriveExplorerList.tsx
+++ b/src/views/Drive/components/DriveExplorer/components/DriveExplorerList.tsx
@@ -271,13 +271,13 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
 
   const moveToTrash = useCallback(
     (items: ContextMenuDriveItem[]) => {
-      if (isSelectedSharedItem) {
+      if (isSelectedSharedItems) {
         props.onOpenStopSharingAndMoveToTrashDialog();
       } else {
         moveItemsToTrash(items as DriveItemData[], () => dispatch(fetchSortedFolderContentThunk(currentFolderId)));
       }
     },
-    [isSelectedSharedItem, props.onOpenStopSharingAndMoveToTrashDialog, moveItemsToTrash, dispatch],
+    [isSelectedSharedItems, props.onOpenStopSharingAndMoveToTrashDialog, moveItemsToTrash, dispatch],
   );
 
   const selectedItemsContextMenu = contextMenuSelectedItems({


### PR DESCRIPTION
## Description

After sending items to trash, the folder was loading permanently. We need to fetch the folder content to display to the user the remaining items.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

1. Go to production > remove some items > see that the loading state is not changing after sending the items to the trash
2. Go to this preview link > remove some items > see that the remaining items are loading after the action

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
