### PR TITLE
[_]: refactor/remove useless part of cancellation modal

### DIFF
--- a/src/app/i18n/locales/de.json
+++ b/src/app/i18n/locales/de.json
@@ -510,9 +510,7 @@
               "titleNew": "Neu",
               "year": "Jahr",
               "month": "Monat",
-              "free": "Kostenlos",
-              "reachedFreeLimit": "Du bist über dem Limit {{freePlanName}}",
-              "reachedFreeLimitDescription": "Weil du derzeit {{currentUsage}} verwendest, synchronisiert dein Internxt Drive deine Dateien nicht mehr und du kannst keine neuen Dateien hinzufügen"
+              "free": "Kostenlos"
             },
             "giveUsFeedback": "Teile uns mit, warum du deinen Vertrag {{currentPlanName}} Internxt-Plan kündigen und auf den kostenlosen Plan wechseln möchtest?",
             "feedback": {

--- a/src/app/i18n/locales/en.json
+++ b/src/app/i18n/locales/en.json
@@ -570,9 +570,7 @@
               "titleNew": "New",
               "year": "year",
               "month": "month",
-              "free": "Free",
-              "reachedFreeLimit": "You are over {{freePlanName}}",
-              "reachedFreeLimitDescription": "As you are currently using {{currentUsage}}, your Internxt Drive will stop syncing your files and you won't be able to add new files"
+              "free": "Free"
             },
             "giveUsFeedback": "Tell us why you want to cancel your {{currentPlanName}} Internxt plan and downgrade to free plan?",
             "feedback": {

--- a/src/app/i18n/locales/es.json
+++ b/src/app/i18n/locales/es.json
@@ -552,9 +552,7 @@
               "titleNew": "Nuevo",
               "year": "año",
               "month": "mes",
-              "free": "Gratis",
-              "reachedFreeLimit": "Has superado el límite de {{freePlanName}}",
-              "reachedFreeLimitDescription": "Como actualmente estás usando {{currentUsage}} de espacio, Internxt Drive dejará de sincronizar tus ficheros, y tampoco serás capaz de añadir nuevos"
+              "free": "Gratis"
             },
             "giveUsFeedback": "Cuéntenos por qué quiere cancelar su plan Internxt de {{currentPlanName}} y cambiar al plan gratuito.",
             "feedback": {

--- a/src/app/i18n/locales/fr.json
+++ b/src/app/i18n/locales/fr.json
@@ -522,9 +522,7 @@
               "titleNew": "Nouveau",
               "year": "année",
               "month": "mois",
-              "free": "Gratuit",
-              "reachedFreeLimit": "Vous dépassez {{freePlanName}}",
-              "reachedFreeLimitDescription": "Comme vous utilisez actuellement {{currentUsage}}, votre Internxt Drive cessera de synchroniser vos fichiers et vous ne pourrez plus en ajouter de nouveaux."
+              "free": "Gratuit"
             },
             "giveUsFeedback": "Dites-nous pourquoi vous souhaitez annuler votre abonnement Internxt {{currentPlanName}} et passer au plan gratuit ?",
             "feedback": {

--- a/src/app/i18n/locales/it.json
+++ b/src/app/i18n/locales/it.json
@@ -613,9 +613,7 @@
               "titleNew": "New",
               "year": "anno",
               "month": "mese",
-              "free": "libero",
-              "reachedFreeLimit": "Hai superato il {{freePlanName}}",
-              "reachedFreeLimitDescription": "Poiché si sta utilizzando {{uso corrente}}, Internxt Drive smetterà di sincronizzare i file e non sarà possibile aggiungere nuovi file."
+              "free": "libero"
             },
             "giveUsFeedback": "Ci dica perché vuole annullare il suo {{currentPlanName}} Internxt e passare al piano gratuito?",
             "feedback": {

--- a/src/app/i18n/locales/ru.json
+++ b/src/app/i18n/locales/ru.json
@@ -522,9 +522,7 @@
               "titleNew": "Новый",
               "year": "год",
               "month": "месяц",
-              "free": "бесплатно",
-              "reachedFreeLimit": "Вы превысили {{freePlanName}}",
-              "reachedFreeLimitDescription": "Поскольку вы сейчас используете {{currentUsage}}, Internxt Drive перестанет синхронизировать ваши файлы, и вы не сможете загрузать новые файлы."
+              "free": "бесплатно"
             },
             "giveUsFeedback": "Нам важно знать, почему вы хотите отменить {{currentPlanName}} план Internxt и перейти на бесплатный план?",
             "feedback": {

--- a/src/app/i18n/locales/tw.json
+++ b/src/app/i18n/locales/tw.json
@@ -538,9 +538,7 @@
               "titleNew": "新的",
               "year": "年",
               "month": "月",
-              "free": "免費",
-              "reachedFreeLimit": "您已超過 {{freePlanName}}",
-              "reachedFreeLimitDescription": "由於您當前使用 {{currentUsage}}，您的 Internxt Drive 將停止同步文件，並且您將無法添加新文件"
+              "free": "免費"
             },
             "giveUsFeedback": "請告訴我們為什麼您想要取消您的 {{currentPlanName}} Internxt 計劃並降級為免費計劃？",
             "feedback": {

--- a/src/app/i18n/locales/zh.json
+++ b/src/app/i18n/locales/zh.json
@@ -536,9 +536,7 @@
               "titleNew": "新建",
               "year": "年度",
               "month": "/月",
-              "free": "免费的",
-              "reachedFreeLimit": "你超过了 {{freePlanName}}",
-              "reachedFreeLimitDescription": "由于您目前正在使用 {{currentUsage}}，您的 Internxt Drive 将停止同步您的文件，您将无法添加新文件"
+              "free": "免费的"
             },
             "giveUsFeedback": "能否告诉我们您为什么要取消您的 {{currentPlanName}} Internxt 计划并降级为免费计划？",
             "feedback": {

--- a/src/views/NewSettings/components/Sections/Workspace/Billing/CancelSubscriptionModal.tsx
+++ b/src/views/NewSettings/components/Sections/Workspace/Billing/CancelSubscriptionModal.tsx
@@ -1,6 +1,5 @@
 import { StoragePlan, UserType } from '@internxt/sdk/dist/drive/payments/types/types';
 import { ArrowRight } from '@phosphor-icons/react';
-import sizeService from 'app/drive/services/size.service';
 import { FreeStoragePlan } from 'app/drive/types';
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
 import { Button, Modal } from '@internxt/ui';
@@ -66,7 +65,6 @@ const CancelPlanModal = ({
 }): JSX.Element => {
   const { translate } = useTranslationContext();
 
-  const isCurrentUsageGreaterThanFreePlan = currentUsage !== -1 && currentUsage >= FreeStoragePlan.storageLimit;
   const monthlyAmount = individualPlan?.monthlyPrice;
   const commitment = individualPlan?.commitment;
   const isCommitmentEnabled = commitment?.enabled;
@@ -143,9 +141,7 @@ const CancelPlanModal = ({
             </p>
           </div>
           <div className="mt-3">
-            <span className={`text-2xl font-bold text-primary ${isCurrentUsageGreaterThanFreePlan ? 'text-red' : ''}`}>
-              {FreeStoragePlan.simpleName}
-            </span>
+            <span className={'text-2xl font-bold text-primary'}>{FreeStoragePlan.simpleName}</span>
           </div>
           <div>
             <span className="font-medium">
@@ -155,24 +151,6 @@ const CancelPlanModal = ({
         </div>
       </div>
 
-      {isCurrentUsageGreaterThanFreePlan && (
-        <div className="mt-5 flex w-full max-w-lg flex-col rounded-xl border border-red/30 bg-red/10 pb-3 pt-3">
-          <div className="flex items-center justify-center p-3">
-            <span className="text-lg font-bold text-red">
-              {translate('views.account.tabs.billing.cancelSubscriptionModal.infoBox.reachedFreeLimit', {
-                freePlanName: FreeStoragePlan.simpleName,
-              })}
-            </span>
-          </div>
-          <div className="flex items-center justify-center p-3">
-            <span className="font-medium text-red">
-              {translate('views.account.tabs.billing.cancelSubscriptionModal.infoBox.reachedFreeLimitDescription', {
-                currentUsage: sizeService.bytesToString(currentUsage),
-              })}
-            </span>
-          </div>
-        </div>
-      )}
       <div className="mt-5 flex justify-end">
         <Button
           className={'shadow-subtle-hard'}


### PR DESCRIPTION
## Description

Remove the section from the cancellation modal that informs users that if their storage usage exceeds the free plan limit (1 GB), their files will no longer sync or be available for download.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
