### PR TITLE
[PB-5969]: skip zero-byte files in folder uploads to prevent blocking

### DIFF
--- a/src/app/core/constants.ts
+++ b/src/app/core/constants.ts
@@ -3,6 +3,7 @@ export const HTTP_CODES = {
   MAX_SPACE_USED: 420,
   FORBIDDEN: 403,
   NOT_FOUND: 404,
+  PAYMENT_REQUIRED: 402,
 };
 export enum ErrorMessages {
   ServerUnavailable = 'Server Unavailable',

--- a/src/app/drive/services/file.service/upload.errors.ts
+++ b/src/app/drive/services/file.service/upload.errors.ts
@@ -14,3 +14,14 @@ export class BucketNotFoundError extends Error {
     Object.setPrototypeOf(this, BucketNotFoundError.prototype);
   }
 }
+
+export class EmptyFileNotAllowedError extends Error {
+  readonly fileName: string;
+
+  constructor(fileName: string) {
+    super('Empty files are not allowed by current plan');
+    this.name = 'EmptyFileNotAllowedError';
+    this.fileName = fileName;
+    Object.setPrototypeOf(this, EmptyFileNotAllowedError.prototype);
+  }
+}

--- a/src/app/drive/services/file.service/uploadFile.test.ts
+++ b/src/app/drive/services/file.service/uploadFile.test.ts
@@ -37,7 +37,7 @@ vi.mock('services/navigation.service', () => ({
 import { SdkFactory } from 'app/core/factory/sdk';
 import workspacesService from 'services/workspace.service';
 import { Network, getEnvironmentConfig } from 'app/drive/services/network.service';
-import { BucketNotFoundError, FileIdRequiredError } from './upload.errors';
+import { BucketNotFoundError, EmptyFileNotAllowedError, FileIdRequiredError } from './upload.errors';
 import { DriveFileData } from 'app/drive/types';
 
 const mockSdkFactory = vi.mocked(SdkFactory);
@@ -338,6 +338,79 @@ describe('Uploading a file', () => {
 
     expect(result).toEqual(expectedResponse);
     expect(mockNetwork).not.toHaveBeenCalled();
+  });
+
+  test('When the plan does not allow empty files, then the user is informed', async () => {
+    const file: FileToUpload = {
+      name: 'empty-file.txt',
+      size: 0,
+      type: 'txt',
+      content: new File([], 'empty-file.txt'),
+      parentFolderId: 'folder-123',
+    };
+    const bucketId = 'bucket-123';
+
+    mockGetEnvironmentConfig.mockReturnValue({
+      bridgeUser: 'user',
+      bridgePass: 'pass',
+      encryptionKey: 'key',
+      bucketId,
+    } as any);
+
+    const paymentRequiredError = Object.assign(new Error('Payment required'), { status: 402 });
+    const mockCreateFileEntryByUuid = vi.fn().mockRejectedValue(paymentRequiredError);
+    mockSdkFactory.getNewApiInstance.mockReturnValue({
+      createNewStorageClient: vi.fn(() => ({
+        createFileEntryByUuid: mockCreateFileEntryByUuid,
+      })),
+    } as any);
+
+    await expect(
+      uploadFile(
+        'user@test.com',
+        file,
+        vi.fn(),
+        { isTeam: false },
+        { taskId: 'task-1', isPaused: false, isRetriedUpload: false },
+      ),
+    ).rejects.toThrow(EmptyFileNotAllowedError);
+    expect(mockNetwork).not.toHaveBeenCalled();
+  });
+
+  test('When uploading an empty file fails unexpectedly, then the original error is shown', async () => {
+    const file: FileToUpload = {
+      name: 'empty-file.txt',
+      size: 0,
+      type: 'txt',
+      content: new File([], 'empty-file.txt'),
+      parentFolderId: 'folder-123',
+    };
+    const bucketId = 'bucket-123';
+
+    mockGetEnvironmentConfig.mockReturnValue({
+      bridgeUser: 'user',
+      bridgePass: 'pass',
+      encryptionKey: 'key',
+      bucketId,
+    } as any);
+
+    const serverError = Object.assign(new Error('Server error'), { status: 500 });
+    const mockCreateFileEntryByUuid = vi.fn().mockRejectedValue(serverError);
+    mockSdkFactory.getNewApiInstance.mockReturnValue({
+      createNewStorageClient: vi.fn(() => ({
+        createFileEntryByUuid: mockCreateFileEntryByUuid,
+      })),
+    } as any);
+
+    await expect(
+      uploadFile(
+        'user@test.com',
+        file,
+        vi.fn(),
+        { isTeam: false },
+        { taskId: 'task-1', isPaused: false, isRetriedUpload: false },
+      ),
+    ).rejects.toThrow('Server error');
   });
 
   test('When uploading a file without bucket id, then an error indicating so is thrown', async () => {

--- a/src/app/drive/services/file.service/uploadFile.ts
+++ b/src/app/drive/services/file.service/uploadFile.ts
@@ -112,7 +112,8 @@ export async function uploadFile(
         ownerToken: workspacesToken,
       });
     } catch (err) {
-      if (errorService.castError(err).status === HTTP_CODES.PAYMENT_REQUIRED) {
+      const error = errorService.castError(err);
+      if (error.status === HTTP_CODES.PAYMENT_REQUIRED) {
         throw new EmptyFileNotAllowedError(file.name);
       }
       throw err;

--- a/src/app/drive/services/file.service/uploadFile.ts
+++ b/src/app/drive/services/file.service/uploadFile.ts
@@ -13,6 +13,7 @@ import { FileToUpload } from './types';
 import { DriveFileData } from '@internxt/sdk/dist/drive/storage/types';
 import { BucketNotFoundError, EmptyFileNotAllowedError, FileIdRequiredError } from './upload.errors';
 import { HTTP_CODES } from 'app/core/constants';
+import errorService from 'services/error.service';
 import { isFileEmpty } from 'utils/isFileEmpty';
 import { FileEntry } from '@internxt/sdk/dist/workspaces';
 
@@ -111,10 +112,7 @@ export async function uploadFile(
         ownerToken: workspacesToken,
       });
     } catch (err) {
-      const status =
-        (err as { status?: number; response?: { status?: number } })?.status ??
-        (err as { response?: { status?: number } })?.response?.status;
-      if (status === HTTP_CODES.PAYMENT_REQUIRED) {
+      if (errorService.castError(err).status === HTTP_CODES.PAYMENT_REQUIRED) {
         throw new EmptyFileNotAllowedError(file.name);
       }
       throw err;

--- a/src/app/drive/services/file.service/uploadFile.ts
+++ b/src/app/drive/services/file.service/uploadFile.ts
@@ -11,7 +11,8 @@ import { generateThumbnailFromFile } from '../thumbnail.service';
 import { OwnerUserAuthenticationData } from 'app/network/types';
 import { FileToUpload } from './types';
 import { DriveFileData } from '@internxt/sdk/dist/drive/storage/types';
-import { BucketNotFoundError, FileIdRequiredError } from './upload.errors';
+import { BucketNotFoundError, EmptyFileNotAllowedError, FileIdRequiredError } from './upload.errors';
+import { HTTP_CODES } from 'app/core/constants';
 import { isFileEmpty } from 'utils/isFileEmpty';
 import { FileEntry } from '@internxt/sdk/dist/workspaces';
 
@@ -101,13 +102,23 @@ export async function uploadFile(
   const isWorkspacesUpload = workspaceId && workspacesToken;
 
   if (isFileEmpty(file.content) && !isWorkspacesUpload) {
-    return createFileEntry({
-      bucketId: bucketId,
-      file,
-      resourcesToken: resourcesToken,
-      workspaceId: workspaceId,
-      ownerToken: workspacesToken,
-    });
+    try {
+      return await createFileEntry({
+        bucketId: bucketId,
+        file,
+        resourcesToken: resourcesToken,
+        workspaceId: workspaceId,
+        ownerToken: workspacesToken,
+      });
+    } catch (err) {
+      const status =
+        (err as { status?: number; response?: { status?: number } })?.status ??
+        (err as { response?: { status?: number } })?.response?.status;
+      if (status === HTTP_CODES.PAYMENT_REQUIRED) {
+        throw new EmptyFileNotAllowedError(file.name);
+      }
+      throw err;
+    }
   }
 
   if (!bucketId) {

--- a/src/app/i18n/locales/de.json
+++ b/src/app/i18n/locales/de.json
@@ -1126,6 +1126,7 @@
     "errorMovingToTrash": "Beim Verschieben der Elemente in den Papierkorb ist ein Fehler aufgetreten.",
     "errorDeletingFromTrash": "Beim Löschen der Elemente aus dem Papierkorb ist ein Fehler aufgetreten.",
     "maxSizeUploadLimitError": "Datei zu groß (größer als 40 GB)",
+    "emptyFileNotAllowed": "\"{{fileName}}\" wurde übersprungen: Aktualisieren Sie Ihren Tarif, um leere Dateien hochzuladen",
     "braveNotSupportMultiplePhotosDowload": "Brave unterstützt nicht das Herunterladen mehrerer Fotos.",
     "updateAvatarError": "Fehler beim Aktualisieren des Avatars",
     "featuresUnavailable": "Einige Funktionen sind möglicherweise nicht verfügbar",

--- a/src/app/i18n/locales/en.json
+++ b/src/app/i18n/locales/en.json
@@ -1200,6 +1200,7 @@
     "errorMovingToTrash": "An error occurred while moving the items to trash.",
     "errorDeletingFromTrash": "An error occurred while deleting the items from trash.",
     "maxSizeUploadLimitError": "File too large (greater than 40GB)",
+    "emptyFileNotAllowed": "\"{{fileName}}\" was skipped: upgrade your plan to upload empty files",
     "connectionLostError": "Internet connection lost",
     "errorLoadingTrashItems": "Error loading trash items",
     "updateAvatarError": "Error updating avatar",

--- a/src/app/i18n/locales/es.json
+++ b/src/app/i18n/locales/es.json
@@ -1177,6 +1177,7 @@
     "errorMovingToTrash": "Ha ocurrido un error mientras se movian los items a la basura.",
     "errorDeletingFromTrash": "Ha ocurrido un error mientras se eliminaban los items de la basura.",
     "maxSizeUploadLimitError": "Archivo demasiado grande (mayor de 40GB)",
+    "emptyFileNotAllowed": "\"{{fileName}}\" fue omitido: actualiza tu plan para subir archivos vacíos",
     "connectionLostError": "Conexión a internet perdida",
     "errorLoadingTrashItems": "Error al cargar items de la papelera",
     "updateAvatarError": "Error al actualizar el avatar",

--- a/src/app/i18n/locales/fr.json
+++ b/src/app/i18n/locales/fr.json
@@ -1128,6 +1128,7 @@
     "emptyPassword": "Le mot de passe précédent ne doit pas être vide",
     "errorMovingToTrash": "Error lors du déplacement des éléments.",
     "maxSizeUploadLimitError": "Fichier trop volumineux (plus de 40GB)",
+    "emptyFileNotAllowed": "\"{{fileName}}\" a été ignoré : améliorez votre forfait pour téléverser des fichiers vides",
     "connectionLostError": "Lost Internet connection",
     "errorLoadingTrashItems": "Erreur de chargement des éléments de la corbeille",
     "updateAvatarError": "Erreur lors de la mise à jour de l'avatar",

--- a/src/app/i18n/locales/it.json
+++ b/src/app/i18n/locales/it.json
@@ -1235,6 +1235,7 @@
     "errorMovingToTrash": "Si è verificato un errore durante lo spostamento degli elementi nel cestino.",
     "errorDeletingFromTrash": "Si è verificato un errore durante l'eliminazione degli elementi dal cestino.",
     "maxSizeUploadLimitError": "File troppo grande (superiore a 40GB)",
+    "emptyFileNotAllowed": "\"{{fileName}}\" è stato ignorato: aggiorna il tuo piano per caricare file vuoti",
     "connectionLostError": "Connessione Internet persa",
     "errorLoadingTrashItems": "Errore nel caricamento degli elementi del cestino",
     "updateAvatarError": "Errore nell'aggiornamento dell'avatar",

--- a/src/app/i18n/locales/ru.json
+++ b/src/app/i18n/locales/ru.json
@@ -1143,6 +1143,7 @@
     "errorMovingToTrash": "При перемещении элементов в корзину произошла ошибка.",
     "errorDeletingFromTrash": "При удалении элементов из корзины произошла ошибка.",
     "maxSizeUploadLimitError": "Слишком большой файл (более 40 ГБ)",
+    "emptyFileNotAllowed": "\"{{fileName}}\" пропущен: обновите тарифный план, чтобы загружать пустые файлы",
     "connectionLostError": "Потеряно подключение к Интернету",
     "errorLoadingTrashItems": "Ошибка при загрузке элементов корзины",
     "updateAvatarError": "Ошибка при обновлении аватара",

--- a/src/app/i18n/locales/tw.json
+++ b/src/app/i18n/locales/tw.json
@@ -1130,6 +1130,7 @@
     "errorMovingToTrash": "將項目移動到垃圾桶時出錯。",
     "errorDeletingFromTrash": "從垃圾桶中刪除項目時出錯。",
     "maxSizeUploadLimitError": "文件過大（大於40GB）",
+    "emptyFileNotAllowed": "已略過 \"{{fileName}}\"：請升級方案以上傳空檔案",
     "connectionLostError": "網絡連接已丟失",
     "errorLoadingTrashItems": "加載垃圾桶項目時出錯",
     "updateAvatarError": "更新頭像時發生錯誤",

--- a/src/app/i18n/locales/zh.json
+++ b/src/app/i18n/locales/zh.json
@@ -1165,6 +1165,7 @@
     "errorMovingToTrash": "将项目移至垃圾箱时出错。",
     "errorDeletingFromTrash": "从垃圾箱中删除项目时出错。",
     "maxSizeUploadLimitError": "文件太大（大于40GB）",
+    "emptyFileNotAllowed": "已跳过 \"{{fileName}}\"：请升级套餐以上传空文件",
     "connectionLostError": "互联网连接丢失",
     "errorLoadingTrashItems": "加载垃圾箱内的项目时出错",
     "updateAvatarError": "更新头像时出错",

--- a/src/app/network/UploadFolderManager.ts
+++ b/src/app/network/UploadFolderManager.ts
@@ -255,10 +255,8 @@ export class UploadFoldersManager {
       }),
     )
       .unwrap()
-      .catch(() => {
-        this.stopUploadTask(taskId, abortController);
-        this.killQueueAndNotifyError(taskId);
-        return;
+      .catch((error) => {
+        errorService.reportError(error);
       });
   };
 

--- a/src/app/network/UploadManager.test.ts
+++ b/src/app/network/UploadManager.test.ts
@@ -715,7 +715,7 @@ describe('checkUploadFiles', () => {
     expect(emptyFileNotAllowedCallback).toHaveBeenCalledWith(fileName);
     expect(updateTaskSpy).toHaveBeenCalledWith({
       taskId: 'taskId',
-      merge: { status: TaskStatus.Cancelled },
+      merge: { status: TaskStatus.Error, subtitle: expect.any(String) },
     });
     expect(reportErrorSpy).not.toHaveBeenCalled();
   });

--- a/src/app/network/UploadManager.test.ts
+++ b/src/app/network/UploadManager.test.ts
@@ -9,6 +9,7 @@ import { DriveFileData } from 'app/drive/types';
 import RetryManager from './RetryManager';
 import { TaskStatus } from 'app/tasks/types';
 import { ErrorMessages } from 'app/core/constants';
+import { EmptyFileNotAllowedError } from 'app/drive/services/file.service/upload.errors';
 
 vi.mock('app/drive/services/file.service/uploadFile', () => ({
   default: vi.fn(() => Promise.resolve({} as DriveFileData)),
@@ -669,5 +670,53 @@ describe('checkUploadFiles', () => {
       }),
       expect.any(Object),
     );
+  });
+
+  it('When the plan does not allow empty files, then the upload is skipped and the user is informed', async () => {
+    const fileName = 'empty-file.txt';
+    (uploadFile as Mock).mockRejectedValueOnce(new EmptyFileNotAllowedError(fileName));
+
+    const updateTaskSpy = vi.spyOn(tasksService, 'updateTask').mockReturnValue();
+    vi.spyOn(tasksService, 'create').mockReturnValue('taskId');
+    vi.spyOn(tasksService, 'addListener').mockReturnValue();
+    vi.spyOn(tasksService, 'removeListener').mockReturnValue();
+    const reportErrorSpy = vi.spyOn(errorService, 'reportError').mockReturnValue();
+    const emptyFileNotAllowedCallback = vi.fn();
+
+    await uploadFileWithManager(
+      [
+        {
+          taskId: 'taskId',
+          filecontent: {
+            content: 'file-content' as unknown as File,
+            type: 'text/plain',
+            name: fileName,
+            size: 0,
+            parentFolderId: 'folder-1',
+          },
+          userEmail: '',
+          parentFolderId: '',
+        },
+      ],
+      openMaxSpaceOccupiedDialogMock,
+      DatabaseUploadRepository.getInstance(),
+      undefined,
+      {
+        ownerUserAuthenticationData: undefined,
+        sharedItemData: {
+          isDeepFolder: false,
+          currentFolderId: 'parentFolderId',
+        },
+        isUploadedFromFolder: true,
+      },
+      { emptyFileNotAllowedCallback },
+    );
+
+    expect(emptyFileNotAllowedCallback).toHaveBeenCalledWith(fileName);
+    expect(updateTaskSpy).toHaveBeenCalledWith({
+      taskId: 'taskId',
+      merge: { status: TaskStatus.Cancelled },
+    });
+    expect(reportErrorSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/app/network/UploadManager.ts
+++ b/src/app/network/UploadManager.ts
@@ -79,7 +79,7 @@ class UploadManager {
   private options?: Options;
   private relatedTaskProgress?: { filesUploaded: number; totalFilesToUpload: number };
   private maxSpaceOccupiedCallback: () => void;
-  private emptyFileNotAllowedCallback?: (fileName: string) => void;
+  private readonly emptyFileNotAllowedCallback?: (fileName: string) => void;
   private onFileUploadCallback?: (driveFileData: DriveFileData) => void;
   private uploadRepository?: PersistUploadRepository;
   private filesUploadedList: (DriveFileData & { taskId: string })[] = [];

--- a/src/app/network/UploadManager.ts
+++ b/src/app/network/UploadManager.ts
@@ -252,7 +252,7 @@ class UploadManager {
               this.emptyFileNotAllowedCallback?.(error.fileName);
               tasksService.updateTask({
                 taskId,
-                merge: { status: TaskStatus.Cancelled },
+                merge: { status: TaskStatus.Error, subtitle: t('tasks.subtitles.upload-failed') as string },
               });
               next(null);
               return;

--- a/src/app/network/UploadManager.ts
+++ b/src/app/network/UploadManager.ts
@@ -47,15 +47,19 @@ export type UploadManagerFileParams = {
   isUploadedFromFolder?: boolean;
 };
 
+export type UploadFileWithManagerCallbacks = {
+  relatedTaskProgress?: { filesUploaded: number; totalFilesToUpload: number };
+  onFileUploadCallback?: (driveFileData: DriveFileData) => void;
+  emptyFileNotAllowedCallback?: (fileName: string) => void;
+};
+
 export const uploadFileWithManager = (
   files: UploadManagerFileParams[],
   maxSpaceOccupiedCallback: () => void,
   uploadRepository: PersistUploadRepository,
   abortController?: AbortController,
   options?: Options,
-  relatedTaskProgress?: { filesUploaded: number; totalFilesToUpload: number },
-  onFileUploadCallback?: (driveFileData: DriveFileData) => void,
-  emptyFileNotAllowedCallback?: (fileName: string) => void,
+  callbacks?: UploadFileWithManagerCallbacks,
 ): Promise<{ uploadedFiles: DriveFileData[] }> => {
   const uploadManager = new UploadManager(
     files,
@@ -63,9 +67,7 @@ export const uploadFileWithManager = (
     uploadRepository,
     abortController,
     options,
-    relatedTaskProgress,
-    onFileUploadCallback,
-    emptyFileNotAllowedCallback,
+    callbacks,
   );
   return uploadManager.run();
 };
@@ -292,18 +294,16 @@ class UploadManager {
     uploadRepository?: PersistUploadRepository,
     abortController?: AbortController,
     options?: Options,
-    relatedTaskProgress?: { filesUploaded: number; totalFilesToUpload: number },
-    onFileUploadCallback?: (driveFileData: DriveFileData) => void,
-    emptyFileNotAllowedCallback?: (fileName: string) => void,
+    callbacks?: UploadFileWithManagerCallbacks,
   ) {
     this.items = items;
     this.abortController = abortController;
     this.options = options;
-    this.relatedTaskProgress = relatedTaskProgress;
+    this.relatedTaskProgress = callbacks?.relatedTaskProgress;
     this.maxSpaceOccupiedCallback = maxSpaceOccupiedCallback;
-    this.emptyFileNotAllowedCallback = emptyFileNotAllowedCallback;
+    this.emptyFileNotAllowedCallback = callbacks?.emptyFileNotAllowedCallback;
     this.uploadRepository = uploadRepository;
-    this.onFileUploadCallback = onFileUploadCallback;
+    this.onFileUploadCallback = callbacks?.onFileUploadCallback;
   }
 
   private handleUploadErrors({

--- a/src/app/network/UploadManager.ts
+++ b/src/app/network/UploadManager.ts
@@ -4,6 +4,7 @@ import { t } from 'i18next';
 import errorService from 'services/error.service';
 import { HTTP_CODES } from '../core/constants';
 import uploadFile from 'app/drive/services/file.service/uploadFile';
+import { EmptyFileNotAllowedError } from 'app/drive/services/file.service/upload.errors';
 import { DriveFileData } from 'app/drive/types';
 import { PersistUploadRepository } from '../repositories/DatabaseUploadRepository';
 import tasksService from '../tasks/services/tasks.service';
@@ -54,6 +55,7 @@ export const uploadFileWithManager = (
   options?: Options,
   relatedTaskProgress?: { filesUploaded: number; totalFilesToUpload: number },
   onFileUploadCallback?: (driveFileData: DriveFileData) => void,
+  emptyFileNotAllowedCallback?: (fileName: string) => void,
 ): Promise<{ uploadedFiles: DriveFileData[] }> => {
   const uploadManager = new UploadManager(
     files,
@@ -63,6 +65,7 @@ export const uploadFileWithManager = (
     options,
     relatedTaskProgress,
     onFileUploadCallback,
+    emptyFileNotAllowedCallback,
   );
   return uploadManager.run();
 };
@@ -76,6 +79,7 @@ class UploadManager {
   private options?: Options;
   private relatedTaskProgress?: { filesUploaded: number; totalFilesToUpload: number };
   private maxSpaceOccupiedCallback: () => void;
+  private emptyFileNotAllowedCallback?: (fileName: string) => void;
   private onFileUploadCallback?: (driveFileData: DriveFileData) => void;
   private uploadRepository?: PersistUploadRepository;
   private filesUploadedList: (DriveFileData & { taskId: string })[] = [];
@@ -240,6 +244,17 @@ class UploadManager {
               !!this.abortController?.signal.aborted || !!fileData.abortController?.signal.aborted || error === 'abort';
             const isLostConnectionError =
               error instanceof ConnectionLostError || error.message === ErrorMessages.NetworkError;
+            const isEmptyFileNotAllowed = error instanceof EmptyFileNotAllowedError;
+
+            if (isEmptyFileNotAllowed) {
+              this.emptyFileNotAllowedCallback?.(error.fileName);
+              tasksService.updateTask({
+                taskId,
+                merge: { status: TaskStatus.Cancelled },
+              });
+              next(null);
+              return;
+            }
 
             if (uploadAttempts < MAX_UPLOAD_ATTEMPTS && !isUploadAborted && !isLostConnectionError) {
               upload();
@@ -279,12 +294,14 @@ class UploadManager {
     options?: Options,
     relatedTaskProgress?: { filesUploaded: number; totalFilesToUpload: number },
     onFileUploadCallback?: (driveFileData: DriveFileData) => void,
+    emptyFileNotAllowedCallback?: (fileName: string) => void,
   ) {
     this.items = items;
     this.abortController = abortController;
     this.options = options;
     this.relatedTaskProgress = relatedTaskProgress;
     this.maxSpaceOccupiedCallback = maxSpaceOccupiedCallback;
+    this.emptyFileNotAllowedCallback = emptyFileNotAllowedCallback;
     this.uploadRepository = uploadRepository;
     this.onFileUploadCallback = onFileUploadCallback;
   }

--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
@@ -98,7 +98,7 @@ const isUploadAllowed = ({
 const notifyEmptyFileSkipped = (fileName: string) =>
   notificationsService.show({
     text: t('error.emptyFileNotAllowed', { fileName }),
-    type: ToastType.Warning,
+    type: ToastType.Error,
   });
 
 /**

--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
@@ -186,9 +186,9 @@ export const uploadItemsThunk = createAsyncThunk<void, UploadItemsPayload, { sta
           },
           isUploadedFromFolder: isRetry,
         },
-        undefined,
-        undefined,
-        notifyEmptyFileSkipped,
+        {
+          emptyFileNotAllowedCallback: notifyEmptyFileSkipped,
+        },
       );
     } catch (error) {
       if (taskId && isRetry) RetryManager.changeStatus(taskId, 'failed');
@@ -462,9 +462,11 @@ export const uploadItemsParallelThunk = createAsyncThunk<void, UploadItemsPayloa
             currentFolderId: parentFolderId,
           },
         },
-        filesProgress,
-        onFileUploadCallback,
-        notifyEmptyFileSkipped,
+        {
+          relatedTaskProgress: filesProgress,
+          onFileUploadCallback,
+          emptyFileNotAllowedCallback: notifyEmptyFileSkipped,
+        },
       );
     } catch (error) {
       errors.push(errorService.castError(error));

--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
@@ -166,6 +166,11 @@ export const uploadItemsThunk = createAsyncThunk<void, UploadItemsPayload, { sta
     }));
 
     const openMaxSpaceOccupiedDialog = () => dispatch(uiActions.setIsReachedPlanLimitDialogOpen(true));
+    const notifyEmptyFileSkipped = (fileName: string) =>
+      notificationsService.show({
+        text: t('error.emptyFileNotAllowed', { fileName }),
+        type: ToastType.Warning,
+      });
 
     try {
       await uploadFileWithManager(
@@ -181,6 +186,9 @@ export const uploadItemsThunk = createAsyncThunk<void, UploadItemsPayload, { sta
           },
           isUploadedFromFolder: isRetry,
         },
+        undefined,
+        undefined,
+        notifyEmptyFileSkipped,
       );
     } catch (error) {
       if (taskId && isRetry) RetryManager.changeStatus(taskId, 'failed');
@@ -440,6 +448,11 @@ export const uploadItemsParallelThunk = createAsyncThunk<void, UploadItemsPayloa
     }));
 
     const openMaxSpaceOccupiedDialog = () => dispatch(uiActions.setIsReachedPlanLimitDialogOpen(true));
+    const notifyEmptyFileSkipped = (fileName: string) =>
+      notificationsService.show({
+        text: t('error.emptyFileNotAllowed', { fileName }),
+        type: ToastType.Warning,
+      });
 
     try {
       await uploadFileWithManager(
@@ -457,6 +470,7 @@ export const uploadItemsParallelThunk = createAsyncThunk<void, UploadItemsPayloa
         },
         filesProgress,
         onFileUploadCallback,
+        notifyEmptyFileSkipped,
       );
     } catch (error) {
       errors.push(errorService.castError(error));

--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
@@ -95,6 +95,12 @@ const isUploadAllowed = ({
   return true;
 };
 
+const notifyEmptyFileSkipped = (fileName: string) =>
+  notificationsService.show({
+    text: t('error.emptyFileNotAllowed', { fileName }),
+    type: ToastType.Warning,
+  });
+
 /**
  * @description
  *  1. Prepare files to upload
@@ -166,12 +172,6 @@ export const uploadItemsThunk = createAsyncThunk<void, UploadItemsPayload, { sta
     }));
 
     const openMaxSpaceOccupiedDialog = () => dispatch(uiActions.setIsReachedPlanLimitDialogOpen(true));
-    const notifyEmptyFileSkipped = (fileName: string) =>
-      notificationsService.show({
-        text: t('error.emptyFileNotAllowed', { fileName }),
-        type: ToastType.Warning,
-      });
-
     try {
       await uploadFileWithManager(
         filesToUploadData,
@@ -448,12 +448,6 @@ export const uploadItemsParallelThunk = createAsyncThunk<void, UploadItemsPayloa
     }));
 
     const openMaxSpaceOccupiedDialog = () => dispatch(uiActions.setIsReachedPlanLimitDialogOpen(true));
-    const notifyEmptyFileSkipped = (fileName: string) =>
-      notificationsService.show({
-        text: t('error.emptyFileNotAllowed', { fileName }),
-        type: ToastType.Warning,
-      });
-
     try {
       await uploadFileWithManager(
         filesToUploadData,


### PR DESCRIPTION
## Description

Filter out empty files before dispatching the folder upload thunk, and log partial failures instead of aborting the whole folder upload. This prevents zero-byte files (e.g. __init__.py) from stalling or failing
the entire directory upload.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
