### PR TITLE
[MKT-856]:feat/use partnerId instead of utmMedium in checkout

### DIFF
--- a/src/app/analytics/impact.service.test.ts
+++ b/src/app/analytics/impact.service.test.ts
@@ -9,6 +9,7 @@ import { getProductAmount } from 'views/Checkout/utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   handleImpactDTCCheckout,
+  resolvePartnerIdFromUrl,
   savePaymentDataInLocalStorage,
   trackPaymentConversion,
   trackSignUp,
@@ -490,7 +491,7 @@ describe('handleImpactDTCCheckout', () => {
   it('When an affiliate partner is identified, then it includes their information in the tracking event', async () => {
     const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
 
-    await handleImpactDTCCheckout({ irclickid, utmMedium });
+    await handleImpactDTCCheckout({ irclickid, partnerId: utmMedium });
 
     const callArgs = axiosSpy.mock.calls[0][1] as { properties: Record<string, unknown> };
     expect(callArgs.properties).toHaveProperty('partner_id', utmMedium);
@@ -514,7 +515,7 @@ describe('handleImpactDTCCheckout', () => {
     const setImpactCookiesSpy = vi.mocked(getCookieMock.setImpactCookies);
     vi.spyOn(axios, 'post').mockResolvedValue({});
 
-    await handleImpactDTCCheckout({ irclickid, utmMedium });
+    await handleImpactDTCCheckout({ irclickid, partnerId: utmMedium });
 
     expect(setImpactCookiesSpy).toHaveBeenCalledWith('anon_id', irclickid, utmMedium);
   });
@@ -527,6 +528,32 @@ describe('handleImpactDTCCheckout', () => {
     await expect(handleImpactDTCCheckout({ irclickid })).resolves.not.toThrow();
 
     expect(errorServiceSpy).toHaveBeenCalledWith(unknownError);
+  });
+});
+
+describe('resolvePartnerIdFromUrl', () => {
+  it('When utm_content is present, then it returns it as the partner ID', () => {
+    expect(resolvePartnerIdFromUrl('?utm_content=partner_abc')).toBe('partner_abc');
+  });
+
+  it('When utm_medium is a numeric string, then it returns it as the partner ID', () => {
+    expect(resolvePartnerIdFromUrl('?utm_medium=312695')).toBe('312695');
+  });
+
+  it('When both utm_content and utm_medium are present, then utm_content takes priority', () => {
+    expect(resolvePartnerIdFromUrl('?utm_content=partner_abc&utm_medium=312695')).toBe('partner_abc');
+  });
+
+  it('When utm_medium is non-numeric, then it returns null', () => {
+    expect(resolvePartnerIdFromUrl('?utm_medium=google')).toBeNull();
+  });
+
+  it('When neither utm_content nor utm_medium are present, then it returns null', () => {
+    expect(resolvePartnerIdFromUrl('?utm_source=newsletter')).toBeNull();
+  });
+
+  it('When the search string is empty, then it returns null', () => {
+    expect(resolvePartnerIdFromUrl('')).toBeNull();
   });
 });
 
@@ -815,7 +842,7 @@ describe('handleImpactDTCCheckout - additional coverage', () => {
   it('When no affiliate partner is identified, then no partner information is included in the event', async () => {
     const axiosSpy = vi.spyOn(axios, 'post').mockResolvedValue({});
 
-    await handleImpactDTCCheckout({ irclickid, utmMedium: null });
+    await handleImpactDTCCheckout({ irclickid, partnerId: null });
 
     const callArgs = axiosSpy.mock.calls[0][1] as { properties: Record<string, unknown> };
     expect(callArgs.properties).not.toHaveProperty('partner_id');

--- a/src/app/analytics/impact.service.ts
+++ b/src/app/analytics/impact.service.ts
@@ -70,19 +70,35 @@ export function savePaymentDataInLocalStorage({
   localStorageService.set('isFirstPurchase', String(isFirstPurchase));
 }
 
+export function resolvePartnerIdFromUrl(search: string = globalThis.location.search): string | null {
+  const params = new URLSearchParams(search);
+  const utmContent = params.get('utm_content');
+  const utmMedium = params.get('utm_medium');
+
+  if (utmContent) {
+    return utmContent;
+  }
+
+  if (utmMedium && /^\d+$/.test(utmMedium)) {
+    return utmMedium;
+  }
+
+  return null;
+}
+
 export async function handleImpactDTCCheckout({
   irclickid,
-  utmMedium,
+  partnerId,
 }: {
   irclickid: string;
-  utmMedium?: string | null;
+  partnerId?: string | null;
 }): Promise<void> {
   try {
     const IMPACT_API = envService.getVariable('impactApiUrl');
     const existingAnonymousId = getCookie('impactAnonymousId');
     const anonymousId = existingAnonymousId || uuidV4();
 
-    setImpactCookies(anonymousId, irclickid, utmMedium);
+    setImpactCookies(anonymousId, irclickid, partnerId);
 
     await axios.post(IMPACT_API, {
       anonymousId,
@@ -97,7 +113,7 @@ export async function handleImpactDTCCheckout({
       type: 'page',
       properties: {
         irclickid,
-        ...(utmMedium && { partner_id: utmMedium }),
+        ...(partnerId && { partner_id: partnerId }),
       },
     });
   } catch (error) {

--- a/src/views/Checkout/views/CheckoutViewWrapper.tsx
+++ b/src/views/Checkout/views/CheckoutViewWrapper.tsx
@@ -122,7 +122,7 @@ const CheckoutViewWrapper = () => {
       localStorageService.set(STORAGE_KEYS.GCLID, gclid);
     }
     if (irclickid) {
-      handleImpactDTCCheckout({ irclickid, utmMedium });
+      handleImpactDTCCheckout({ irclickid, partnerId: utmMedium });
     }
     referralService.captureUcc();
   }, []);


### PR DESCRIPTION
## Description
Context:
Affiliate links from Impact were appending the partner ID to utm_medium (e.g. utm_medium=312695), which broke GA4's channel grouping. The Impact Partner Tracking Template is being updated to use utm_medium=affiliate and utm_content={irpid} instead.

Changes in impact.service.ts
- Renamed the utmMedium param of handleImpactDTCCheckout to partnerId to reflect what it actually represents. The payload sent to Impact (partner_id) is unchanged.
- Added resolvePartnerIdFromUrl() helper that reads the partner ID from the URL with backward compatibility:

<!-- Provide a clear and concise summary of the changes. Include the reason and context, if applicable. -->

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [ ] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
