### PR TITLE
[_]: initialize Cello SDK and eligibility check at login instead of deferring to SidenavWrapper

### DIFF
--- a/src/app/network/UploadManager.test.ts
+++ b/src/app/network/UploadManager.test.ts
@@ -49,7 +49,7 @@ vi.mock('app/repositories/DatabaseUploadRepository', () => {
   };
 });
 
-vi.mock('i18next', () => ({ t: () => 'Translation message' }));
+vi.mock('i18next', () => ({ default: { language: 'en' }, t: () => 'Translation message' }));
 
 const openMaxSpaceOccupiedDialogMock = vi.fn();
 

--- a/src/app/store/slices/referrals/index.ts
+++ b/src/app/store/slices/referrals/index.ts
@@ -5,7 +5,7 @@ import usersReferralsService from 'app/referrals/services/users-referrals.servic
 import referralService from 'services/referral.service';
 
 import { ReferralKey, UserReferral } from '@internxt/sdk/dist/drive/referrals/types';
-import { t as translate } from 'i18next';
+import i18next, { t as translate } from 'i18next';
 import { RootState } from 'app/store';
 import { planThunks } from '../plan';
 import { uiActions } from '../ui';
@@ -31,6 +31,15 @@ const initializeThunk = createAsyncThunk<void, void, { state: RootState }>(
 
     if (isAuthenticated && hasReferralsProgram) {
       await dispatch(fetchUserReferralsThunk());
+    }
+
+    const user = userSelectors.getUser(getState());
+    if (isAuthenticated && user) {
+      referralService.boot(
+        { name: user.name, lastname: user.lastname, email: user.email, emailVerified: user.emailVerified },
+        i18next.language,
+      );
+      await dispatch(fetchIsEligibleThunk({ accountCreatedAt: user.createdAt ? new Date(user.createdAt) : undefined }));
     }
   },
 );

--- a/src/app/store/slices/user/index.ts
+++ b/src/app/store/slices/user/index.ts
@@ -9,7 +9,7 @@ import { deleteDatabaseProfileAvatar } from '../../../drive/services/database.se
 import { saveAvatarToDatabase } from '../../../../views/NewSettings/components/Sections/Account/Account/components/AvatarWrapper';
 import notificationsService, { ToastType } from '../../../notifications/services/notifications.service';
 import tasksService from '../../../tasks/services/tasks.service';
-import { referralsActions } from '../referrals';
+import { referralsActions, referralsThunks } from '../referrals';
 import { sessionActions } from '../session';
 import { storageActions } from '../storage';
 import { uiActions } from '../ui';
@@ -54,6 +54,7 @@ export const initializeUserThunk = createAsyncThunk<
     dispatch(refreshUserThunk());
     dispatch(getUserTierFeaturesThunk());
     dispatch(refreshAvatarThunk());
+    await dispatch(referralsThunks.initializeThunk());
     dispatch(setIsUserInitialized(true));
   } else if (payload.redirectToLogin) {
     navigationService.push(AppView.Login);
@@ -262,6 +263,7 @@ export const userSelectors = {
     const { user } = state.user;
     return dayjs(user?.createdAt).isSame(new Date(), 'day');
   },
+  getUser: (state: RootState) => state.user.user,
   isFromAppSumo: (state: RootState): boolean => !!state.user.user?.appSumoDetails,
   hasReferralsProgram: (state: RootState): boolean => !!state.user.user?.hasReferralsProgram,
 };

--- a/src/app/store/slices/user/userStore.test.ts
+++ b/src/app/store/slices/user/userStore.test.ts
@@ -7,7 +7,7 @@ import notificationsService, { ToastType } from '../../../notifications/services
 
 const MOCK_TRANSLATION_MESSAGE = 'Some features may be unavailable';
 
-vi.mock('i18next', () => ({ t: () => MOCK_TRANSLATION_MESSAGE }));
+vi.mock('i18next', () => ({ default: { language: 'en' }, t: () => MOCK_TRANSLATION_MESSAGE }));
 
 describe('User reducer', () => {
   let store: ReturnType<typeof createTestStore>;

--- a/src/components/SidenavWrapper.tsx
+++ b/src/components/SidenavWrapper.tsx
@@ -23,7 +23,6 @@ import { useSidenavNavigation } from 'hooks/useSidenavNavigation';
 import { uiActions } from 'app/store/slices/ui';
 import ReferralBanner from './ReferralBanner';
 import referralService from 'services/referral.service';
-import { referralsThunks } from 'app/store/slices/referrals';
 
 interface SidenavWrapperProps {
   user: UserSettings | undefined;
@@ -64,20 +63,6 @@ const SidenavWrapper = ({
     dispatch(sharedThunks.getPendingInvitations());
     referralService.trackAppOpenDay();
   }, []);
-
-  useEffect(() => {
-    if (user) {
-      referralService.boot(
-        { name: user.name, lastname: user.lastname, email: user.email, emailVerified: user.emailVerified },
-        i18n.language,
-      );
-      dispatch(
-        referralsThunks.fetchIsEligibleThunk({
-          accountCreatedAt: user.createdAt ? new Date(user.createdAt) : undefined,
-        }),
-      );
-    }
-  }, [user]);
 
   useEffect(() => {
     referralService.changeLanguage(i18n.language);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,6 @@ import { planThunks } from './app/store/slices/plan';
 import storageThunks from './app/store/slices/storage/storage.thunks';
 import { taskManagerThunks } from './app/store/slices/taskManager';
 import { sessionActions } from './app/store/slices/session';
-import { referralsThunks } from 'app/store/slices/referrals';
 
 import 'react-tooltip/dist/react-tooltip.css';
 import './index.scss';
@@ -74,7 +73,6 @@ store.dispatch(sessionActions.initialize());
 store.dispatch(storageThunks.initializeThunk());
 store.dispatch(planThunks.initializeThunk());
 store.dispatch(taskManagerThunks.initializeThunk());
-store.dispatch(referralsThunks.initializeThunk());
 
 const container = document.getElementById('root') as HTMLElement;
 document.documentElement.setAttribute('translate', 'no');

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -36,7 +36,6 @@ import { AuthMethodTypes } from 'views/Checkout/types';
 import { AppDispatch } from 'app/store';
 import { planThunks } from 'app/store/slices/plan';
 import { productsThunks } from 'app/store/slices/products';
-import { referralsThunks } from 'app/store/slices/referrals';
 import { initializeUserThunk, userActions, userThunks } from 'app/store/slices/user';
 import { workspaceThunks } from 'app/store/slices/workspaces/workspacesStore';
 import { BackupData, detectBackupKeyFormat, prepareOldBackupRecoverPayloadForBackend } from 'utils/backupKeyUtils';
@@ -586,7 +585,6 @@ export const signUp = async (params: SignUpParams) => {
   dispatch(productsThunks.initializeThunk());
 
   if (!redeemCodeObject) dispatch(planThunks.initializeThunk());
-  dispatch(referralsThunks.initializeThunk());
   await trackSignUp(xUser.uuid);
   trackLead(xUser.email, xUser.userId);
 
@@ -601,7 +599,6 @@ export const logIn = async (params: LogInParams): Promise<ProfileInfo> => {
   try {
     dispatch(productsThunks.initializeThunk());
     dispatch(planThunks.initializeThunk());
-    dispatch(referralsThunks.initializeThunk());
     await dispatch(initializeUserThunk())?.unwrap();
     dispatch(workspaceThunks.fetchWorkspaces());
     dispatch(workspaceThunks.checkAndSetLocalWorkspace());

--- a/src/views/NewSettings/utils/suscriptionUtils.test.ts
+++ b/src/views/NewSettings/utils/suscriptionUtils.test.ts
@@ -4,6 +4,7 @@ import { UserSubscription, UserType, StoragePlan, RenewalPeriod } from '@internx
 import { PlanState } from 'app/store/slices/plan';
 
 vi.mock('i18next', () => ({
+  default: { language: 'en' },
   t: (key: string) => {
     if (key === 'views.account.tabs.billing.cancelSubscriptionModal.infoBox.month') return 'month';
     if (key === 'views.account.tabs.billing.cancelSubscriptionModal.infoBox.year') return 'year';

--- a/src/views/Signup/utils/guestSignupOnSubmit.test.ts
+++ b/src/views/Signup/utils/guestSignupOnSubmit.test.ts
@@ -9,7 +9,6 @@ import { parseAndDecryptUserKeys } from 'app/crypto/services/keys.service';
 import { userActions, userThunks } from 'app/store/slices/user';
 import { productsThunks } from 'app/store/slices/products';
 import { planThunks } from 'app/store/slices/plan';
-import { referralsThunks } from 'app/store/slices/referrals';
 
 vi.mock(import('services/error.service'));
 vi.mock(import('services/local-storage.service'));
@@ -71,7 +70,6 @@ describe('guestSignupOnSubmit', () => {
     vi.mocked(userThunks.initializeUserThunk).mockReturnValue({} as any);
     vi.mocked(productsThunks.initializeThunk).mockReturnValue({} as any);
     vi.mocked(planThunks.initializeThunk).mockReturnValue({} as any);
-    vi.mocked(referralsThunks.initializeThunk).mockReturnValue({} as any);
   });
 
   it('should successfully register user and navigate to redirect page', async () => {
@@ -106,7 +104,6 @@ describe('guestSignupOnSubmit', () => {
     expect(mockDispatch).toHaveBeenCalledWith(userThunks.initializeUserThunk());
     expect(mockDispatch).toHaveBeenCalledWith(productsThunks.initializeThunk());
     expect(mockDispatch).toHaveBeenCalledWith(planThunks.initializeThunk());
-    expect(mockDispatch).toHaveBeenCalledWith(referralsThunks.initializeThunk());
     expect(navigationService.push).toHaveBeenCalledWith(AppView.Drive);
     expect(mockSetShowError).toHaveBeenCalledWith(true);
   });

--- a/src/views/Signup/utils/guestSignupOnSubmit.ts
+++ b/src/views/Signup/utils/guestSignupOnSubmit.ts
@@ -7,7 +7,6 @@ import { parseAndDecryptUserKeys } from 'app/crypto/services/keys.service';
 import { userActions, userThunks } from 'app/store/slices/user';
 import { productsThunks } from 'app/store/slices/products';
 import { planThunks } from 'app/store/slices/plan';
-import { referralsThunks } from 'app/store/slices/referrals';
 import { AppDispatch } from 'app/store';
 
 interface GuestSignupOnSubmitParams {
@@ -77,7 +76,6 @@ export const guestSignupOnSubmit = async ({
     await dispatch(userThunks.initializeUserThunk());
     dispatch(productsThunks.initializeThunk());
     dispatch(planThunks.initializeThunk());
-    dispatch(referralsThunks.initializeThunk());
 
     return navigationService.push(redirectTo);
   } catch (err: unknown) {


### PR DESCRIPTION
## Description

initialize Cello SDK and eligibility check at login instead of deferring to SidenavWrapper

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [x] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
