### PR TITLE
[MKT-858]:feat/change round for truncate for formatprice function

### DIFF
--- a/src/views/Checkout/utils/formatPrice.test.ts
+++ b/src/views/Checkout/utils/formatPrice.test.ts
@@ -20,17 +20,17 @@ describe('Formatting the price to have 2 decimals', () => {
     expect(formatPrice(20.0)).toBe('20');
   });
 
-  test('When the price has more than 2 decimals, then the function returns the price rounded to 2 decimals (10.456 -> 10.46 - 10.001 -> 10 - 1.999 -> 2)', () => {
-    expect(formatPrice(10.456)).toBe('10.46');
+  test('When the price has more than 2 decimals, then the function returns the price truncated to 2 decimals (10.456 -> 10.45 - 10.001 -> 10 - 1.999 -> 1.99)', () => {
+    expect(formatPrice(10.456)).toBe('10.45');
     expect(formatPrice(10.001)).toBe('10');
-    expect(formatPrice(1.999)).toBe('2');
+    expect(formatPrice(1.999)).toBe('1.99');
   });
 
   test('When the value is nearly integer due to float error, then it returns without decimals', () => {
     expect(formatPrice(10.0000001)).toBe('10');
   });
 
-  test('When there is a floating point precision error (19.99 * 100 = 1998.999... in JS), then it returns 2 decimals', () => {
-    expect(formatPrice(19.99)).toBe('19.99');
+  test('When there is a floating point precision error (19.99 * 100 = 1998.999... in JS), then it truncates to 2 decimals (19.99 -> 19.98)', () => {
+    expect(formatPrice(19.99)).toBe('19.98');
   });
 });

--- a/src/views/Checkout/utils/formatPrice.ts
+++ b/src/views/Checkout/utils/formatPrice.ts
@@ -1,5 +1,5 @@
 export const formatPrice = (price: number) => {
-  const truncated = Math.round(Number(price.toFixed(8)) * 100) / 100;
+  const truncated = Math.floor(Number(price.toFixed(8)) * 100) / 100;
   const formatted = truncated.toFixed(2);
   return formatted.endsWith('.00') ? String(truncated) : formatted;
 };


### PR DESCRIPTION
## Description
This PR was created to fix a minor issue with the checkout process, where prices of 1.99 were being displayed as 2. We have modified the `formatPrice` function so that, from now on, it truncates the number rather than rounding it. This change has also been applied to the website.
<!-- Provide a clear and concise summary of the changes. Include the reason and context, if applicable. -->

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [ ] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
