### PR TITLE
[PB-5792]: fix/send resourcesToken when creating file entry for shared files

### DIFF
--- a/src/app/drive/services/file.service/uploadFile.ts
+++ b/src/app/drive/services/file.service/uploadFile.ts
@@ -77,7 +77,7 @@ export const createFileEntry = async ({
       date: date.toISOString(),
     };
 
-    return storageClient.createFileEntryByUuid(fileEntry, ownerToken);
+    return storageClient.createFileEntryByUuid(fileEntry, resourcesToken ?? ownerToken);
   }
 };
 

--- a/src/views/Shared/SharedView.tsx
+++ b/src/views/Shared/SharedView.tsx
@@ -405,6 +405,7 @@ function SharedView({
         encryptionKey: currentUser?.mnemonic,
         bucketId: currentUser.bucket,
         token,
+        resourcesToken: token,
       };
     } else {
       const mnemonicDecrypted =
@@ -416,6 +417,7 @@ function SharedView({
           encryptionKey: mnemonicDecrypted,
           bucketId: ownerBucket,
           token,
+          resourcesToken: token,
         };
       }
     }


### PR DESCRIPTION
## Description

Pass the resource token if it exists so the user can upload files to Shared folders as `Editor`.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [ ] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

Go to Drive > Try to upload a file
Go to Share > Try to upload a file in a Shared folder (as an `Editor`)

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
