### PR TITLE
[_]: feat/add notification toast instead of file size limit dialog

### DIFF
--- a/src/app/core/layouts/HeaderAndSidenavLayout/HeaderAndSidenavLayout.tsx
+++ b/src/app/core/layouts/HeaderAndSidenavLayout/HeaderAndSidenavLayout.tsx
@@ -11,7 +11,6 @@ import DriveItemInfoMenu from 'app/drive/components/DriveItemInfoMenu/DriveItemI
 import { getAppConfig } from 'services/config.service';
 import ShareItemDialog from '../../../../views/Shared/components/ShareItemDialog/ShareItemDialog';
 import { Sidebar as VersionHistorySidebar } from '../../../../views/Drive/components/VersionHistory';
-import ReachedFileSizeLimitDialog from 'app/drive/components/ReachedFileSizeLimitDialog';
 
 export interface HeaderAndSidenavLayoutProps {
   children: JSX.Element;
@@ -41,7 +40,7 @@ export default function HeaderAndSidenavLayout(props: HeaderAndSidenavLayoutProp
     <div className="flex h-auto min-h-full flex-col">
       {isShareItemDialogOpen && itemToShare && <ShareItemDialog share={itemToShare?.share} item={itemToShare.item} />}
       {isReachedPlanLimitDialogOpen && <ReachedPlanLimitDialog />}
-      <ReachedFileSizeLimitDialog />
+      {/* <ReachedFileSizeLimitDialog /> */}
 
       <div className="flex h-1 grow">
         <Sidenav />

--- a/src/app/i18n/locales/de.json
+++ b/src/app/i18n/locales/de.json
@@ -1484,7 +1484,8 @@
     "errorAcceptingWorkspaceInvitation": "Beim Annehmen der Einladung ist ein Fehler aufgetreten",
     "errorWhileUpdatingWorkspaceMembers": "Beim Aktualisieren der Mitglieder ist ein Fehler aufgetreten",
     "errorWhileFetchingCurrentWorkspaceMembers": "Beim Abrufen der Mitglieder des Arbeitsbereichs ist ein Fehler aufgetreten",
-    "newMembersCannotBeLessThanTheExistentOnesError": "Die ausgewählten Mitglieder dürfen nicht weniger sein als die aktuellen Mitglieder des Arbeitsbereichs"
+    "newMembersCannotBeLessThanTheExistentOnesError": "Die ausgewählten Mitglieder dürfen nicht weniger sein als die aktuellen Mitglieder des Arbeitsbereichs",
+    "reachedFileSizeLimit": "Dateigrößenlimit überschritten"
   },
   "actions": {
     "undo": "Rückgängig machen",

--- a/src/app/i18n/locales/en.json
+++ b/src/app/i18n/locales/en.json
@@ -1565,7 +1565,8 @@
     "errorAcceptingWorkspaceInvitation": "Something went wrong while accepting the invitation",
     "errorWhileUpdatingWorkspaceMembers": "Something went wrong while updating the members",
     "errorWhileFetchingCurrentWorkspaceMembers": "Something went wrong while fetching workspace members",
-    "newMembersCannotBeLessThanTheExistentOnesError": "Selected members cannot be fewer than current workspace members"
+    "newMembersCannotBeLessThanTheExistentOnesError": "Selected members cannot be fewer than current workspace members",
+    "reachedFileSizeLimit": "File size limit exceeded"
   },
   "actions": {
     "undo": "Undo",

--- a/src/app/i18n/locales/es.json
+++ b/src/app/i18n/locales/es.json
@@ -1528,7 +1528,8 @@
     "errorAcceptingWorkspaceInvitation": "Ocurrió un error al aceptar la invitación",
     "errorWhileUpdatingWorkspaceMembers": "Ocurrió un error al actualizar los miembros",
     "errorWhileFetchingCurrentWorkspaceMembers": "Ocurrió un error al obtener los miembros del espacio de trabajo",
-    "newMembersCannotBeLessThanTheExistentOnesError": "Los miembros seleccionados no pueden ser menos que los miembros actuales del espacio de trabajo"
+    "newMembersCannotBeLessThanTheExistentOnesError": "Los miembros seleccionados no pueden ser menos que los miembros actuales del espacio de trabajo",
+    "reachedFileSizeLimit": "Límite de tamaño de archivo superado"
   },
   "success": {
     "passwordChanged": "Contraseña actualizada correctamente",

--- a/src/app/i18n/locales/fr.json
+++ b/src/app/i18n/locales/fr.json
@@ -1489,7 +1489,8 @@
     "errorAcceptingWorkspaceInvitation": "Une erreur s'est produite lors de l'acceptation de l'invitation",
     "errorWhileUpdatingWorkspaceMembers": "Une erreur s'est produite lors de la mise à jour des membres",
     "errorWhileFetchingCurrentWorkspaceMembers": "Une erreur s'est produite lors de la récupération des membres de l'espace de travail",
-    "newMembersCannotBeLessThanTheExistentOnesError": "Les membres sélectionnés ne peuvent pas être inférieurs au nombre de membres actuels de l'espace de travail"
+    "newMembersCannotBeLessThanTheExistentOnesError": "Les membres sélectionnés ne peuvent pas être inférieurs au nombre de membres actuels de l'espace de travail",
+    "reachedFileSizeLimit": "Limite de taille de fichier dépassée"
   },
   "actions": {
     "undo": "Annuler",

--- a/src/app/i18n/locales/it.json
+++ b/src/app/i18n/locales/it.json
@@ -1596,7 +1596,8 @@
     "errorAcceptingWorkspaceInvitation": "Si è verificato un errore durante l'accettazione dell'invito",
     "errorWhileUpdatingWorkspaceMembers": "Si è verificato un errore durante l'aggiornamento dei membri",
     "errorWhileFetchingCurrentWorkspaceMembers": "Si è verificato un errore durante il recupero dei membri dello spazio di lavoro",
-    "newMembersCannotBeLessThanTheExistentOnesError": "I membri selezionati non possono essere meno dei membri attuali dello spazio di lavoro"
+    "newMembersCannotBeLessThanTheExistentOnesError": "I membri selezionati non possono essere meno dei membri attuali dello spazio di lavoro",
+    "reachedFileSizeLimit": "Limite di dimensione del file superato"
   },
   "actions": {
     "undo": "Annulla",

--- a/src/app/i18n/locales/ru.json
+++ b/src/app/i18n/locales/ru.json
@@ -1504,7 +1504,8 @@
     "errorAcceptingWorkspaceInvitation": "Произошла ошибка при принятии приглашения",
     "errorWhileUpdatingWorkspaceMembers": "Произошла ошибка при обновлении участников",
     "errorWhileFetchingCurrentWorkspaceMembers": "Произошла ошибка при получении участников рабочего пространства",
-    "newMembersCannotBeLessThanTheExistentOnesError": "Выбранных участников не может быть меньше, чем текущих участников рабочего пространства"
+    "newMembersCannotBeLessThanTheExistentOnesError": "Выбранных участников не может быть меньше, чем текущих участников рабочего пространства",
+    "reachedFileSizeLimit": "Превышен лимит размера файла"
   },
   "actions": {
     "undo": "Отменить",

--- a/src/app/i18n/locales/tw.json
+++ b/src/app/i18n/locales/tw.json
@@ -1495,7 +1495,8 @@
     "errorAcceptingWorkspaceInvitation": "接受邀請時出錯",
     "errorWhileUpdatingWorkspaceMembers": "更新成員時出了點問題",
     "errorWhileFetchingCurrentWorkspaceMembers": "獲取工作區成員時出了點問題",
-    "newMembersCannotBeLessThanTheExistentOnesError": "選擇的成員數量不能少於當前工作區的成員數量。"
+    "newMembersCannotBeLessThanTheExistentOnesError": "選擇的成員數量不能少於當前工作區的成員數量。",
+    "reachedFileSizeLimit": "已超過檔案大小限制"
   },
   "actions": {
     "undo": "撤銷",

--- a/src/app/i18n/locales/zh.json
+++ b/src/app/i18n/locales/zh.json
@@ -1530,7 +1530,8 @@
     "errorAcceptingWorkspaceInvitation": "接受邀请时出错",
     "errorWhileUpdatingWorkspaceMembers": "更新成员时出了点问题",
     "errorWhileFetchingCurrentWorkspaceMembers": "获取工作区成员时出了点问题",
-    "newMembersCannotBeLessThanTheExistentOnesError": "选择的成员数量不能少于当前工作区的成员数量。"
+    "newMembersCannotBeLessThanTheExistentOnesError": "选择的成员数量不能少于当前工作区的成员数量。",
+    "reachedFileSizeLimit": "已超过文件大小限制"
   },
   "actions": {
     "undo": "撤销",

--- a/src/app/network/UploadFolderManager.ts
+++ b/src/app/network/UploadFolderManager.ts
@@ -23,6 +23,7 @@ import { logNetworkInfoForUpload } from './networkInformation';
 import { uiActions } from 'app/store/slices/ui';
 import { FilesExceedsSizeLimitError } from 'app/drive/services/file.service/upload.errors';
 import { filterFilesByMaxSize } from 'app/store/slices/storage/fileUtils/filterFilesByMaxSize';
+import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
 
 interface UploadFolderPayload {
   root: IRoot;
@@ -257,6 +258,10 @@ export class UploadFoldersManager {
     if (allFilesExceedSizeLimit && hasNoChildFolders) {
       await this.stopUploadTask(taskId, abortController);
       this.killQueueAndNotifyError(taskId);
+      notificationsService.show({
+        text: t('notificationMessages.reachedFileSizeLimit'),
+        type: ToastType.Warning,
+      });
       this.dispatch(
         uiActions.setOpenFileSizeLimitReachedDialog({ open: true, info: { exceededFiles: level.childrenFiles } }),
       );

--- a/src/app/store/slices/storage/storage.thunks/uploadFolderThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadFolderThunk.ts
@@ -174,6 +174,10 @@ export const uploadFolderThunk = createAsyncThunk<void, UploadFolderThunkPayload
 
           if (allFilesExceedSizeLimit && hasNoChildFolders) {
             await stopUploadTask(uploadFolderAbortController, dispatch, taskId, rootFolderItem);
+            notificationsService.show({
+              text: t('notificationMessages.reachedFileSizeLimit'),
+              type: ToastType.Warning,
+            });
             dispatch(
               uiActions.setOpenFileSizeLimitReachedDialog({ open: true, info: { exceededFiles: level.childrenFiles } }),
             );

--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
@@ -59,7 +59,7 @@ const DEFAULT_OPTIONS: Partial<UploadItemsThunkOptions> = {
   showErrors: true,
 };
 
-const openReachedFileSizeLimitDIalog = (
+const openReachedFileSizeLimitDialog = (
   exceededFiles: ExceededFile[],
   dispatch: ThunkDispatch<RootState, unknown, AnyAction>,
 ) => {
@@ -81,7 +81,11 @@ const validateFileSize = (
   const { allowedFilesToUpload, exceededFiles } = filterFilesByMaxSize({ files, maxUploadFileSize });
 
   if (exceededFiles.length > 0) {
-    openReachedFileSizeLimitDIalog(exceededFiles, dispatch);
+    notificationsService.show({
+      text: t('notificationMessages.reachedFileSizeLimit'),
+      type: ToastType.Warning,
+    });
+    openReachedFileSizeLimitDialog(exceededFiles, dispatch);
   }
 
   return allowedFilesToUpload;
@@ -205,7 +209,7 @@ export const uploadItemsThunk = createAsyncThunk<void, UploadItemsPayload, { sta
         }),
       );
 
-    const openFileSizeLimitDialog = () => openReachedFileSizeLimitDIalog(allowedFilesToUpload, dispatch);
+    const openFileSizeLimitDialog = () => openReachedFileSizeLimitDialog(allowedFilesToUpload, dispatch);
 
     try {
       await uploadFileWithManager({
@@ -499,7 +503,7 @@ export const uploadItemsParallelThunk = createAsyncThunk<void, UploadItemsPayloa
         }),
       );
 
-    const openFileSizeLimitDialog = () => openReachedFileSizeLimitDIalog(allowedFilesToUpload, dispatch);
+    const openFileSizeLimitDialog = () => openReachedFileSizeLimitDialog(allowedFilesToUpload, dispatch);
 
     try {
       await uploadFileWithManager({


### PR DESCRIPTION
## Description

Hide file size limit reached dialog and display a notification toast instead.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
