### PR TITLE
[PB-6019/PB-6021/PB-6056]: feature/small improvements

### DIFF
--- a/src/app/i18n/locales/de.json
+++ b/src/app/i18n/locales/de.json
@@ -842,7 +842,7 @@
         "userItem": {
           "roles": {
             "owner": "Besitzer",
-            "editor": "Herausgeber",
+            "editor": "Bearbeiter",
             "reader": "Betrachter"
           },
           "remove": "Entfernen"
@@ -876,7 +876,7 @@
           "accept": "Akzeptieren",
           "deny": "Ablehnen",
           "roles": {
-            "editor": "Redakteur",
+            "editor": "Bearbeiter",
             "reader": "Betrachter"
           }
         }
@@ -916,7 +916,7 @@
         "duplicatedEmail": "Die E-Mail-Adresse existiert bereits",
         "email": "E-Mail eingeben",
         "invite": "Einladen",
-        "editor": "Redakteur",
+        "editor": "Bearbeiter",
         "reader": "Betrachter",
         "listUsers": "einzuladende Benutzer",
         "successSentInvitation": "Erfolgreiche Freigabe mit {{email}}",

--- a/src/components/SidenavWrapper.tsx
+++ b/src/components/SidenavWrapper.tsx
@@ -52,6 +52,7 @@ const SidenavWrapper = ({
   const workspaceUuid = selectedWorkspace?.workspaceUser.workspaceId;
   const { itemsNavigation } = useSidenavNavigation();
   const { suiteArray } = useSuiteLauncher();
+  const userUsage = planUsage > 0 ? bytesToString(planUsage) : '0GB';
 
   const [isCollapsed, setIsCollapsed] = useState(() => {
     const savedState = sessionStorage.getItem('sidenav-collapsed');
@@ -131,7 +132,7 @@ const SidenavWrapper = ({
           )
         }
         storage={{
-          usage: bytesToString(planUsage),
+          usage: userUsage,
           limit: bytesToString(planLimit),
           percentage: Math.min((planUsage / planLimit) * 100, 100),
           onUpgradeClick: handleUpgradeClick,

--- a/src/views/Home/components/WorkspaceSelector.tsx
+++ b/src/views/Home/components/WorkspaceSelector.tsx
@@ -16,7 +16,6 @@ export interface Workspace {
 interface WorkspaceSelectorProps {
   userWorkspace: Workspace;
   workspaces: Workspace[];
-  onCreateWorkspaceButtonClicked: () => void;
   onChangeWorkspace: (workspaceId: string | null) => void;
   selectedWorkspace: Workspace | null;
   setIsDialogOpen: (boolean) => void;
@@ -71,7 +70,6 @@ const WorkspaceCard = ({
 const WorkspaceSelector: React.FC<WorkspaceSelectorProps> = ({
   userWorkspace,
   workspaces,
-  onCreateWorkspaceButtonClicked,
   onChangeWorkspace,
   setIsDialogOpen,
   pendingWorkspacesInvitesLength,
@@ -81,10 +79,12 @@ const WorkspaceSelector: React.FC<WorkspaceSelectorProps> = ({
   isCollapsed = false,
 }) => {
   const dropdownRef = useRef<HTMLInputElement>(null);
+  const isWorkspaceDropdownDisabled = workspaces.length === 0;
 
   const { translate } = useTranslationContext();
 
   const toggleDropdown = () => {
+    if (isWorkspaceDropdownDisabled) return;
     setIsWorkspaceSelectorOpen(!isWorkspaceSelectorOpen);
   };
 
@@ -115,7 +115,7 @@ const WorkspaceSelector: React.FC<WorkspaceSelectorProps> = ({
       <button
         className={`w-full rounded-lg border border-gray-10 ${
           isWorkspaceSelectorOpen ? 'bg-gray-1' : 'bg-surface'
-        } ${isCollapsed ? 'py-3 px-1.5' : 'p-3'} text-left dark:bg-gray-5`}
+        } ${isCollapsed ? 'py-3 px-1.5' : 'p-3'} ${isWorkspaceDropdownDisabled ? 'cursor-default' : 'cursor-pointer'} text-left dark:bg-gray-5`}
         onClick={toggleDropdown}
         title={isCollapsed ? selectedWorkspace?.name : undefined}
       >
@@ -159,7 +159,7 @@ const WorkspaceSelector: React.FC<WorkspaceSelectorProps> = ({
               </p>
             </div>
             <div className="w-4">
-              <CaretUpDown colorRendering="bg-gray-100" weight="bold" size={16} />
+              {!isWorkspaceDropdownDisabled && <CaretUpDown colorRendering="bg-gray-100" weight="bold" size={16} />}
             </div>
           </div>
         )}

--- a/src/views/Home/components/WorkspaceSelectorContainer.tsx
+++ b/src/views/Home/components/WorkspaceSelectorContainer.tsx
@@ -85,7 +85,6 @@ const WorkspaceSelectorContainer = ({ user, isCollapsed }: WorkspaceSelectorCont
         userWorkspace={userWorkspace}
         workspaces={allParsedWorkspaces}
         onChangeWorkspace={handleWorkspaceChange}
-        onCreateWorkspaceButtonClicked={() => undefined}
         selectedWorkspace={selectedWorkspace ? parseWorkspaces([selectedWorkspace])[0] : userWorkspace}
         pendingWorkspacesInvitesLength={pendingWorkspacesInvites.length}
         setIsDialogOpen={setIsDialogOpen}


### PR DESCRIPTION
## Description

- Disabling the workspace selection when the user does not have any workspace (only individual account).
- Improving German translation for "Editor" role.
- Showing 0GB instead of 0 bytes when the user does not have usage in their account (sidebar corner)

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
