### PR TITLE
[PB-3527]:feat/replace custom file grid with UI library Grid component

### DIFF
--- a/src/views/Drive/components/DriveExplorer/components/DriveExplorerGrid.scss
+++ b/src/views/Drive/components/DriveExplorer/components/DriveExplorerGrid.scss
@@ -1,9 +1,0 @@
-@tailwind components;
-
-@layer components {
-  .files-grid {
-    max-width: fit-content;
-
-    @apply mb-2 grid min-w-full auto-rows-min grid-cols-2 gap-2 overflow-y-auto overflow-x-hidden sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6;
-  }
-}

--- a/src/views/Drive/components/DriveExplorer/components/DriveExplorerGrid.tsx
+++ b/src/views/Drive/components/DriveExplorer/components/DriveExplorerGrid.tsx
@@ -1,14 +1,13 @@
 import React, { FC, useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
-
 import { useAppDispatch } from 'app/store/hooks';
 import { fetchSortedFolderContentThunk } from 'app/store/slices/storage/storage.thunks/fetchSortedFolderContentThunk';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { DriveItemData } from 'app/drive/types';
+import { Grid } from '@internxt/ui';
 import DriveGridItemSkeleton from '../../DriveGridItemSkeleton';
 import EditItemNameDialog from 'app/drive/components/EditItemNameDialog/EditItemNameDialog';
 import DriveExplorerGridItem from './DriveExplorerGridItem';
-import './DriveExplorerGrid.scss';
 
 interface DriveExplorerGridProps {
   folderId: string;
@@ -93,7 +92,7 @@ const DriveExplorerGrid: FC<DriveExplorerGridProps> = (props: DriveExplorerGridP
   return (
     <>
       {isLoading && isFirstLoad.current ? (
-        <div className="files-grid grow">{loadingSkeleton()}</div>
+        <Grid className="grow">{loadingSkeleton()}</Grid>
       ) : (
         <div
           id="scrollableList"
@@ -116,14 +115,16 @@ const DriveExplorerGrid: FC<DriveExplorerGridProps> = (props: DriveExplorerGridP
             dataLength={itemsList().length}
             next={onEndOfScroll}
             hasMore={hasMoreItems}
-            loader={loadingSkeleton()}
+            loader={<Grid>{loadingSkeleton()}</Grid>}
             scrollableTarget="scrollableList"
-            className="files-grid z-0 grow"
+            className="z-0 grow"
             style={{ overflow: 'visible' }}
             scrollThreshold={0.6}
           >
-            {itemsFolderList()}
-            {itemsFileList()}
+            <Grid>
+              {itemsFolderList()}
+              {itemsFileList()}
+            </Grid>
           </InfiniteScroll>
         </div>
       )}


### PR DESCRIPTION
## Description
This PR refactors the DriveExplorerGrid component to use the newly standardized Grid component from the @internxt/ui library, key changes:

Replaced the custom .files-grid CSS class implementation in [DriveExplorerGrid.tsx] with the generic component imported from @internxt/ui.
Wrapped both the files list and the loading skeletons used within the InfiniteScroll in the new element to ensure consistent container layouts at all times.
Deleted DriveExplorerGrid.scss
<!-- Provide a clear and concise summary of the changes. Include the reason and context, if applicable. -->

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [ ] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
