### PR TITLE
[_]: fix/downloads for dev environment

### DIFF
--- a/src/app/drive/services/download.service/fetchFileStream.ts
+++ b/src/app/drive/services/download.service/fetchFileStream.ts
@@ -1,5 +1,5 @@
 import { Downloadable, downloadFile } from 'app/network/download';
-import { getEnvironmentConfig } from '../network.service';
+import { getEnvironmentConfig } from '../network.service/getEnvironmentConfig';
 
 type FetchFileStreamOptions = {
   updateProgressCallback: (progress: number) => void;

--- a/src/app/drive/services/network.service/getEnvironmentConfig.test.ts
+++ b/src/app/drive/services/network.service/getEnvironmentConfig.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
+import { getEnvironmentConfig } from './getEnvironmentConfig';
+import localStorageService from 'services/local-storage.service';
+import envService from 'services/env.service';
+
+vi.mock('services/local-storage.service', () => ({
+  default: {
+    getWorkspaceCredentials: vi.fn(),
+    getB2BWorkspace: vi.fn(),
+    getUser: vi.fn(),
+  },
+}));
+
+vi.mock('services/env.service', () => ({
+  default: {
+    getVariable: vi.fn(),
+  },
+}));
+
+const mockedLocalStorage = vi.mocked(localStorageService);
+const mockedEnvService = vi.mocked(envService);
+
+const createMockUser = (overrides: Partial<UserSettings> = {}): UserSettings =>
+  ({
+    bridgeUser: 'user@internxt.com',
+    userId: 'user-id-123',
+    mnemonic: 'personal-mnemonic',
+    bucket: 'personal-bucket',
+    ...overrides,
+  }) as UserSettings;
+
+const createMockWorkspaceCredentials = () =>
+  ({
+    credentials: {
+      networkUser: 'workspace-user',
+      networkPass: 'workspace-pass',
+    },
+    bucket: 'workspace-bucket',
+  }) as any;
+
+const createMockWorkspace = () =>
+  ({
+    workspaceUser: {
+      key: 'workspace-key',
+    },
+  }) as any;
+
+describe('Get Environment Config', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Personal account context', () => {
+    test('When the user is not in a workspace, then the personal credentials are returned', () => {
+      mockedLocalStorage.getUser.mockReturnValue(createMockUser());
+      mockedEnvService.getVariable.mockReturnValue('false');
+
+      const result = getEnvironmentConfig(false);
+
+      expect(result).toEqual({
+        bridgeUser: 'user@internxt.com',
+        bridgePass: 'user-id-123',
+        encryptionKey: 'personal-mnemonic',
+        bucketId: 'personal-bucket',
+        useProxy: true,
+      });
+    });
+
+    test('When the workspace flag is not provided, then the personal credentials are returned by default', () => {
+      mockedLocalStorage.getUser.mockReturnValue(createMockUser());
+      mockedEnvService.getVariable.mockReturnValue('false');
+
+      const result = getEnvironmentConfig();
+
+      expect(result.bridgeUser).toBe('user@internxt.com');
+      expect(result.bucketId).toBe('personal-bucket');
+    });
+
+    test('When the user requests workspace context but no workspace credentials are stored, then the personal credentials are returned', () => {
+      mockedLocalStorage.getWorkspaceCredentials.mockReturnValue(null);
+      mockedLocalStorage.getB2BWorkspace.mockReturnValue(createMockWorkspace());
+      mockedLocalStorage.getUser.mockReturnValue(createMockUser());
+      mockedEnvService.getVariable.mockReturnValue('false');
+
+      const result = getEnvironmentConfig(true);
+
+      expect(result.bridgeUser).toBe('user@internxt.com');
+      expect(result.encryptionKey).toBe('personal-mnemonic');
+    });
+
+    test('When the user requests workspace context but no workspace data is stored, then the personal credentials are returned', () => {
+      mockedLocalStorage.getWorkspaceCredentials.mockReturnValue(createMockWorkspaceCredentials());
+      mockedLocalStorage.getB2BWorkspace.mockReturnValue(null);
+      mockedLocalStorage.getUser.mockReturnValue(createMockUser());
+      mockedEnvService.getVariable.mockReturnValue('false');
+
+      const result = getEnvironmentConfig(true);
+
+      expect(result.bridgeUser).toBe('user@internxt.com');
+      expect(result.encryptionKey).toBe('personal-mnemonic');
+    });
+  });
+
+  describe('Workspace account context', () => {
+    test('When the user is in a workspace, then the workspace credentials are returned', () => {
+      mockedLocalStorage.getWorkspaceCredentials.mockReturnValue(createMockWorkspaceCredentials());
+      mockedLocalStorage.getB2BWorkspace.mockReturnValue(createMockWorkspace());
+      mockedEnvService.getVariable.mockReturnValue('false');
+
+      const result = getEnvironmentConfig(true);
+
+      expect(result).toEqual({
+        bridgeUser: 'workspace-user',
+        bridgePass: 'workspace-pass',
+        encryptionKey: 'workspace-key',
+        bucketId: 'workspace-bucket',
+        useProxy: true,
+      });
+    });
+
+    test('When the user is in a workspace, then the workspace encryption key is used instead of the personal one', () => {
+      mockedLocalStorage.getWorkspaceCredentials.mockReturnValue(createMockWorkspaceCredentials());
+      mockedLocalStorage.getB2BWorkspace.mockReturnValue(createMockWorkspace());
+      mockedLocalStorage.getUser.mockReturnValue(createMockUser());
+      mockedEnvService.getVariable.mockReturnValue('false');
+
+      const result = getEnvironmentConfig(true);
+
+      expect(result.encryptionKey).toBe('workspace-key');
+      expect(result.encryptionKey).not.toBe('personal-mnemonic');
+    });
+  });
+
+  describe('Proxy usage', () => {
+    test('When proxy usage is enabled in the environment, then the proxy flag is true', () => {
+      mockedLocalStorage.getUser.mockReturnValue(createMockUser());
+      mockedEnvService.getVariable.mockReturnValue('false');
+
+      const result = getEnvironmentConfig(false);
+
+      expect(result.useProxy).toBe(true);
+    });
+
+    test('When proxy usage is disabled in the environment, then the proxy flag is false', () => {
+      mockedLocalStorage.getUser.mockReturnValue(createMockUser());
+      mockedEnvService.getVariable.mockReturnValue('true');
+
+      const result = getEnvironmentConfig(false);
+
+      expect(result.useProxy).toBe(false);
+    });
+
+    test('When the proxy setting is not configured in the environment, then the proxy is used by default', () => {
+      mockedLocalStorage.getUser.mockReturnValue(createMockUser());
+      mockedEnvService.getVariable.mockReturnValue('');
+
+      const result = getEnvironmentConfig(false);
+
+      expect(result.useProxy).toBe(true);
+    });
+  });
+});

--- a/src/app/drive/services/network.service/getEnvironmentConfig.ts
+++ b/src/app/drive/services/network.service/getEnvironmentConfig.ts
@@ -1,0 +1,33 @@
+import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
+import envService from 'services/env.service';
+import localStorageService from 'services/local-storage.service';
+import { EnvironmentConfig } from './types';
+
+/**
+ * Returns required config to upload files to the Internxt Network
+ * @param isWorkspace Flag to indicate if is a team or not
+ */
+export function getEnvironmentConfig(isWorkspace?: boolean): EnvironmentConfig {
+  const workspaceCredentials = localStorageService.getWorkspaceCredentials();
+  const workspace = localStorageService.getB2BWorkspace();
+
+  if (isWorkspace && workspaceCredentials && workspace) {
+    return {
+      bridgeUser: workspaceCredentials?.credentials?.networkUser,
+      bridgePass: workspaceCredentials?.credentials?.networkPass,
+      encryptionKey: workspace.workspaceUser.key,
+      bucketId: workspaceCredentials?.bucket,
+      useProxy: envService.getVariable('dontUseProxy') !== 'true',
+    };
+  }
+
+  const user = localStorageService.getUser() as UserSettings;
+
+  return {
+    bridgeUser: user.bridgeUser,
+    bridgePass: user.userId,
+    encryptionKey: user.mnemonic,
+    bucketId: user.bucket,
+    useProxy: envService.getVariable('dontUseProxy') !== 'true',
+  };
+}

--- a/src/app/drive/services/network.service/index.ts
+++ b/src/app/drive/services/network.service/index.ts
@@ -1,11 +1,10 @@
-import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
-import envService from 'services/env.service';
 import { Abortable } from 'app/network/Abortable';
 import { createUploadWebWorker } from '../../../../WebWorker';
-import localStorageService from 'services/local-storage.service';
 import { createWorkerMessageHandlerPromise } from '../worker.service/uploadWorkerUtils';
 import { notifyUserWithCooldown } from 'app/core/factory/sdk/retryStrategies';
-import { EnvironmentConfig, IUploadParams } from './types';
+import { IUploadParams } from './types';
+
+export { getEnvironmentConfig } from './getEnvironmentConfig';
 
 export const MAX_ALLOWED_UPLOAD_SIZE = 40 * 1024 * 1024 * 1024;
 
@@ -80,35 +79,4 @@ export class Network {
 
     return createWorkerMessageHandlerPromise(worker, params, continueUploadOptions, notifyUserWithCooldown);
   }
-}
-
-/**
- * Returns required config to upload files to the Internxt Network
- * @param isTeam Flag to indicate if is a team or not
- * @returns
- */
-export function getEnvironmentConfig(isWorkspace?: boolean): EnvironmentConfig {
-  const workspaceCredentials = localStorageService.getWorkspaceCredentials();
-  const workspace = localStorageService.getB2BWorkspace();
-
-  if (isWorkspace && workspaceCredentials && workspace) {
-    return {
-      bridgeUser: workspaceCredentials?.credentials?.networkUser,
-      bridgePass: workspaceCredentials?.credentials?.networkPass,
-      // decrypted mnemonic
-      encryptionKey: workspace.workspaceUser.key,
-      bucketId: workspaceCredentials?.bucket,
-      useProxy: envService.getVariable('dontUseProxy') !== 'true',
-    };
-  }
-
-  const user = localStorageService.getUser() as UserSettings;
-
-  return {
-    bridgeUser: user.bridgeUser,
-    bridgePass: user.userId,
-    encryptionKey: user.mnemonic,
-    bucketId: user.bucket,
-    useProxy: envService.getVariable('dontUseProxy') !== 'true',
-  };
 }


### PR DESCRIPTION
## Description

Extract `getEnvironmentConfig` into its own module so the download Web Worker no longer imports React code transitively, fixing the `Uncaught ReferenceError: window is not defined` that prevented file downloads in dev mode. The worker imported `fetchFileStream`, which pulled `getEnvironmentConfig` from `network.service/index.ts`, and that barrel also imported `notifyUserWithCooldown` → `notifications.service` → `react-hot-toast` and React components. 

In dev, Vite has no tree-shaking and injects the @react-refresh HMR prelude into any module that looks like React code, and that prelude references window, which doesn't exist inside a Web Worker, so the worker crashed at load time. 

In production it didn't surface because Rollup tree-shakes the unused branch and there's no HMR prelude, but the coupling was fragile.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
