### PR TITLE
[_]: fix/disallow ordering by size

### DIFF
--- a/src/views/Drive/components/DriveExplorer/components/DriveExplorerList.tsx
+++ b/src/views/Drive/components/DriveExplorer/components/DriveExplorerList.tsx
@@ -166,10 +166,6 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
         resetDriveOrder({ dispatch, orderType: 'updatedAt', direction, currentFolderId });
       }
     }
-
-    if (value.field === 'size') {
-      resetDriveOrder({ dispatch, orderType: 'size', direction, currentFolderId });
-    }
   };
 
   function handleMouseEnter() {
@@ -492,8 +488,7 @@ const DriveExplorerList: React.FC<DriveExplorerListProps> = memo((props) => {
             },
             {
               label: translate('drive.list.columns.size'),
-              orderable: !isRecents && !isTrash,
-              defaultDirection: 'ASC',
+              orderable: false,
               width: 'w-size',
               name: 'size',
             },


### PR DESCRIPTION
## Description

Removing the option of ordering the items by size in Drive.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [x] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
