### PR TITLE
[MKT-863]:feat/new banner end day

### DIFF
--- a/src/app/banners/BannerWrapper.tsx
+++ b/src/app/banners/BannerWrapper.tsx
@@ -10,7 +10,7 @@ import newStorageService from 'app/drive/services/new-storage.service';
 import { ActionDialog } from 'app/contexts/dialog-manager/ActionDialogManager.context';
 import { useActionDialog } from 'app/contexts/dialog-manager/useActionDialog';
 
-const OFFER_END_DAY = new Date('2026-04-26');
+const OFFER_END_DAY = new Date('2027-04-26');
 const TIMEOUT = 90000;
 
 const BannerWrapper = (): JSX.Element => {


### PR DESCRIPTION
## Description
This PR introduces a new banner end day for the banner that displays on drive-web, we just updated the date to 2027, because will be a continue offer.
<!-- Provide a clear and concise summary of the changes. Include the reason and context, if applicable. -->

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process
Created a new free account and uploaded a file, 90 seconds after that the banner displays as expected
<img width="1256" height="954" alt="Captura de pantalla 2026-06-11 a las 8 46 40" src="https://github.com/user-attachments/assets/3c390b3f-4690-4f41-b5dc-53e0dd345587" />

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
