### PR TITLE
  [MKT-834]:feat: account popover new design

### DIFF
--- a/src/app/i18n/locales/de.json
+++ b/src/app/i18n/locales/de.json
@@ -402,7 +402,9 @@
         "logout": "Log-out",
         "referAndEarn": "Empfehlen und verdienen",
         "earnReferral": "Verdiene 100 €",
-        "spaceUsed": "{{space}}% Platz verbraucht"
+        "spaceUsed": "{{space}}% Platz verbraucht",
+        "account": "Konto",
+        "giveFeedback": "Feedback geben"
       },
       "tabs": {
         "account": {

--- a/src/app/i18n/locales/en.json
+++ b/src/app/i18n/locales/en.json
@@ -462,7 +462,9 @@
         "logout": "Log out",
         "referAndEarn": "Refer and Earn",
         "earnReferral": "Earn €100",
-        "spaceUsed": "{{space}}% space used"
+        "spaceUsed": "{{space}}% space used",
+        "account": "Account",
+        "giveFeedback": "Give Feedback"
       },
       "tabs": {
         "account": {

--- a/src/app/i18n/locales/es.json
+++ b/src/app/i18n/locales/es.json
@@ -445,7 +445,9 @@
         "logout": "Cerrar sesión",
         "referAndEarn": "Recomienda y gana",
         "earnReferral": "Gana 100 €",
-        "spaceUsed": "{{space}}% espacio usado"
+        "spaceUsed": "{{space}}% espacio usado",
+        "account": "Cuenta",
+        "giveFeedback": "Enviar comentarios"
       },
       "tabs": {
         "account": {

--- a/src/app/i18n/locales/fr.json
+++ b/src/app/i18n/locales/fr.json
@@ -414,7 +414,9 @@
         "logout": "Déconnexion",
         "referAndEarn": "Parrainez et gagnez",
         "earnReferral": "Gagnez 100 €",
-        "spaceUsed": "{{space}}% d'espace utilisé"
+        "spaceUsed": "{{space}}% d'espace utilisé",
+        "account": "Compte",
+        "giveFeedback": "Donner votre avis"
       },
       "tabs": {
         "account": {

--- a/src/app/i18n/locales/it.json
+++ b/src/app/i18n/locales/it.json
@@ -505,7 +505,9 @@
         "logout": "Disconnettersi",
         "referAndEarn": "Invita e guadagna",
         "earnReferral": "Guadagna 100 €",
-        "spaceUsed": "{{space}}% spazio usato"
+        "spaceUsed": "{{space}}% spazio usato",
+        "account": "Account",
+        "giveFeedback": "Invia feedback"
       },
       "tabs": {
         "account": {

--- a/src/app/i18n/locales/ru.json
+++ b/src/app/i18n/locales/ru.json
@@ -414,7 +414,9 @@
         "logout": "Выйти",
         "referAndEarn": "Приглашайте и зарабатывайте",
         "earnReferral": "Заработайте 100 €",
-        "spaceUsed": "{{space}}% памяти использовано"
+        "spaceUsed": "{{space}}% памяти использовано",
+        "account": "Аккаунт",
+        "giveFeedback": "Оставить отзыв"
       },
       "tabs": {
         "account": {

--- a/src/app/i18n/locales/tw.json
+++ b/src/app/i18n/locales/tw.json
@@ -430,7 +430,9 @@
         "logout": "登出",
         "referAndEarn": "推薦賺取",
         "earnReferral": "賺取 €100",
-        "spaceUsed": "已使用 {{space}}% 的空間"
+        "spaceUsed": "已使用 {{space}}% 的空間",
+        "account": "帳戶",
+        "giveFeedback": "提供意見回饋"
       },
       "tabs": {
         "account": {

--- a/src/app/i18n/locales/zh.json
+++ b/src/app/i18n/locales/zh.json
@@ -428,7 +428,9 @@
         "logout": "登出",
         "referAndEarn": "推荐赚取",
         "earnReferral": "赚取 €100",
-        "spaceUsed": "已使用储存空间的{{space}}%"
+        "spaceUsed": "已使用储存空间的{{space}}%",
+        "account": "账户",
+        "giveFeedback": "提供反馈"
       },
       "tabs": {
         "account": {

--- a/src/app/i18n/locales/zh.json
+++ b/src/app/i18n/locales/zh.json
@@ -428,7 +428,7 @@
         "logout": "登出",
         "referAndEarn": "推荐赚取",
         "earnReferral": "赚取 €100",
-        "spaceUsed": "已使用储存空间的{{space}}%",
+        "spaceUsed": "已用存储空间{{space}}%",
         "account": "账户",
         "giveFeedback": "提供反馈"
       },

--- a/src/views/Home/components/AccountPopover.tsx
+++ b/src/views/Home/components/AccountPopover.tsx
@@ -78,7 +78,7 @@ export default function AccountPopover({ className = '', user, plan }: Readonly<
         </p>
 
         <button
-          className="w-min cursor-pointer  text-sm font-medium text-primary no-underline"
+          className="w-full cursor-pointer  text-sm font-medium text-primary no-underline"
           onClick={() => {
             navigationService.openPreferencesDialog({
               section: 'account',

--- a/src/views/Home/components/AccountPopover.tsx
+++ b/src/views/Home/components/AccountPopover.tsx
@@ -144,7 +144,7 @@ export default function AccountPopover({ className = '', user, plan }: Readonly<
         </Item>
       )}
       <Item onClick={() => window.open(FEEDBACK_URL, '_blank', 'noopener,noreferrer')}>
-        <Megaphone size={20} />
+        <Megaphone size={20} className="-scale-x-100" />
         <p className="ml-3 truncate">{translate('views.account.popover.giveFeedback')}</p>
       </Item>
       {separator}

--- a/src/views/Home/components/AccountPopover.tsx
+++ b/src/views/Home/components/AccountPopover.tsx
@@ -53,7 +53,7 @@ export default function AccountPopover({ className = '', user, plan }: Readonly<
   }
 
   const panel = (
-    <div className="w-52">
+    <div className="w-56">
       <div className="flex items-center p-3">
         {avatarWrapper}
         <div className="ml-2 min-w-0">
@@ -78,7 +78,7 @@ export default function AccountPopover({ className = '', user, plan }: Readonly<
         </p>
 
         <button
-          className="w-full cursor-pointer  text-sm font-medium text-primary no-underline"
+          className="w-min whitespace-nowrap cursor-pointer  text-sm font-medium text-primary no-underline"
           onClick={() => {
             navigationService.openPreferencesDialog({
               section: 'account',

--- a/src/views/Home/components/AccountPopover.tsx
+++ b/src/views/Home/components/AccountPopover.tsx
@@ -76,20 +76,21 @@ export default function AccountPopover({ className = '', user, plan }: Readonly<
         <p className="text-sm text-gray-50">
           {translate('views.account.popover.spaceUsed', { space: percentageUsed })}
         </p>
-
-        <button
-          className="w-min whitespace-nowrap cursor-pointer  text-sm font-medium text-primary no-underline"
-          onClick={() => {
-            navigationService.openPreferencesDialog({
-              section: 'account',
-              subsection: 'billing',
-              workspaceUuid: selectedWorkspace?.workspaceUser.workspaceId,
-            });
-            dispatch(uiActions.setIsPreferencesDialogOpen(true));
-          }}
-        >
-          {translate('actions.upgrade')}
-        </button>
+        {plan.showUpgrade && (
+          <button
+            className="w-min whitespace-nowrap cursor-pointer  text-sm font-medium text-primary no-underline"
+            onClick={() => {
+              navigationService.openPreferencesDialog({
+                section: 'account',
+                subsection: 'billing',
+                workspaceUuid: selectedWorkspace?.workspaceUser.workspaceId,
+              });
+              dispatch(uiActions.setIsPreferencesDialogOpen(true));
+            }}
+          >
+            {translate('actions.upgrade')}
+          </button>
+        )}
       </div>
       {separator}
       <button

--- a/src/views/Home/components/AccountPopover.tsx
+++ b/src/views/Home/components/AccountPopover.tsx
@@ -32,7 +32,7 @@ export default function AccountPopover({ className = '', user, plan }: Readonly<
   const usage = memberId ? plan.businessPlanUsage : plan.planUsage;
   const limit = memberId ? plan.businessPlanLimit : plan.planLimit;
 
-  const isReferralEligible = true;
+  const isReferralEligible = useAppSelector((state: RootState) => state.referrals.isEligible);
   const { translate } = useTranslationContext();
   const name = user?.name ?? '';
   const lastName = user?.lastname ?? '';

--- a/src/views/Home/components/AccountPopover.tsx
+++ b/src/views/Home/components/AccountPopover.tsx
@@ -1,6 +1,6 @@
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
-import { Desktop, SignOut, Gear, Gift } from '@phosphor-icons/react';
+import { Desktop, SignOut, Gear, Gift, User, Megaphone } from '@phosphor-icons/react';
 import i18next from 'i18next';
 import { ReactNode } from 'react';
 import { Popover } from '@internxt/ui';
@@ -32,7 +32,7 @@ export default function AccountPopover({ className = '', user, plan }: Readonly<
   const usage = memberId ? plan.businessPlanUsage : plan.planUsage;
   const limit = memberId ? plan.businessPlanLimit : plan.planLimit;
 
-  const isReferralEligible = useAppSelector((state: RootState) => state.referrals.isEligible);
+  const isReferralEligible = true;
   const { translate } = useTranslationContext();
   const name = user?.name ?? '';
   const lastName = user?.lastname ?? '';
@@ -44,7 +44,9 @@ export default function AccountPopover({ className = '', user, plan }: Readonly<
 
   const percentageUsed = Math.round((usage / limit) * 100) || 0;
 
-  const separator = <div className="border-translate mx-3 my-0.5 border-gray-10" />;
+  const separator = <div className="border-translate mx-3 my-0.5 bg-gray-10 h-[1px]" />;
+
+  const FEEDBACK_URL = 'https://internxt.userjot.com/';
 
   function onLogout() {
     dispatch(userThunks.logoutThunk());
@@ -74,27 +76,36 @@ export default function AccountPopover({ className = '', user, plan }: Readonly<
         <p className="text-sm text-gray-50">
           {translate('views.account.popover.spaceUsed', { space: percentageUsed })}
         </p>
-        {plan.showUpgrade && (
-          <button
-            className="w-full cursor-pointer text-sm font-medium text-primary no-underline"
-            onClick={() => {
-              navigationService.openPreferencesDialog({
-                section: 'account',
-                subsection: 'billing',
-                workspaceUuid: selectedWorkspace?.workspaceUser.workspaceId,
-              });
-              dispatch(uiActions.setIsPreferencesDialogOpen(true));
-            }}
-          >
-            {translate('actions.upgrade')}
-          </button>
-        )}
+
+        <button
+          className="w-min cursor-pointer  text-sm font-medium text-primary no-underline"
+          onClick={() => {
+            navigationService.openPreferencesDialog({
+              section: 'account',
+              subsection: 'billing',
+              workspaceUuid: selectedWorkspace?.workspaceUser.workspaceId,
+            });
+            dispatch(uiActions.setIsPreferencesDialogOpen(true));
+          }}
+        >
+          {translate('actions.upgrade')}
+        </button>
       </div>
       {separator}
-      <Item onClick={() => desktopService.openDownloadAppUrl(translate)}>
-        <Desktop size={20} />
-        <p className="ml-3 truncate">{translate('views.account.popover.downloadApp')}</p>
-      </Item>
+      <button
+        className="flex w-full cursor-pointer items-center px-3 py-2 text-gray-80 no-underline hover:bg-gray-1 hover:text-gray-80 dark:hover:bg-gray-10"
+        onClick={() => {
+          navigationService.openPreferencesDialog({
+            section: 'account',
+            subsection: 'account',
+            workspaceUuid: selectedWorkspace?.workspaceUser.workspaceId,
+          });
+          dispatch(uiActions.setIsPreferencesDialogOpen(true));
+        }}
+      >
+        <User size={20} />
+        <p className="ml-3">{translate('views.account.popover.account')}</p>
+      </button>
       <button
         className="flex w-full cursor-pointer items-center px-3 py-2 text-gray-80 no-underline hover:bg-gray-1 hover:text-gray-80 dark:hover:bg-gray-10"
         onClick={() => {
@@ -109,6 +120,11 @@ export default function AccountPopover({ className = '', user, plan }: Readonly<
         <Gear size={20} />
         <p className="ml-3">{translate('views.account.popover.settings')}</p>
       </button>
+      <Item onClick={() => desktopService.openDownloadAppUrl(translate)}>
+        <Desktop size={20} />
+        <p className="ml-3 truncate">{translate('views.account.popover.downloadApp')}</p>
+      </Item>
+      {separator}
       {isReferralEligible && (
         <Item
           onClick={() => {
@@ -127,6 +143,10 @@ export default function AccountPopover({ className = '', user, plan }: Readonly<
           <p className="ml-3 truncate">{translate('views.account.popover.referAndEarn')}</p>
         </Item>
       )}
+      <Item onClick={() => window.open(FEEDBACK_URL, '_blank', 'noopener,noreferrer')}>
+        <Megaphone size={20} />
+        <p className="ml-3 truncate">{translate('views.account.popover.giveFeedback')}</p>
+      </Item>
       {separator}
       <Item onClick={onLogout}>
         <SignOut size={20} />

--- a/src/views/Home/components/AccountPopover.tsx
+++ b/src/views/Home/components/AccountPopover.tsx
@@ -93,8 +93,7 @@ export default function AccountPopover({ className = '', user, plan }: Readonly<
         )}
       </div>
       {separator}
-      <button
-        className="flex w-full cursor-pointer items-center px-3 py-2 text-gray-80 no-underline hover:bg-gray-1 hover:text-gray-80 dark:hover:bg-gray-10"
+      <Item
         onClick={() => {
           navigationService.openPreferencesDialog({
             section: 'account',
@@ -106,9 +105,8 @@ export default function AccountPopover({ className = '', user, plan }: Readonly<
       >
         <User size={20} />
         <p className="ml-3">{translate('views.account.popover.account')}</p>
-      </button>
-      <button
-        className="flex w-full cursor-pointer items-center px-3 py-2 text-gray-80 no-underline hover:bg-gray-1 hover:text-gray-80 dark:hover:bg-gray-10"
+      </Item>
+      <Item
         onClick={() => {
           navigationService.openPreferencesDialog({
             section: 'general',
@@ -120,7 +118,7 @@ export default function AccountPopover({ className = '', user, plan }: Readonly<
       >
         <Gear size={20} />
         <p className="ml-3">{translate('views.account.popover.settings')}</p>
-      </button>
+      </Item>
       <Item onClick={() => desktopService.openDownloadAppUrl(translate)}>
         <Desktop size={20} />
         <p className="ml-3 truncate">{translate('views.account.popover.downloadApp')}</p>


### PR DESCRIPTION
## Description
In this PR, we’ve updated the design of the popover that appears when you click on AccountPopover. Changes:
- We’ve changed the separator; it’s no longer a barely visible border but a div no wider than 1px, which helps us better distinguish between sections
- We’ve slightly rearranged the position of the elements and added two new ones: “Account” and “Give Feedback.” The first opens the preferences panel to the account section, just as it does in the settings. The second, meanwhile, opens a new tab to the page where users can provide feedback on the product; to do this, we’ve added the URL in the same way links to “meet” or “send” are managed
- Update all necessary content in the JSONs
- We've also slightly adjusted the width of the popover and the upgrade button to prevent the line break that occurred in some languages, which looked pretty ugly. 
## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process
Oppened the popover on all languages and checked the upgrade section shows as expected and all other buttons works as before
<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
