### PR TITLE
[HOT-FIX]: prevent Google Translate from modifying the DOM by setting translate attribute to 'no'

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -77,6 +77,7 @@ store.dispatch(taskManagerThunks.initializeThunk());
 store.dispatch(referralsThunks.initializeThunk());
 
 const container = document.getElementById('root') as HTMLElement;
+container.setAttribute('translate', 'no');
 const root = createRoot(container);
 root.render(
   <React.StrictMode>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -77,7 +77,7 @@ store.dispatch(taskManagerThunks.initializeThunk());
 store.dispatch(referralsThunks.initializeThunk());
 
 const container = document.getElementById('root') as HTMLElement;
-container.setAttribute('translate', 'no');
+document.documentElement.setAttribute('translate', 'no');
 const root = createRoot(container);
 root.render(
   <React.StrictMode>


### PR DESCRIPTION
## Description

Prevent Google Translate from modifying the DOM by setting translate attribute to 'no'

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
