### PR TITLE
[BR-1933]: fix/plan size handling and comparison when updating plan

### DIFF
--- a/src/views/NewSettings/components/Sections/Account/Plans/components/ChangePlanDialog.tsx
+++ b/src/views/NewSettings/components/Sections/Account/Plans/components/ChangePlanDialog.tsx
@@ -45,10 +45,9 @@ const ChangePlanDialog = ({
   const selectedPlanSize = priceSelected?.bytes;
   const selectedPlanAmount = priceSelected?.amount;
   const selectedPlanInterval = priceSelected?.interval;
-  const selectedPlanSizeString =
-    userHasLifetimeSub && selectedPlanInterval === 'lifetime'
-      ? bytesToString(selectedPlanSize + planLimit)
-      : bytesToString(selectedPlanSize);
+  const planSize =
+    userHasLifetimeSub && selectedPlanInterval === 'lifetime' ? selectedPlanSize + planLimit : selectedPlanSize;
+  const selectedPlanSizeString = bytesToString(planSize);
   const currentPlanSizeString = bytesToString(
     isIndividualSubscription ? planLimit : (businessPlan?.storageLimit ?? businessPlanLimit),
   );
@@ -133,7 +132,7 @@ const ChangePlanDialog = ({
           )}
         </div>
       </div>
-      {selectedPlanSize < currentPlanUsage && (
+      {selectedPlanSize < planSize && (
         <div className="mb-5 flex flex-col items-center rounded-xl border border-red/20 bg-red/10 px-4 py-5 text-red">
           <h4 className="mb-1.5 text-center text-xl font-semibold">
             {translate('views.account.tabs.plans.dialog.alert.title')}

--- a/src/views/NewSettings/components/Sections/Account/Plans/components/ChangePlanDialog.tsx
+++ b/src/views/NewSettings/components/Sections/Account/Plans/components/ChangePlanDialog.tsx
@@ -45,13 +45,14 @@ const ChangePlanDialog = ({
   const selectedPlanSize = priceSelected?.bytes;
   const selectedPlanAmount = priceSelected?.amount;
   const selectedPlanInterval = priceSelected?.interval;
-  const planSize =
+  const newPlanTotalSize =
     userHasLifetimeSub && selectedPlanInterval === 'lifetime' ? selectedPlanSize + planLimit : selectedPlanSize;
-  const selectedPlanSizeString = bytesToString(planSize);
+  const selectedPlanSizeString = bytesToString(newPlanTotalSize);
   const currentPlanSizeString = bytesToString(
     isIndividualSubscription ? planLimit : (businessPlan?.storageLimit ?? businessPlanLimit),
   );
   const currentPlanUsage = isIndividualSubscription ? planUsage : businessPlanUsage;
+  const isStorageExceeded = currentPlanUsage > newPlanTotalSize;
   let amountMonthly: number | null = null;
   let currentAmountMonthly: number | null = null;
   let subscriptionCurrencySymbol: string | null = null;
@@ -112,7 +113,7 @@ const ChangePlanDialog = ({
           <p className="mb-2.5 rounded-xl border border-gray-10 bg-gray-5 px-2 py-1 text-xs font-medium text-gray-80">
             {translate('views.account.tabs.plans.dialog.plan.new')}
           </p>
-          <p className={`text-2xl font-medium ${selectedPlanSize < currentPlanUsage ? 'text-red' : 'text-primary'}`}>
+          <p className={`text-2xl font-medium ${isStorageExceeded ? 'text-red' : 'text-primary'}`}>
             {selectedPlanSizeString}
           </p>
           {selectedPlanInterval === 'lifetime' ? (
@@ -132,7 +133,7 @@ const ChangePlanDialog = ({
           )}
         </div>
       </div>
-      {selectedPlanSize < planSize && (
+      {isStorageExceeded && (
         <div className="mb-5 flex flex-col items-center rounded-xl border border-red/20 bg-red/10 px-4 py-5 text-red">
           <h4 className="mb-1.5 text-center text-xl font-semibold">
             {translate('views.account.tabs.plans.dialog.alert.title')}


### PR DESCRIPTION
## Description

When a user already has a lifetime plan and attempts to purchase an additional one, the current warning message can be misleading. For example, if the user has a total storage limit of 10TB with only 8.1GB used and tries to purchase an additional 5TB plan, the alert incorrectly indicates that the user has 8TB and is about to buy 5TB. This happens because the system is not properly accounting for the existing lifetime plan. Instead, when a user with an active lifetime plan purchases another lifetime plan, the calculation should be based on the sum of the current storage limit and the new storage being added, rather than considering only the new plan in isolation.


## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process
- Log in with a user that already has an active lifetime plan with a known storage limit (e.g., 10TB) and usage (e.g., 8TB used) > Navigate to the Plan tab (Preferences) and select an additional lifetime plan (e.g., +5TB) > Verify that the warning message shown before completing the purchase does not appear.

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
