### PR TITLE
[PB-6509]: feat/verify-integrity-on-download

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@iconscout/react-unicons": "^1.1.6",
     "@internxt/css-config": "1.1.0",
     "@internxt/lib": "1.4.1",
-    "@internxt/sdk": "=1.16.4",
+    "@internxt/sdk": "=1.17.8",
     "@internxt/ui": "=0.1.19",
     "@phosphor-icons/react": "^2.1.7",
     "@popperjs/core": "^2.11.6",

--- a/src/app/crypto/services/utils.ts
+++ b/src/app/crypto/services/utils.ts
@@ -114,6 +114,10 @@ const getItemPlainName = (item: DriveItemData | AdvancedSharedItem) => {
   else return item.name;
 };
 
+async function getFileHmacFromShardHashes(fileKey: Buffer, shardHashes: string[]): Promise<string> {
+  return getSha512Combined(fileKey, Buffer.from(shardHashes.join(''), 'hex'));
+}
+
 export {
   decryptText,
   decryptTextWithKey,
@@ -126,6 +130,7 @@ export {
   getSha256,
   getSha256Hasher,
   getSha512Combined,
+  getFileHmacFromShardHashes,
   passToHash,
   renameFile,
 };

--- a/src/app/network/NetworkFacade.test.ts
+++ b/src/app/network/NetworkFacade.test.ts
@@ -3,7 +3,10 @@ import { describe, it, expect, vi, beforeEach, afterEach, test } from 'vitest';
 import { NetworkFacade } from './NetworkFacade';
 import { Network as NetworkModule } from '@internxt/sdk';
 import { downloadFile } from '@internxt/sdk/dist/network/download';
-import { decryptStream } from 'services/stream.service';
+import { buildProgressStream, decryptStream } from 'services/stream.service';
+import { createSha256HashingStream } from './crypto';
+import { getDecryptedStream } from './download';
+import { getFileHmacFromShardHashes } from 'app/crypto/services/utils';
 import {
   DownloadAbortedByUserError,
   DownloadFailedWithUnknownError,
@@ -18,6 +21,19 @@ vi.mock('services/stream.service', () => ({
   buildProgressStream: vi.fn(),
   decryptStream: vi.fn(),
   joinReadableBinaryStreams: vi.fn(),
+}));
+vi.mock('./crypto', () => ({
+  createSha256HashingStream: vi.fn(),
+  encryptStreamInParts: vi.fn(),
+  generateFileKey: vi.fn(),
+  getEncryptedFile: vi.fn(),
+  processEveryFileBlobReturnHash: vi.fn(),
+}));
+vi.mock('./download', () => ({
+  getDecryptedStream: vi.fn(),
+}));
+vi.mock('app/crypto/services/utils', () => ({
+  getFileHmacFromShardHashes: vi.fn(),
 }));
 
 describe('NetworkFacade', () => {
@@ -36,6 +52,105 @@ describe('NetworkFacade', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  describe('Downloading a file', () => {
+    const downloadUrl = 'http://s3.inxt.download.com/example';
+    const bucketId = 'test-bucket';
+    const fileId = 'test-file';
+    const mnemonic = 'test-mnemonic';
+    const fakeKey = Buffer.alloc(32);
+    const fakeIv = Buffer.alloc(16);
+    const fakeShardHash = 'aabbcc';
+
+    function mockDownloadFile(fileInfoOverride: object = {}) {
+      (downloadFile as any).mockImplementation(
+        async (_fId, _bId, _mn, _net, _crypto, _buf, downloadCb, decryptCb) => {
+          await downloadCb([{ url: downloadUrl }], { size: 100, ...fileInfoOverride });
+          await decryptCb('AES256CTR', fakeKey, fakeIv, 100);
+        },
+      );
+    }
+
+    beforeEach(() => {
+      const mockHashingStream = new ReadableStream({ start: (c) => c.close() });
+      const mockDecryptedStream = new ReadableStream({ start: (c) => c.close() });
+      const mockProgressStream = new ReadableStream({ start: (c) => c.close() });
+
+      (global.fetch as any).mockResolvedValue({ body: new ReadableStream() });
+      vi.mocked(createSha256HashingStream).mockImplementation(async (_src, onHash) => {
+        onHash(fakeShardHash);
+        return mockHashingStream;
+      });
+      vi.mocked(getDecryptedStream).mockReturnValue(mockDecryptedStream);
+      vi.mocked(buildProgressStream).mockReturnValue(mockProgressStream);
+    });
+
+    test('When fileInfo has no HMAC, the download resolves without integrity check', async () => {
+      mockDownloadFile();
+      vi.mocked(getFileHmacFromShardHashes).mockResolvedValue('any-hmac');
+
+      const result = await networkFacade.download(bucketId, fileId, mnemonic);
+
+      expect(result).toBeDefined();
+      expect(buildProgressStream).toHaveBeenCalledOnce();
+    });
+
+    test('When the computed HMAC matches fileInfo.hmac.value, onFinished resolves without error', async () => {
+      const expectedHmac = 'matching-hmac-value';
+      mockDownloadFile({ hmac: { type: 'sha512', value: expectedHmac } });
+      vi.mocked(getFileHmacFromShardHashes).mockResolvedValue(expectedHmac);
+
+      let capturedOnFinished: (() => Promise<void>) | undefined;
+      vi.mocked(buildProgressStream).mockImplementation((_src, _onRead, onFinished) => {
+        capturedOnFinished = onFinished;
+        return new ReadableStream({ start: (c) => c.close() });
+      });
+
+      await networkFacade.download(bucketId, fileId, mnemonic);
+
+      await expect(capturedOnFinished?.()).resolves.toBeUndefined();
+    });
+
+    test('When the computed HMAC does not match fileInfo.hmac.value, onFinished throws', async () => {
+      mockDownloadFile({ hmac: { type: 'sha512', value: 'expected-hmac' } });
+      vi.mocked(getFileHmacFromShardHashes).mockResolvedValue('different-hmac');
+
+      let capturedOnFinished: (() => Promise<void>) | undefined;
+      vi.mocked(buildProgressStream).mockImplementation((_src, _onRead, onFinished) => {
+        capturedOnFinished = onFinished;
+        return new ReadableStream({ start: (c) => c.close() });
+      });
+
+      await networkFacade.download(bucketId, fileId, mnemonic);
+
+      await expect(capturedOnFinished?.()).rejects.toThrow('File integrity check failed');
+    });
+
+    test('When a shard is downloaded, its SHA256 hash is computed via createSha256HashingStream', async () => {
+      mockDownloadFile();
+      vi.mocked(getFileHmacFromShardHashes).mockResolvedValue('any-hmac');
+
+      await networkFacade.download(bucketId, fileId, mnemonic);
+
+      expect(createSha256HashingStream).toHaveBeenCalledOnce();
+    });
+
+    test('When computing the HMAC, getFileHmacFromShardHashes receives the shard hashes collected during download', async () => {
+      mockDownloadFile({ hmac: { type: 'sha512', value: 'some-hmac' } });
+      vi.mocked(getFileHmacFromShardHashes).mockResolvedValue('some-hmac');
+
+      let capturedOnFinished: (() => Promise<void>) | undefined;
+      vi.mocked(buildProgressStream).mockImplementation((_src, _onRead, onFinished) => {
+        capturedOnFinished = onFinished;
+        return new ReadableStream({ start: (c) => c.close() });
+      });
+
+      await networkFacade.download(bucketId, fileId, mnemonic);
+      await capturedOnFinished?.();
+
+      expect(getFileHmacFromShardHashes).toHaveBeenCalledWith(fakeKey, [fakeShardHash]);
+    });
   });
 
   describe('Downloading a chunk', () => {
@@ -115,7 +230,7 @@ describe('NetworkFacade', () => {
       );
     });
 
-    it('When the download is aborted, then an error indicating so is thrown', async () => {
+    it('When the download is aborted, then an DownloadAbortedByUserError error is thrown', async () => {
       const abortController = new AbortController();
       abortController.abort();
 

--- a/src/app/network/NetworkFacade.ts
+++ b/src/app/network/NetworkFacade.ts
@@ -13,7 +13,7 @@ import { buildProgressStream, decryptStream } from 'services/stream.service';
 import { WORKER_MESSAGE_STATES } from 'app/drive/services/worker.service/types/upload';
 import { waitForContinueUploadSignal } from 'app/drive/services/worker.service/uploadWorkerUtils';
 import { TaskStatus } from '../tasks/types';
-import { encryptStreamInParts, generateFileKey, getEncryptedFile, processEveryFileBlobReturnHash } from './crypto';
+import { createSha256HashingStream, encryptStreamInParts, generateFileKey, getEncryptedFile, processEveryFileBlobReturnHash } from './crypto';
 import { DownloadProgressCallback, getDecryptedStream } from './download';
 import {
   DownloadAbortedByUserError,
@@ -23,6 +23,7 @@ import {
 import { ALLOWED_CHUNK_OVERHEAD, UPLOAD_CHUNK_SIZE } from './networkConstants';
 import { DownloadChunkPayload } from './types/index';
 import { uploadFileUint8Array, UploadProgressCallback } from './upload-utils';
+import { getFileHmacFromShardHashes } from 'app/crypto/services/utils';
 
 interface UploadOptions {
   uploadingCallback: UploadProgressCallback;
@@ -254,9 +255,9 @@ export class NetworkFacade {
     options?: DownloadOptions,
   ): Promise<ReadableStream> {
     const encryptedContentStreams: ReadableStream<Uint8Array>[] = [];
+    const shardHashes: string[] = [];
+    let fileInfoRef: { hmac?: { value: string; type: string } } = {};
     let fileStream: ReadableStream<Uint8Array>;
-
-    // TODO: Check hash when downloaded
 
     await downloadFile(
       fileId,
@@ -265,7 +266,8 @@ export class NetworkFacade {
       this.network,
       this.cryptoLib,
       Buffer.from,
-      async (downloadables) => {
+      async (downloadables, fileInfo) => {
+        fileInfoRef = fileInfo;
         for (const downloadable of downloadables) {
           if (options?.abortController?.signal.aborted) {
             throw new Error('Download aborted');
@@ -281,7 +283,11 @@ export class NetworkFacade {
             return res.body;
           });
 
-          encryptedContentStreams.push(encryptedContentStream);
+          encryptedContentStreams.push(
+            await createSha256HashingStream(encryptedContentStream, (digest) => {
+              shardHashes.push(digest);
+            })
+          );
         }
       },
       async (algorithm, key, iv, fileSize) => {
@@ -290,9 +296,14 @@ export class NetworkFacade {
           createDecipheriv('aes-256-ctr', options?.key || (key as Buffer), iv as Buffer),
         );
 
-        fileStream = buildProgressStream(decryptedStream, (readBytes) => {
-          options && options.downloadingCallback && options.downloadingCallback(fileSize, readBytes);
-        });
+        fileStream = buildProgressStream(
+          decryptedStream, 
+          (readBytes) => options?.downloadingCallback?.(fileSize, readBytes),
+          async () => {
+            const hmac = await getFileHmacFromShardHashes(key as Buffer, shardHashes);
+            if (fileInfoRef.hmac?.value && hmac !== fileInfoRef.hmac.value) throw new Error('File integrity check failed');
+          }
+        );
       },
       (options?.token && { token: options.token }) || undefined,
     );

--- a/src/app/network/crypto.test.ts
+++ b/src/app/network/crypto.test.ts
@@ -12,6 +12,7 @@ import {
   getFileDeterministicKey,
   processEveryFileBlobReturnHash,
   encryptStreamInParts,
+  createSha256HashingStream,
 } from './crypto';
 import { mnemonicToSeed } from 'bip39';
 
@@ -393,5 +394,94 @@ describe('File key generation functions', () => {
 
       expect(newResult.equals(oldResult)).toBe(true);
     });
+  });
+});
+
+describe('createSha256HashingStream', () => {
+  globalThis.Buffer = Buffer;
+
+  async function drainStream(stream: ReadableStream<Uint8Array>): Promise<Uint8Array[]> {
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+    let result = await reader.read();
+    while (!result.done) {
+      chunks.push(result.value);
+      result = await reader.read();
+    }
+    return chunks;
+  }
+
+  it('should pass all chunks through unchanged', async () => {
+    const input = [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])];
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of input) controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+
+    const onHash = vi.fn();
+    const stream = await createSha256HashingStream(source, onHash);
+    const chunks = await drainStream(stream);
+
+    expect(chunks).toEqual(input);
+  });
+
+  it('should call onHash exactly once when the stream ends', async () => {
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.close();
+      },
+    });
+
+    const onHash = vi.fn();
+    const stream = await createSha256HashingStream(source, onHash);
+    await drainStream(stream);
+
+    expect(onHash).toHaveBeenCalledOnce();
+  });
+
+  it('should call onHash with the correct SHA256 digest for a single chunk', async () => {
+    const data = new Uint8Array([1, 2, 3, 4, 5, 6]);
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(data);
+        controller.close();
+      },
+    });
+
+    const onHash = vi.fn();
+    const stream = await createSha256HashingStream(source, onHash);
+    await drainStream(stream);
+
+    const expected = crypto.createHash('sha256').update(Buffer.from(data)).digest('hex');
+    expect(onHash).toHaveBeenCalledWith(expected);
+  });
+
+  it('should produce the same digest regardless of chunk boundaries', async () => {
+    const fullData = new Uint8Array([1, 2, 3, 4, 5, 6]);
+
+    const singleChunkSource = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(fullData);
+        controller.close();
+      },
+    });
+    const multiChunkSource = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(fullData.slice(0, 3));
+        controller.enqueue(fullData.slice(3));
+        controller.close();
+      },
+    });
+
+    const onHashSingle = vi.fn();
+    const onHashMulti = vi.fn();
+
+    await drainStream(await createSha256HashingStream(singleChunkSource, onHashSingle));
+    await drainStream(await createSha256HashingStream(multiChunkSource, onHashMulti));
+
+    expect(onHashSingle).toHaveBeenCalledWith(onHashMulti.mock.calls[0][0]);
   });
 });

--- a/src/app/network/crypto.ts
+++ b/src/app/network/crypto.ts
@@ -1,6 +1,7 @@
 import { mnemonicToSeed } from 'bip39';
 import { Cipher } from 'crypto';
 
+import { createSHA256 } from 'hash-wasm';
 import { getRipemd160FromHex, getSha256Hasher, getSha512Combined } from '../crypto/services/utils';
 
 /**
@@ -161,4 +162,30 @@ export async function generateFileBucketKey(mnemonic: string, bucketId: string):
 export async function getFileDeterministicKey(key: Buffer, data: Buffer): Promise<Buffer> {
   const hashHex = await getSha512Combined(key, data);
   return Buffer.from(hashHex, 'hex');
+}
+
+export async function createSha256HashingStream(
+  source: ReadableStream<Uint8Array>,
+  onHash: (digest: string) => void,
+): Promise<ReadableStream<Uint8Array>> {
+  const hasher = await createSHA256();
+  hasher.init();
+
+  const reader = source.getReader();
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        onHash(hasher.digest('hex'));
+        controller.close();
+      } else {
+        hasher.update(value);
+        controller.enqueue(value);
+      }
+    },
+    cancel() {
+      reader.cancel();
+    },
+  });
 }

--- a/src/services/stream.service.test.ts
+++ b/src/services/stream.service.test.ts
@@ -230,6 +230,54 @@ describe('Stream service', () => {
       expect(onRead).not.toHaveBeenCalled();
     });
 
+    it('should call onFinished once when the stream completes', async () => {
+      const sourceStream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.close();
+        },
+      });
+
+      const onFinished = vi.fn().mockResolvedValue(undefined);
+      const progressStream = buildProgressStream(sourceStream, vi.fn(), onFinished);
+      const reader = progressStream.getReader();
+
+      await reader.read();
+      await reader.read();
+
+      expect(onFinished).toHaveBeenCalledOnce();
+    });
+
+    it('should propagate errors thrown by onFinished', async () => {
+      const sourceStream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close();
+        },
+      });
+
+      const onFinished = vi.fn().mockRejectedValue(new Error('integrity check failed'));
+      const progressStream = buildProgressStream(sourceStream, vi.fn(), onFinished);
+      const reader = progressStream.getReader();
+
+      await expect(reader.read()).rejects.toThrow('integrity check failed');
+    });
+
+    it('should not call onFinished if stream is cancelled before completing', async () => {
+      const sourceStream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+        },
+      });
+
+      const onFinished = vi.fn().mockResolvedValue(undefined);
+      const progressStream = buildProgressStream(sourceStream, vi.fn(), onFinished);
+      const reader = progressStream.getReader();
+
+      await reader.cancel();
+
+      expect(onFinished).not.toHaveBeenCalled();
+    });
+
     it('should accumulate read bytes across multiple chunks', async () => {
       const mockData = [new Uint8Array([1, 2]), new Uint8Array([3, 4, 5]), new Uint8Array([6])];
       const sourceStream = new ReadableStream<Uint8Array>({

--- a/src/services/stream.service.ts
+++ b/src/services/stream.service.ts
@@ -56,7 +56,11 @@ export async function binaryStreamToUint8Array(
   return result;
 }
 
-export function buildProgressStream(source: BinaryStream, onRead: (readBytes: number) => void): BinaryStream {
+export function buildProgressStream(
+  source: BinaryStream,
+  onRead: (readBytes: number) => void,
+  onFinished?: () => Promise<void>,
+): BinaryStream {
   const reader = source.getReader();
   let readBytes = 0;
 
@@ -65,6 +69,7 @@ export function buildProgressStream(source: BinaryStream, onRead: (readBytes: nu
       const status = await reader.read();
 
       if (status.done) {
+        await onFinished?.();
         controller.close();
       } else {
         readBytes += (status.value as Uint8Array).length;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,10 +2031,10 @@
   version "1.0.2"
   resolved "https://codeload.github.com/internxt/prettier-config/tar.gz/9fa74e9a2805e1538b50c3809324f1c9d0f3e4f9"
 
-"@internxt/sdk@=1.16.4":
-  version "1.16.4"
-  resolved "https://registry.yarnpkg.com/@internxt/sdk/-/sdk-1.16.4.tgz#1dad7c3fe1581cfb62f9720b6a6470b7c52d7f34"
-  integrity sha512-L4UG7SvNAlldCqx43f5EWt/oVOleqssBb67y1ZUqCcGh3h/wC9mpvkuz80lsGmkzO/ZSZZ0beUzWFlk0LmWM6g==
+"@internxt/sdk@=1.17.8":
+  version "1.17.8"
+  resolved "https://registry.yarnpkg.com/@internxt/sdk/-/sdk-1.17.8.tgz#9ea04ee56f6055832f076e12fc6cf627b85ea5a9"
+  integrity sha512-N+mTXFSfaZSSr3erCfJWxIJTO0o3HwWUt9WMUTgle7K0SXrNioGv669oUKC59FcqycqsDTV9EoHK+vwDWJygZg==
   dependencies:
     axios "^1.16.0"
 
@@ -4017,6 +4017,13 @@ acorn@^8.0.4:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -4277,12 +4284,13 @@ axios@^1.15.2:
     proxy-from-env "^2.1.0"
 
 axios@^1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
-  integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.18.0.tgz#8a7f8854af280fcaae063272df2ed9f3837d2398"
+  integrity sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==
   dependencies:
     follow-redirects "^1.16.0"
     form-data "^4.0.5"
+    https-proxy-agent "^5.0.1"
     proxy-from-env "^2.1.0"
 
 babel-plugin-emotion@^10.0.27:
@@ -5235,7 +5243,7 @@ dayjs@^1.11.7, dayjs@^1.8.34:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.10.tgz#68acea85317a6e164457d6d6947564029a6a16a0"
   integrity sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==
 
-debug@^4.0.1, debug@~4.4.1:
+debug@4, debug@^4.0.1, debug@~4.4.1:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -5624,9 +5632,9 @@ es-module-lexer@^2.0.0:
   integrity sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==
 
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
-  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz#a2d0b373205724dfa525d23b0c3e1b1ca582c99b"
+  integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
   dependencies:
     es-errors "^1.3.0"
 
@@ -6054,15 +6062,15 @@ foreground-child@^3.1.0:
     signal-exit "^4.0.1"
 
 form-data@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
-  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
-    hasown "^2.0.2"
-    mime-types "^2.1.12"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
 
 fraction.js@^4.3.6:
   version "4.3.6"
@@ -6317,12 +6325,12 @@ has-proto@^1.0.1:
   resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
   integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
 
-has-symbols@^1.0.2, has-symbols@^1.0.3:
+has-symbols@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
-has-symbols@^1.1.0:
+has-symbols@^1.0.3, has-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
   integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
@@ -6383,10 +6391,17 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hasown@^2.0.0, hasown@^2.0.2:
+hasown@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
+hasown@^2.0.2, hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
 
@@ -6451,6 +6466,14 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==
+
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 husky@^7.0.2:
   version "7.0.4"
@@ -7335,7 +7358,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12:
+mime-types@^2.1.35:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==


### PR DESCRIPTION
## Description

Validate file's integrity by calculating the hash on download to get the HMAC of the downloaded file to compare against the network one. 

## Related Issues

None

## Related Pull Requests

None

## Checklist

- [X] Changes have been tested locally.
- [X] Unit tests have been written or updated as necessary.
- [X] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [X] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [x] QA Passed

## Testing Process
- When uploading 10MB, 100MB and 1GB from production and downloading from this environment, the file is downloaded correctly (check integrity with hashes)
- When uploading a 1GB file on this environment, the RAM usage stays almost the same as in the production version

## Additional Notes
None