### PR TITLE
[MKT-850]:feat/new tracking for impact in checkout

### DIFF
--- a/src/app/analytics/impact.service.test.ts
+++ b/src/app/analytics/impact.service.test.ts
@@ -34,6 +34,7 @@ vi.mock('./utils', () => ({
     if (key === 'gclid') return '';
     return '';
   }),
+  setImpactCookies: vi.fn(),
 }));
 
 vi.mock('./addShoppers.services', () => ({
@@ -450,7 +451,7 @@ describe('handleImpactDTCCheckout', () => {
   const irclickid = 'TZr0kB1hUxyZWqOxHoVulWsMUkuRX82pgw77Sk0';
   const utmMedium = '312695';
 
-  it('When called with irclickid, then it sends a page view event to the Impact API with the correct payload', async () => {
+  it('When tracking an affiliate click, then it reports the event to Impact analytics with the click identifier', async () => {
     const getCookieMock = await import('./utils');
     vi.mocked(getCookieMock.getCookie).mockImplementation((key) => {
       if (key === 'impactAnonymousId') return 'anon_id';
@@ -472,7 +473,7 @@ describe('handleImpactDTCCheckout', () => {
     );
   });
 
-  it('When no existing anonymousId cookie, then it generates a new UUID and uses it', async () => {
+  it('When the user has not been tracked before, then it creates a unique identifier for them', async () => {
     const getCookieMock = await import('./utils');
     vi.mocked(getCookieMock.getCookie).mockImplementation((key) => {
       if (key === 'impactAnonymousId') return '';
@@ -486,7 +487,7 @@ describe('handleImpactDTCCheckout', () => {
     expect(callArgs.anonymousId).toBe(mockedUserUuid);
   });
 
-  it('When utmMedium is provided, then it includes partner_id in the Impact API payload', async () => {
+  it('When an affiliate partner is identified, then it includes their information in the tracking event', async () => {
     const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
 
     await handleImpactDTCCheckout({ irclickid, utmMedium });
@@ -495,7 +496,7 @@ describe('handleImpactDTCCheckout', () => {
     expect(callArgs.properties).toHaveProperty('partner_id', utmMedium);
   });
 
-  it('When utmMedium is not provided, then it does not include partner_id in the payload', async () => {
+  it('When no affiliate partner is identified, then the tracking event omits partner information', async () => {
     const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
 
     await handleImpactDTCCheckout({ irclickid });
@@ -504,25 +505,21 @@ describe('handleImpactDTCCheckout', () => {
     expect(callArgs.properties).not.toHaveProperty('partner_id');
   });
 
-  it('When called, then it sets the required Impact cookies', async () => {
+  it('When tracking is initialized, then it persists tracking identifiers for future affiliate attribution', async () => {
     const getCookieMock = await import('./utils');
     vi.mocked(getCookieMock.getCookie).mockImplementation((key) => {
       if (key === 'impactAnonymousId') return 'anon_id';
       return '';
     });
+    const setImpactCookiesSpy = vi.mocked(getCookieMock.setImpactCookies);
     vi.spyOn(axios, 'post').mockResolvedValue({});
-    const cookieSpy = vi.spyOn(document, 'cookie', 'set');
 
     await handleImpactDTCCheckout({ irclickid, utmMedium });
 
-    const setCookieCalls = cookieSpy.mock.calls.map((c) => c[0]);
-    expect(setCookieCalls.some((c) => c.startsWith('impactSource=Impact'))).toBe(true);
-    expect(setCookieCalls.some((c) => c.startsWith('impactAnonymousId=anon_id'))).toBe(true);
-    expect(setCookieCalls.some((c) => c.startsWith(`impactClickId=${irclickid}`))).toBe(true);
-    expect(setCookieCalls.some((c) => c.startsWith(`impactPartnerId=${utmMedium}`))).toBe(true);
+    expect(setImpactCookiesSpy).toHaveBeenCalledWith('anon_id', irclickid, utmMedium);
   });
 
-  it('When the Impact API call fails, then it reports the error', async () => {
+  it('When the tracking service is unavailable, then it handles the failure gracefully and continues', async () => {
     const unknownError = new Error('API Error');
     vi.spyOn(axios, 'post').mockRejectedValue(unknownError);
     const errorServiceSpy = vi.spyOn(errorService, 'reportError');

--- a/src/app/analytics/impact.service.test.ts
+++ b/src/app/analytics/impact.service.test.ts
@@ -537,3 +537,287 @@ describe('uuid library', () => {
     expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
   });
 });
+
+describe('savePaymentDataInLocalStorage - edge cases', () => {
+  it('When no plan has been selected, then no plan details are stored for later', () => {
+    const setToLocalStorageSpy = vi.spyOn(localStorageService, 'set');
+
+    savePaymentDataInLocalStorage({
+      subscriptionId: subId,
+      paymentIntentId,
+      selectedPlan: undefined,
+      users: 1,
+      couponCodeData: promoCode,
+      isFirstPurchase: true,
+    });
+
+    expect(setToLocalStorageSpy).not.toHaveBeenCalledWith('productName', expect.anything());
+    expect(setToLocalStorageSpy).not.toHaveBeenCalledWith('amountPaid', expect.anything());
+    expect(setToLocalStorageSpy).not.toHaveBeenCalledWith('priceId', expect.anything());
+    expect(setToLocalStorageSpy).not.toHaveBeenCalledWith('currency', expect.anything());
+  });
+
+  it('When a discount code has no identifier, then it is not stored for later use', () => {
+    const setToLocalStorageSpy = vi.spyOn(localStorageService, 'set');
+    const couponWithoutName = { ...promoCode, codeName: '' };
+
+    savePaymentDataInLocalStorage({
+      subscriptionId: subId,
+      paymentIntentId,
+      selectedPlan: product as PriceWithTax,
+      users: 1,
+      couponCodeData: couponWithoutName,
+      isFirstPurchase: true,
+    });
+
+    expect(setToLocalStorageSpy).not.toHaveBeenCalledWith('couponCode', expect.anything());
+  });
+
+  it('When no discount code is provided, then no discount information is stored', () => {
+    const setToLocalStorageSpy = vi.spyOn(localStorageService, 'set');
+
+    savePaymentDataInLocalStorage({
+      subscriptionId: subId,
+      paymentIntentId,
+      selectedPlan: product as PriceWithTax,
+      users: 1,
+      couponCodeData: undefined,
+      isFirstPurchase: true,
+    });
+
+    expect(setToLocalStorageSpy).not.toHaveBeenCalledWith('couponCode', expect.anything());
+  });
+
+  it('When the user buys a lifetime plan, then no recurring subscription reference is stored', () => {
+    const setToLocalStorageSpy = vi.spyOn(localStorageService, 'set');
+    const lifetimeProduct = { ...product, price: { ...product.price, interval: 'lifetime' } };
+
+    savePaymentDataInLocalStorage({
+      subscriptionId: subId,
+      paymentIntentId,
+      selectedPlan: lifetimeProduct as PriceWithTax,
+      users: 1,
+      couponCodeData: promoCode,
+      isFirstPurchase: true,
+    });
+
+    expect(setToLocalStorageSpy).not.toHaveBeenCalledWith('subscriptionId', expect.anything());
+  });
+
+  it('When the user buys a subscription plan, then no one-time payment reference is stored', () => {
+    const setToLocalStorageSpy = vi.spyOn(localStorageService, 'set');
+
+    savePaymentDataInLocalStorage({
+      subscriptionId: subId,
+      paymentIntentId,
+      selectedPlan: product as PriceWithTax,
+      users: 1,
+      couponCodeData: promoCode,
+      isFirstPurchase: true,
+    });
+
+    expect(setToLocalStorageSpy).not.toHaveBeenCalledWith('paymentIntentId', expect.anything());
+  });
+
+  it('When this is a returning customer, then that is correctly recorded', () => {
+    const setToLocalStorageSpy = vi.spyOn(localStorageService, 'set');
+
+    savePaymentDataInLocalStorage({
+      subscriptionId: subId,
+      paymentIntentId,
+      selectedPlan: product as PriceWithTax,
+      users: 1,
+      couponCodeData: promoCode,
+      isFirstPurchase: false,
+    });
+
+    expect(setToLocalStorageSpy).toHaveBeenCalledWith('isFirstPurchase', 'false');
+  });
+});
+
+describe('trackSignUp - additional coverage', () => {
+  it('When the traffic source is unknown, then no signup event is reported', async () => {
+    const getCookieMock = await import('./utils');
+    vi.mocked(getCookieMock.getCookie).mockImplementation((key) => {
+      if (key === 'impactSource') return '';
+      if (key === 'impactAnonymousId') return 'anon_id';
+      return '';
+    });
+    const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
+
+    await trackSignUp(mockedUserUuid);
+
+    expect(axiosSpy).not.toHaveBeenCalled();
+  });
+
+  it('When the user arrived via a Google ad, then their ad click identifier is included in the signup event', async () => {
+    const getCookieMock = await import('./utils');
+    vi.mocked(getCookieMock.getCookie).mockImplementation((key) => {
+      if (key === 'gclid') return 'test_gclid_123';
+      if (key === 'impactSource') return 'ads';
+      if (key === 'impactAnonymousId') return 'anon_id';
+      return '';
+    });
+    const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
+
+    await trackSignUp(mockedUserUuid);
+
+    const callArgs = axiosSpy.mock.calls[0][1] as Record<string, unknown>;
+    expect(callArgs).toHaveProperty('gclid', 'test_gclid_123');
+  });
+
+  it('When the user did not arrive via a Google ad, then no ad click identifier is included in the signup event', async () => {
+    const getCookieMock = await import('./utils');
+    vi.mocked(getCookieMock.getCookie).mockImplementation((key) => {
+      if (key === 'gclid') return '';
+      if (key === 'impactSource') return 'ads';
+      if (key === 'impactAnonymousId') return 'anon_id';
+      return '';
+    });
+    const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
+
+    await trackSignUp(mockedUserUuid);
+
+    const callArgs = axiosSpy.mock.calls[0][1] as Record<string, unknown>;
+    expect(callArgs).not.toHaveProperty('gclid');
+  });
+
+  it('When Google Analytics is not available, then the signup event is still reported to Impact', async () => {
+    globalThis.window.gtag = undefined as any;
+    const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
+
+    await trackSignUp(mockedUserUuid);
+
+    expect(axiosSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('trackPaymentConversion - additional coverage', () => {
+  it('When the shopping affiliate tracker fails, then the error is handled gracefully and the Impact conversion is still reported', async () => {
+    const { sendAddShoppersConversion } = await import('./addShoppers.services');
+    vi.mocked(sendAddShoppersConversion).mockImplementation(() => {
+      throw new Error('AddShoppers Error');
+    });
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
+
+    await expect(trackPaymentConversion()).resolves.not.toThrow();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('[Impact Service] AddShoppers conversion failed:', expect.any(Error));
+    expect(axiosSpy).toHaveBeenCalledTimes(1);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('When no discount code was used, then no promo code is included in the conversion event', async () => {
+    vi.spyOn(localStorageService, 'get').mockImplementation((key) => {
+      if (key === 'couponCode') return null;
+      if (key === 'amountPaid') return expectedAmount;
+      if (key === 'subscriptionId') return subId;
+      if (key === 'isFirstPurchase') return 'true';
+      if (key === 'currency') return product.price.currency;
+      return null;
+    });
+    const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
+
+    await trackPaymentConversion();
+
+    const callArgs = axiosSpy.mock.calls[0][1] as { properties: Record<string, unknown> };
+    expect(callArgs.properties).not.toHaveProperty('order_promo_code');
+  });
+
+  it('When a first-time customer arrives through a tracked channel, then the conversion is reported even without a discount code', async () => {
+    vi.spyOn(localStorageService, 'get').mockImplementation((key) => {
+      if (key === 'couponCode') return null;
+      if (key === 'amountPaid') return expectedAmount;
+      if (key === 'subscriptionId') return subId;
+      if (key === 'isFirstPurchase') return 'true';
+      if (key === 'currency') return product.price.currency;
+      return null;
+    });
+    const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
+
+    await trackPaymentConversion();
+
+    expect(axiosSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('When a first-time customer uses the CLOUDOFF partner code on a direct visit, then the conversion is still attributed to the partner', async () => {
+    const getCookieMock = await import('./utils');
+    vi.mocked(getCookieMock.getCookie).mockImplementation((key) => {
+      if (key === 'impactSource') return 'direct';
+      if (key === 'impactAnonymousId') return 'anon_id';
+      return '';
+    });
+    vi.spyOn(localStorageService, 'get').mockImplementation((key) => {
+      if (key === 'couponCode') return 'CLOUDOFF';
+      if (key === 'amountPaid') return expectedAmount;
+      if (key === 'subscriptionId') return subId;
+      if (key === 'isFirstPurchase') return 'true';
+      return null;
+    });
+    const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
+
+    await trackPaymentConversion();
+
+    expect(axiosSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('When a first-time customer uses the SPECIAL partner code on a direct visit, then the conversion is still attributed to the partner', async () => {
+    const getCookieMock = await import('./utils');
+    vi.mocked(getCookieMock.getCookie).mockImplementation((key) => {
+      if (key === 'impactSource') return 'direct';
+      if (key === 'impactAnonymousId') return 'anon_id';
+      return '';
+    });
+    vi.spyOn(localStorageService, 'get').mockImplementation((key) => {
+      if (key === 'couponCode') return 'SPECIAL';
+      if (key === 'amountPaid') return expectedAmount;
+      if (key === 'subscriptionId') return subId;
+      if (key === 'isFirstPurchase') return 'true';
+      return null;
+    });
+    const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
+
+    await trackPaymentConversion();
+
+    expect(axiosSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('When a conversion is tracked, then the shopping affiliate is notified with the customer and purchase details', async () => {
+    const { sendAddShoppersConversion } = await import('./addShoppers.services');
+    vi.spyOn(axios, 'post').mockResolvedValue({});
+
+    await trackPaymentConversion();
+
+    expect(sendAddShoppersConversion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderId: mockedUserUuid,
+        email: 'usuario@ejemplo.com',
+        currency: product.price.currency,
+      }),
+    );
+  });
+});
+
+describe('handleImpactDTCCheckout - additional coverage', () => {
+  const irclickid = 'TZr0kB1hUxyZWqOxHoVulWsMUkuRX82pgw77Sk0';
+
+  it('When an affiliate click is tracked, then the browser and page information is included in the event', async () => {
+    const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
+
+    await handleImpactDTCCheckout({ irclickid });
+
+    const callArgs = axiosSpy.mock.calls[0][1] as { context: Record<string, unknown> };
+    expect(callArgs.context).toHaveProperty('userAgent');
+    expect(callArgs.context).toHaveProperty('page');
+  });
+
+  it('When no affiliate partner is identified, then no partner information is included in the event', async () => {
+    const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
+
+    await handleImpactDTCCheckout({ irclickid, utmMedium: null });
+
+    const callArgs = axiosSpy.mock.calls[0][1] as { properties: Record<string, unknown> };
+    expect(callArgs.properties).not.toHaveProperty('partner_id');
+  });
+});

--- a/src/app/analytics/impact.service.test.ts
+++ b/src/app/analytics/impact.service.test.ts
@@ -7,7 +7,12 @@ import errorService from 'services/error.service';
 import localStorageService from 'services/local-storage.service';
 import { getProductAmount } from 'views/Checkout/utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { savePaymentDataInLocalStorage, trackPaymentConversion, trackSignUp } from './impact.service';
+import {
+  handleImpactDTCCheckout,
+  savePaymentDataInLocalStorage,
+  trackPaymentConversion,
+  trackSignUp,
+} from './impact.service';
 
 vi.mock('services/local-storage.service', () => ({
   default: {
@@ -438,6 +443,93 @@ describe('Testing Impact Service', () => {
         consoleErrorSpy.mockRestore();
       });
     });
+  });
+});
+
+describe('handleImpactDTCCheckout', () => {
+  const irclickid = 'TZr0kB1hUxyZWqOxHoVulWsMUkuRX82pgw77Sk0';
+  const utmMedium = '312695';
+
+  it('When called with irclickid, then it sends a page view event to the Impact API with the correct payload', async () => {
+    const getCookieMock = await import('./utils');
+    vi.mocked(getCookieMock.getCookie).mockImplementation((key) => {
+      if (key === 'impactAnonymousId') return 'anon_id';
+      return '';
+    });
+    const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
+
+    await handleImpactDTCCheckout({ irclickid });
+
+    expect(axiosSpy).toHaveBeenCalledTimes(1);
+    expect(axiosSpy).toHaveBeenCalledWith(
+      mockImpactApiUrl,
+      expect.objectContaining({
+        anonymousId: 'anon_id',
+        type: 'page',
+        timestamp: expect.any(String),
+        properties: expect.objectContaining({ irclickid }),
+      }),
+    );
+  });
+
+  it('When no existing anonymousId cookie, then it generates a new UUID and uses it', async () => {
+    const getCookieMock = await import('./utils');
+    vi.mocked(getCookieMock.getCookie).mockImplementation((key) => {
+      if (key === 'impactAnonymousId') return '';
+      return '';
+    });
+    const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
+
+    await handleImpactDTCCheckout({ irclickid });
+
+    const callArgs = axiosSpy.mock.calls[0][1] as { anonymousId: string };
+    expect(callArgs.anonymousId).toBe(mockedUserUuid);
+  });
+
+  it('When utmMedium is provided, then it includes partner_id in the Impact API payload', async () => {
+    const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
+
+    await handleImpactDTCCheckout({ irclickid, utmMedium });
+
+    const callArgs = axiosSpy.mock.calls[0][1] as { properties: Record<string, unknown> };
+    expect(callArgs.properties).toHaveProperty('partner_id', utmMedium);
+  });
+
+  it('When utmMedium is not provided, then it does not include partner_id in the payload', async () => {
+    const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
+
+    await handleImpactDTCCheckout({ irclickid });
+
+    const callArgs = axiosSpy.mock.calls[0][1] as { properties: Record<string, unknown> };
+    expect(callArgs.properties).not.toHaveProperty('partner_id');
+  });
+
+  it('When called, then it sets the required Impact cookies', async () => {
+    const getCookieMock = await import('./utils');
+    vi.mocked(getCookieMock.getCookie).mockImplementation((key) => {
+      if (key === 'impactAnonymousId') return 'anon_id';
+      return '';
+    });
+    vi.spyOn(axios, 'post').mockResolvedValue({});
+    const cookieSpy = vi.spyOn(document, 'cookie', 'set');
+
+    await handleImpactDTCCheckout({ irclickid, utmMedium });
+
+    const setCookieCalls = cookieSpy.mock.calls.map((c) => c[0]);
+    expect(setCookieCalls.some((c) => c.startsWith('impactSource=Impact'))).toBe(true);
+    expect(setCookieCalls.some((c) => c.startsWith('impactAnonymousId=anon_id'))).toBe(true);
+    expect(setCookieCalls.some((c) => c.startsWith(`impactClickId=${irclickid}`))).toBe(true);
+    expect(setCookieCalls.some((c) => c.startsWith(`impactPartnerId=${utmMedium}`))).toBe(true);
+  });
+
+  it('When the Impact API call fails, then it reports the error', async () => {
+    const unknownError = new Error('API Error');
+    vi.spyOn(axios, 'post').mockRejectedValue(unknownError);
+    const errorServiceSpy = vi.spyOn(errorService, 'reportError');
+
+    await expect(handleImpactDTCCheckout({ irclickid })).resolves.not.toThrow();
+
+    expect(errorServiceSpy).toHaveBeenCalledWith(unknownError);
   });
 });
 

--- a/src/app/analytics/impact.service.ts
+++ b/src/app/analytics/impact.service.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { v4 as uuidV4 } from 'uuid';
 import dayjs from 'dayjs';
-import { getCookie } from './utils';
+import { getCookie, setImpactCookies } from './utils';
 import errorService from 'services/error.service';
 import localStorageService from 'services/local-storage.service';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
@@ -81,24 +81,8 @@ export async function handleImpactDTCCheckout({
     const IMPACT_API = envService.getVariable('impactApiUrl');
     const existingAnonymousId = getCookie('impactAnonymousId');
     const anonymousId = existingAnonymousId || uuidV4();
-    const cookieDomain = 'internxt.com';
 
-    const sourceExpiration = new Date();
-    sourceExpiration.setHours(sourceExpiration.getHours() + 2);
-
-    const anonymousExpiration = new Date();
-    anonymousExpiration.setFullYear(anonymousExpiration.getFullYear() + 10);
-
-    const trackingExpiration = new Date();
-    trackingExpiration.setDate(trackingExpiration.getDate() + 30);
-
-    document.cookie = `impactSource=Impact;expires=${sourceExpiration.toUTCString()};domain=${cookieDomain};Path=/`;
-    document.cookie = `impactAnonymousId=${anonymousId};expires=${anonymousExpiration.toUTCString()};domain=${cookieDomain};Path=/`;
-    document.cookie = `impactClickId=${irclickid};expires=${trackingExpiration.toUTCString()};domain=${cookieDomain};Path=/`;
-
-    if (utmMedium) {
-      document.cookie = `impactPartnerId=${utmMedium};expires=${trackingExpiration.toUTCString()};domain=${cookieDomain};Path=/`;
-    }
+    setImpactCookies(anonymousId, irclickid, utmMedium);
 
     await axios.post(IMPACT_API, {
       anonymousId,

--- a/src/app/analytics/impact.service.ts
+++ b/src/app/analytics/impact.service.ts
@@ -106,7 +106,7 @@ export async function handleImpactDTCCheckout({
       context: {
         userAgent: navigator.userAgent,
         page: {
-          url: window.location.href,
+          url: globalThis.location.href,
           referrer: document.referrer,
         },
       },

--- a/src/app/analytics/impact.service.ts
+++ b/src/app/analytics/impact.service.ts
@@ -70,6 +70,58 @@ export function savePaymentDataInLocalStorage({
   localStorageService.set('isFirstPurchase', String(isFirstPurchase));
 }
 
+export async function handleImpactDTCCheckout({
+  irclickid,
+  utmMedium,
+}: {
+  irclickid: string;
+  utmMedium?: string | null;
+}): Promise<void> {
+  try {
+    const IMPACT_API = envService.getVariable('impactApiUrl');
+    const existingAnonymousId = getCookie('impactAnonymousId');
+    const anonymousId = existingAnonymousId || uuidV4();
+    const cookieDomain = 'internxt.com';
+
+    const sourceExpiration = new Date();
+    sourceExpiration.setHours(sourceExpiration.getHours() + 2);
+
+    const anonymousExpiration = new Date();
+    anonymousExpiration.setFullYear(anonymousExpiration.getFullYear() + 10);
+
+    const trackingExpiration = new Date();
+    trackingExpiration.setDate(trackingExpiration.getDate() + 30);
+
+    document.cookie = `impactSource=Impact;expires=${sourceExpiration.toUTCString()};domain=${cookieDomain};Path=/`;
+    document.cookie = `impactAnonymousId=${anonymousId};expires=${anonymousExpiration.toUTCString()};domain=${cookieDomain};Path=/`;
+    document.cookie = `impactClickId=${irclickid};expires=${trackingExpiration.toUTCString()};domain=${cookieDomain};Path=/`;
+
+    if (utmMedium) {
+      document.cookie = `impactPartnerId=${utmMedium};expires=${trackingExpiration.toUTCString()};domain=${cookieDomain};Path=/`;
+    }
+
+    await axios.post(IMPACT_API, {
+      anonymousId,
+      timestamp: dayjs().format('YYYY-MM-DDTHH:mm:ss.sssZ'),
+      context: {
+        userAgent: navigator.userAgent,
+        page: {
+          url: window.location.href,
+          referrer: document.referrer,
+        },
+      },
+      type: 'page',
+      properties: {
+        irclickid,
+        ...(utmMedium && { partner_id: utmMedium }),
+      },
+    });
+  } catch (error) {
+    const castedError = errorService.castError(error);
+    errorService.reportError(castedError);
+  }
+}
+
 export async function trackSignUp(uuid: string): Promise<void> {
   try {
     const gclid = getCookie('gclid');

--- a/src/app/analytics/utils.test.ts
+++ b/src/app/analytics/utils.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { setImpactCookies } from './utils';
+
+function getCookieCalls(cookieSetter: ReturnType<typeof vi.spyOn>): string[] {
+  return cookieSetter.mock.calls.map((call) => call[0] as string);
+}
+
+describe('setImpactCookies', () => {
+  let cookieSetter: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    cookieSetter = vi.spyOn(document, 'cookie', 'set');
+  });
+
+  it('When called, then it marks the traffic source as Impact', () => {
+    setImpactCookies('anon_123', 'click_abc');
+
+    const sourceCookie = getCookieCalls(cookieSetter).find((v) => v.startsWith('impactSource='));
+    expect(sourceCookie).toBeDefined();
+    expect(sourceCookie).toContain('impactSource=Impact');
+  });
+
+  it('When called, then it stores the anonymous identifier so the user can be recognized later', () => {
+    setImpactCookies('anon_123', 'click_abc');
+
+    const anonCookie = getCookieCalls(cookieSetter).find((v) => v.startsWith('impactAnonymousId='));
+    expect(anonCookie).toBeDefined();
+    expect(anonCookie).toContain('impactAnonymousId=anon_123');
+  });
+
+  it('When called, then it stores the affiliate click identifier for attribution', () => {
+    setImpactCookies('anon_123', 'click_abc');
+
+    const clickCookie = getCookieCalls(cookieSetter).find((v) => v.startsWith('impactClickId='));
+    expect(clickCookie).toBeDefined();
+    expect(clickCookie).toContain('impactClickId=click_abc');
+  });
+
+  it('When an affiliate partner is identified, then their identifier is also stored', () => {
+    setImpactCookies('anon_123', 'click_abc', 'partner_456');
+
+    const partnerCookie = getCookieCalls(cookieSetter).find((v) => v.startsWith('impactPartnerId='));
+    expect(partnerCookie).toBeDefined();
+    expect(partnerCookie).toContain('impactPartnerId=partner_456');
+  });
+
+  it('When no affiliate partner is identified, then no partner cookie is stored', () => {
+    setImpactCookies('anon_123', 'click_abc');
+
+    const partnerCookie = getCookieCalls(cookieSetter).find((v) => v.startsWith('impactPartnerId='));
+    expect(partnerCookie).toBeUndefined();
+  });
+
+  it('When no affiliate partner is identified due to an explicit absence, then no partner cookie is stored', () => {
+    setImpactCookies('anon_123', 'click_abc', null);
+
+    const partnerCookie = getCookieCalls(cookieSetter).find((v) => v.startsWith('impactPartnerId='));
+    expect(partnerCookie).toBeUndefined();
+  });
+
+  it('When called, then the traffic source cookie expires within hours, not days', () => {
+    const before = new Date();
+    setImpactCookies('anon_123', 'click_abc');
+
+    const sourceCookie = getCookieCalls(cookieSetter).find((v) => v.startsWith('impactSource='))!;
+    const expiresDate = new Date(sourceCookie.match(/expires=([^;]+)/)![1]);
+    const hoursDiff = (expiresDate.getTime() - before.getTime()) / (1000 * 60 * 60);
+
+    expect(hoursDiff).toBeGreaterThan(1);
+    expect(hoursDiff).toBeLessThan(3);
+  });
+
+  it('When called, then the anonymous identifier cookie is kept for years so returning users are recognized', () => {
+    const before = new Date();
+    setImpactCookies('anon_123', 'click_abc');
+
+    const anonCookie = getCookieCalls(cookieSetter).find((v) => v.startsWith('impactAnonymousId='))!;
+    const expiresDate = new Date(anonCookie.match(/expires=([^;]+)/)![1]);
+    const yearsDiff = (expiresDate.getTime() - before.getTime()) / (1000 * 60 * 60 * 24 * 365);
+
+    expect(yearsDiff).toBeGreaterThan(9);
+    expect(yearsDiff).toBeLessThan(11);
+  });
+
+  it('When called, then the affiliate click cookie expires after 30 days', () => {
+    const before = new Date();
+    setImpactCookies('anon_123', 'click_abc');
+
+    const clickCookie = getCookieCalls(cookieSetter).find((v) => v.startsWith('impactClickId='))!;
+    const expiresDate = new Date(clickCookie.match(/expires=([^;]+)/)![1]);
+    const daysDiff = (expiresDate.getTime() - before.getTime()) / (1000 * 60 * 60 * 24);
+
+    expect(daysDiff).toBeGreaterThan(29);
+    expect(daysDiff).toBeLessThan(31);
+  });
+});

--- a/src/app/analytics/utils.ts
+++ b/src/app/analytics/utils.ts
@@ -5,6 +5,27 @@ export function setCookie(cookieName: string, cookieValue: string, expDays = 30)
   window.document.cookie = `${cookieName}=${cookieValue}; ${expires}; domain=internxt.com'`;
 }
 
+export function setImpactCookies(anonymousId: string, irclickid: string, utmMedium?: string | null): void {
+  const cookieDomain = 'internxt.com';
+
+  const sourceExpiration = new Date();
+  sourceExpiration.setHours(sourceExpiration.getHours() + 2);
+
+  const anonymousExpiration = new Date();
+  anonymousExpiration.setFullYear(anonymousExpiration.getFullYear() + 10);
+
+  const trackingExpiration = new Date();
+  trackingExpiration.setDate(trackingExpiration.getDate() + 30);
+
+  document.cookie = `impactSource=Impact;expires=${sourceExpiration.toUTCString()};domain=${cookieDomain};Path=/`;
+  document.cookie = `impactAnonymousId=${anonymousId};expires=${anonymousExpiration.toUTCString()};domain=${cookieDomain};Path=/`;
+  document.cookie = `impactClickId=${irclickid};expires=${trackingExpiration.toUTCString()};domain=${cookieDomain};Path=/`;
+
+  if (utmMedium) {
+    document.cookie = `impactPartnerId=${utmMedium};expires=${trackingExpiration.toUTCString()};domain=${cookieDomain};Path=/`;
+  }
+}
+
 export function getCookie(cookieName: string): string {
   const cookie = {};
   document.cookie.split(';').forEach((el) => {

--- a/src/views/Checkout/hooks/useCheckoutQueryParams.ts
+++ b/src/views/Checkout/hooks/useCheckoutQueryParams.ts
@@ -7,5 +7,7 @@ export const useCheckoutQueryParams = () => {
     currency: params.get('currency'),
     paramMobileToken: params.get('mobileToken'),
     gclid: params.get('gclid') ?? '',
+    irclickid: params.get('irclickid'),
+    utmMedium: params.get('utm_medium'),
   };
 };

--- a/src/views/Checkout/views/CheckoutViewWrapper.tsx
+++ b/src/views/Checkout/views/CheckoutViewWrapper.tsx
@@ -30,6 +30,7 @@ import { CRYPTO_PAYMENT_DIALOG_KEY, CryptoPaymentDialog } from 'views/Checkout/c
 import { useActionDialog } from 'app/contexts/dialog-manager/useActionDialog';
 import { generateCaptchaToken } from 'utils/generateCaptchaToken';
 import gaService from 'app/analytics/ga.service';
+import { handleImpactDTCCheckout } from 'app/analytics/impact.service';
 import referralService from 'services/referral.service';
 import metaService from 'app/analytics/meta.service';
 import { useCheckoutQueryParams } from '../hooks/useCheckoutQueryParams';
@@ -56,7 +57,7 @@ const CheckoutViewWrapper = () => {
   const { setAuthMethod, setIsUserPaying, setIsUpdateSubscriptionDialogOpen, setIsUpdatingSubscription } =
     useCheckout(dispatchReducer);
 
-  const { planId, promotionCode, currency, paramMobileToken, gclid } = useCheckoutQueryParams();
+  const { planId, promotionCode, currency, paramMobileToken, gclid, irclickid, utmMedium } = useCheckoutQueryParams();
   const { location: userLocationData } = useUserLocation();
 
   const { couponError, promoCodeData, onPromoCodeError, removeCouponCode, fetchPromotionCode } = usePromotionalCode({
@@ -119,6 +120,9 @@ const CheckoutViewWrapper = () => {
       expiryDate.setTime(expiryDate.getTime() + GCLID_COOKIE_LIFESPAN_DAYS * MILLISECONDS_PER_DAY);
       document.cookie = `gclid=${gclid}; expires=${expiryDate.toUTCString()}; path=/`;
       localStorageService.set(STORAGE_KEYS.GCLID, gclid);
+    }
+    if (irclickid) {
+      handleImpactDTCCheckout({ irclickid, utmMedium });
     }
     referralService.captureUcc();
   }, []);


### PR DESCRIPTION
## Description

When traffic arrives directly at the checkout page via a DTC affiliate link (e.g. drive.internxt.com/checkout?irclickid=...), Impact tracking was not working*. The impactSource and impactAnonymousId cookies were never set because the website's handleImpact() never ran, so trackPaymentConversion() silently skipped sending the conversion event. As a result, subid1 and shareID were not populating in Impact's dashboard and sales were not attributed to affiliates.

The fix replicates the same tracking logic the website runs on the homepage flow, but now directly in the checkout page:

- If irclickid is present in the URL on load, handleImpactDTCCheckout sets the impactSource, impactAnonymousId, and impactClickId cookies on internxt.com domain.
- It also fires a page-view event to the Impact API with the irclickid and anonymousId, which is the step that allows Impact to later link that anonymous ID to the affiliate click when the conversion event arrives.
## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
