### PR TITLE
[_]: fix/remove useless check for postal code

### DIFF
--- a/src/views/Checkout/views/CheckoutViewWrapper.tsx
+++ b/src/views/Checkout/views/CheckoutViewWrapper.tsx
@@ -307,7 +307,7 @@ const CheckoutViewWrapper = () => {
         return;
       }
 
-      if (!address?.line1 || !address?.city || !address.country || !address?.postal_code) {
+      if (!address?.line1 || !address?.city || !address.country) {
         throw new Error(translate('checkout.error.addressRequired'));
       }
 


### PR DESCRIPTION
## Description

Removing the postal code validation, as some countries do not use postal codes, which prevents users from completing their Stripe billing address.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
