### PR TITLE
[PB-6509]: feat/store-hmac-on-upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@iconscout/react-unicons": "^1.1.6",
     "@internxt/css-config": "1.1.0",
     "@internxt/lib": "1.4.1",
-    "@internxt/sdk": "=1.17.8",
+    "@internxt/sdk": "=1.17.9",
     "@internxt/ui": "=0.1.21",
     "@phosphor-icons/react": "^2.1.7",
     "@popperjs/core": "^2.11.6",

--- a/src/app/crypto/services/utils.test.ts
+++ b/src/app/crypto/services/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { hmacSha512, getFileHmacFromShardHashes } from './utils';
+import { hmacSha512, deriveHmacKey, getFileHmacFromShardHashes } from './utils';
 
 describe('hmacSha512', () => {
   const key = Buffer.alloc(32, 0x01);
@@ -26,6 +26,32 @@ describe('hmacSha512', () => {
     const r1 = await hmacSha512(key, Buffer.from('data1'));
     const r2 = await hmacSha512(key, Buffer.from('data2'));
     expect(r1).not.toBe(r2);
+  });
+});
+
+describe('deriveHmacKey', () => {
+  it('returns a 64-byte Buffer', async () => {
+    const result = await deriveHmacKey(Buffer.alloc(32, 0x01));
+    expect(result).toHaveLength(64);
+  });
+
+  it('is deterministic', async () => {
+    const fileKey = Buffer.alloc(32, 0x01);
+    const r1 = await deriveHmacKey(fileKey);
+    const r2 = await deriveHmacKey(fileKey);
+    expect(r1.toString('hex')).toBe(r2.toString('hex'));
+  });
+
+  it('produces a different key for different file keys', async () => {
+    const r1 = await deriveHmacKey(Buffer.alloc(32, 0x01));
+    const r2 = await deriveHmacKey(Buffer.alloc(32, 0x02));
+    expect(r1.toString('hex')).not.toBe(r2.toString('hex'));
+  });
+
+  it('derived key is different from the original file key', async () => {
+    const fileKey = Buffer.alloc(32, 0x01);
+    const derived = await deriveHmacKey(fileKey);
+    expect(derived.subarray(0, 32).toString('hex')).not.toBe(fileKey.toString('hex'));
   });
 });
 
@@ -60,7 +86,7 @@ describe('getFileHmacFromShardHashes', () => {
     const hash1 = 'aabbcc';
     const hash2 = 'ddeeff';
     const resultMulti = await getFileHmacFromShardHashes(fileKey, [hash1, hash2]);
-    const resultSingle = await hmacSha512(fileKey, Buffer.from(hash1 + hash2, 'hex'));
+    const resultSingle = await getFileHmacFromShardHashes(fileKey, [hash1 + hash2]);
     expect(resultMulti).toBe(resultSingle);
   });
 });

--- a/src/app/crypto/services/utils.test.ts
+++ b/src/app/crypto/services/utils.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { hmacSha512, getFileHmacFromShardHashes } from './utils';
+
+describe('hmacSha512', () => {
+  const key = Buffer.alloc(32, 0x01);
+
+  it('returns a 128-character lowercase hex string', async () => {
+    const result = await hmacSha512(key, Buffer.from('test'));
+    expect(result).toHaveLength(128);
+    expect(result).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('is deterministic', async () => {
+    const data = Buffer.from('same data');
+    expect(await hmacSha512(key, data)).toBe(await hmacSha512(key, data));
+  });
+
+  it('produces different output for different keys', async () => {
+    const data = Buffer.from('data');
+    const r1 = await hmacSha512(Buffer.alloc(32, 0x01), data);
+    const r2 = await hmacSha512(Buffer.alloc(32, 0x02), data);
+    expect(r1).not.toBe(r2);
+  });
+
+  it('produces different output for different data', async () => {
+    const r1 = await hmacSha512(key, Buffer.from('data1'));
+    const r2 = await hmacSha512(key, Buffer.from('data2'));
+    expect(r1).not.toBe(r2);
+  });
+});
+
+describe('getFileHmacFromShardHashes', () => {
+  const fileKey = Buffer.alloc(32, 0x01);
+
+  it('returns a 128-character hex string', async () => {
+    const result = await getFileHmacFromShardHashes(fileKey, ['aabbcc']);
+    expect(result).toHaveLength(128);
+    expect(result).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('is deterministic', async () => {
+    const r1 = await getFileHmacFromShardHashes(fileKey, ['aabbcc']);
+    const r2 = await getFileHmacFromShardHashes(fileKey, ['aabbcc']);
+    expect(r1).toBe(r2);
+  });
+
+  it('produces different output for different file keys', async () => {
+    const r1 = await getFileHmacFromShardHashes(Buffer.alloc(32, 0x01), ['aabbcc']);
+    const r2 = await getFileHmacFromShardHashes(Buffer.alloc(32, 0x02), ['aabbcc']);
+    expect(r1).not.toBe(r2);
+  });
+
+  it('produces different output for different shard hashes', async () => {
+    const r1 = await getFileHmacFromShardHashes(fileKey, ['aabbcc']);
+    const r2 = await getFileHmacFromShardHashes(fileKey, ['ddeeff']);
+    expect(r1).not.toBe(r2);
+  });
+
+  it('computes HMAC over the concatenated bytes of all shard hashes', async () => {
+    const hash1 = 'aabbcc';
+    const hash2 = 'ddeeff';
+    const resultMulti = await getFileHmacFromShardHashes(fileKey, [hash1, hash2]);
+    const resultSingle = await hmacSha512(fileKey, Buffer.from(hash1 + hash2, 'hex'));
+    expect(resultMulti).toBe(resultSingle);
+  });
+});

--- a/src/app/crypto/services/utils.ts
+++ b/src/app/crypto/services/utils.ts
@@ -2,7 +2,7 @@ import { aes, items as itemUtils } from '@internxt/lib';
 import envService from 'services/env.service';
 import { Buffer } from 'buffer';
 import CryptoJS from 'crypto-js';
-import { blake3, createSHA256, createSHA512, ripemd160, sha256 } from 'hash-wasm';
+import { blake3, createHMAC, createSHA256, createSHA512, ripemd160, sha256 } from 'hash-wasm';
 import { DriveItemData } from 'app/drive/types';
 import { AdvancedSharedItem } from '../../share/types';
 
@@ -15,6 +15,11 @@ import { AdvancedSharedItem } from '../../share/types';
 async function getSha512Combined(key: Buffer, data: Buffer): Promise<string> {
   const hash = await createSHA512();
   return hash.init().update(key).update(data).digest();
+}
+
+async function hmacSha512(key: Buffer, data: Buffer): Promise<string> {
+  const hmac = await createHMAC(createSHA512(), key);
+  return hmac.init().update(data).digest();
 }
 
 interface PassObjectInterface {
@@ -115,7 +120,7 @@ const getItemPlainName = (item: DriveItemData | AdvancedSharedItem) => {
 };
 
 async function getFileHmacFromShardHashes(fileKey: Buffer, shardHashes: string[]): Promise<string> {
-  return getSha512Combined(fileKey, Buffer.from(shardHashes.join(''), 'hex'));
+  return hmacSha512(fileKey, Buffer.from(shardHashes.join(''), 'hex'));
 }
 
 export {
@@ -130,6 +135,7 @@ export {
   getSha256,
   getSha256Hasher,
   getSha512Combined,
+  hmacSha512,
   getFileHmacFromShardHashes,
   passToHash,
   renameFile,

--- a/src/app/crypto/services/utils.ts
+++ b/src/app/crypto/services/utils.ts
@@ -22,6 +22,16 @@ async function hmacSha512(key: Buffer, data: Buffer): Promise<string> {
   return hmac.init().update(data).digest();
 }
 
+async function deriveHmacKey(fileKey: Buffer): Promise<Buffer> {
+  const keyMaterial = await crypto.subtle.importKey('raw', new Uint8Array(fileKey), 'HKDF', false, ['deriveBits']);
+  const derivedBits = await crypto.subtle.deriveBits(
+    { name: 'HKDF', hash: 'SHA-512', salt: new Uint8Array(64), info: new TextEncoder().encode('for hmac') },
+    keyMaterial,
+    512,
+  );
+  return Buffer.from(derivedBits);
+}
+
 interface PassObjectInterface {
   salt?: string | null;
   password: string;
@@ -120,7 +130,8 @@ const getItemPlainName = (item: DriveItemData | AdvancedSharedItem) => {
 };
 
 async function getFileHmacFromShardHashes(fileKey: Buffer, shardHashes: string[]): Promise<string> {
-  return hmacSha512(fileKey, Buffer.from(shardHashes.join(''), 'hex'));
+  const hmacKey = await deriveHmacKey(fileKey);
+  return hmacSha512(hmacKey, Buffer.from(shardHashes.join(''), 'hex'));
 }
 
 export {
@@ -136,6 +147,7 @@ export {
   getSha256Hasher,
   getSha512Combined,
   hmacSha512,
+  deriveHmacKey,
   getFileHmacFromShardHashes,
   passToHash,
   renameFile,

--- a/src/app/network/NetworkFacade.test.ts
+++ b/src/app/network/NetworkFacade.test.ts
@@ -3,10 +3,11 @@ import { describe, it, expect, vi, beforeEach, afterEach, test } from 'vitest';
 import { NetworkFacade } from './NetworkFacade';
 import { Network as NetworkModule } from '@internxt/sdk';
 import { downloadFile } from '@internxt/sdk/dist/network/download';
+import { uploadFile } from '@internxt/sdk/dist/network/upload';
 import { buildProgressStream, decryptStream } from 'services/stream.service';
 import { createSha256HashingStream } from './crypto';
 import { getDecryptedStream } from './download';
-import { getFileHmacFromShardHashes } from 'app/crypto/services/utils';
+import { getFileHmacFromShardHashes, getRipemd160FromHex } from 'app/crypto/services/utils';
 import {
   DownloadAbortedByUserError,
   DownloadFailedWithUnknownError,
@@ -15,6 +16,10 @@ import {
 
 vi.mock('@internxt/sdk/dist/network/download', () => ({
   downloadFile: vi.fn(),
+}));
+vi.mock('@internxt/sdk/dist/network/upload', () => ({
+  uploadFile: vi.fn(),
+  uploadMultipartFile: vi.fn(),
 }));
 vi.mock('services/stream.service', () => ({
   binaryStreamToBlob: vi.fn(),
@@ -34,6 +39,7 @@ vi.mock('./download', () => ({
 }));
 vi.mock('app/crypto/services/utils', () => ({
   getFileHmacFromShardHashes: vi.fn(),
+  getRipemd160FromHex: vi.fn(),
 }));
 
 describe('NetworkFacade', () => {
@@ -62,6 +68,7 @@ describe('NetworkFacade', () => {
     const fakeKey = Buffer.alloc(32);
     const fakeIv = Buffer.alloc(16);
     const fakeShardHash = 'aabbcc';
+    const fakeRipemd160Hash = 'ddeeff';
 
     function mockDownloadFile(fileInfoOverride: object = {}) {
       (downloadFile as any).mockImplementation(
@@ -82,6 +89,7 @@ describe('NetworkFacade', () => {
         onHash(fakeShardHash);
         return mockHashingStream;
       });
+      vi.mocked(getRipemd160FromHex).mockResolvedValue(fakeRipemd160Hash);
       vi.mocked(getDecryptedStream).mockReturnValue(mockDecryptedStream);
       vi.mocked(buildProgressStream).mockReturnValue(mockProgressStream);
     });
@@ -149,7 +157,7 @@ describe('NetworkFacade', () => {
       await networkFacade.download(bucketId, fileId, mnemonic);
       await capturedOnFinished?.();
 
-      expect(getFileHmacFromShardHashes).toHaveBeenCalledWith(fakeKey, [fakeShardHash]);
+      expect(getFileHmacFromShardHashes).toHaveBeenCalledWith(fakeKey, [fakeRipemd160Hash]);
     });
   });
 
@@ -251,6 +259,51 @@ describe('NetworkFacade', () => {
           },
         }),
       ).rejects.toThrow(DownloadAbortedByUserError);
+    });
+  });
+
+  describe('Uploading a file', () => {
+    const fakeKey = Buffer.alloc(32, 0x01);
+    const fakeShardHash = 'aabbcc';
+
+    test('computeHmac is provided in the cryptoLib passed to the SDK', async () => {
+      let capturedCrypto: NetworkModule.Crypto | undefined;
+      vi.mocked(uploadFile).mockImplementation(async (_net, crypto) => {
+        capturedCrypto = crypto;
+        return 'file-id';
+      });
+
+      await networkFacade.upload('bucket', 'mnemonic', new File([''], 'test.txt'), { uploadingCallback: vi.fn() });
+
+      expect(capturedCrypto?.computeHmac).toBeDefined();
+    });
+
+    test('computeHmac calls getFileHmacFromShardHashes with the file key and shard hashes', async () => {
+      let capturedCrypto: NetworkModule.Crypto | undefined;
+      vi.mocked(uploadFile).mockImplementation(async (_net, crypto) => {
+        capturedCrypto = crypto;
+        return 'file-id';
+      });
+      vi.mocked(getFileHmacFromShardHashes).mockResolvedValue('computed-hmac');
+
+      await networkFacade.upload('bucket', 'mnemonic', new File([''], 'test.txt'), { uploadingCallback: vi.fn() });
+      await capturedCrypto?.computeHmac?.(fakeKey, [fakeShardHash]);
+
+      expect(getFileHmacFromShardHashes).toHaveBeenCalledWith(fakeKey, [fakeShardHash]);
+    });
+
+    test('computeHmac returns the HMAC value with type sha512', async () => {
+      let capturedCrypto: NetworkModule.Crypto | undefined;
+      vi.mocked(uploadFile).mockImplementation(async (_net, crypto) => {
+        capturedCrypto = crypto;
+        return 'file-id';
+      });
+      vi.mocked(getFileHmacFromShardHashes).mockResolvedValue('computed-hmac-value');
+
+      await networkFacade.upload('bucket', 'mnemonic', new File([''], 'test.txt'), { uploadingCallback: vi.fn() });
+      const result = await capturedCrypto?.computeHmac?.(fakeKey, [fakeShardHash]);
+
+      expect(result).toEqual({ type: 'sha512', value: 'computed-hmac-value' });
     });
   });
 });

--- a/src/app/network/NetworkFacade.ts
+++ b/src/app/network/NetworkFacade.ts
@@ -304,8 +304,6 @@ export class NetworkFacade {
           async () => {
             const shardHashes = await Promise.all(sha256Hashes.map(getRipemd160FromHex));
             const hmac = await getFileHmacFromShardHashes(key as Buffer, shardHashes);
-            console.log('calculated HMAC', hmac);
-            console.log('received hmac', fileInfoRef.hmac?.value);
             if (fileInfoRef.hmac?.value && hmac !== fileInfoRef.hmac.value) throw new Error('File integrity check failed');
           }
         );

--- a/src/app/network/NetworkFacade.ts
+++ b/src/app/network/NetworkFacade.ts
@@ -23,7 +23,7 @@ import {
 import { ALLOWED_CHUNK_OVERHEAD, UPLOAD_CHUNK_SIZE } from './networkConstants';
 import { DownloadChunkPayload } from './types/index';
 import { uploadFileUint8Array, UploadProgressCallback } from './upload-utils';
-import { getFileHmacFromShardHashes } from 'app/crypto/services/utils';
+import { getFileHmacFromShardHashes, getRipemd160FromHex } from 'app/crypto/services/utils';
 
 interface UploadOptions {
   uploadingCallback: UploadProgressCallback;
@@ -70,6 +70,10 @@ export class NetworkFacade {
         return generateFileKey(mnemonic, bucketId, index as Buffer);
       },
       randomBytes,
+      computeHmac: async (key, shardHashes) => {
+        const value = await getFileHmacFromShardHashes(key as Buffer, shardHashes);
+        return { type: 'sha512', value };
+      },
     };
   }
 
@@ -255,7 +259,7 @@ export class NetworkFacade {
     options?: DownloadOptions,
   ): Promise<ReadableStream> {
     const encryptedContentStreams: ReadableStream<Uint8Array>[] = [];
-    const shardHashes: string[] = [];
+    const sha256Hashes: string[] = [];
     let fileInfoRef: { hmac?: { value: string; type: string } } = {};
     let fileStream: ReadableStream<Uint8Array>;
 
@@ -284,9 +288,7 @@ export class NetworkFacade {
           });
 
           encryptedContentStreams.push(
-            await createSha256HashingStream(encryptedContentStream, (digest) => {
-              shardHashes.push(digest);
-            })
+            await createSha256HashingStream(encryptedContentStream, (h) => sha256Hashes.push(h))
           );
         }
       },
@@ -297,10 +299,13 @@ export class NetworkFacade {
         );
 
         fileStream = buildProgressStream(
-          decryptedStream, 
+          decryptedStream,
           (readBytes) => options?.downloadingCallback?.(fileSize, readBytes),
           async () => {
+            const shardHashes = await Promise.all(sha256Hashes.map(getRipemd160FromHex));
             const hmac = await getFileHmacFromShardHashes(key as Buffer, shardHashes);
+            console.log('calculated HMAC', hmac);
+            console.log('received hmac', fileInfoRef.hmac?.value);
             if (fileInfoRef.hmac?.value && hmac !== fileInfoRef.hmac.value) throw new Error('File integrity check failed');
           }
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1872,10 +1872,10 @@
   version "1.0.2"
   resolved "https://codeload.github.com/internxt/prettier-config/tar.gz/9fa74e9a2805e1538b50c3809324f1c9d0f3e4f9"
 
-"@internxt/sdk@=1.17.8":
-  version "1.17.8"
-  resolved "https://registry.yarnpkg.com/@internxt/sdk/-/sdk-1.17.8.tgz#9ea04ee56f6055832f076e12fc6cf627b85ea5a9"
-  integrity sha512-N+mTXFSfaZSSr3erCfJWxIJTO0o3HwWUt9WMUTgle7K0SXrNioGv669oUKC59FcqycqsDTV9EoHK+vwDWJygZg==
+"@internxt/sdk@=1.17.9":
+  version "1.17.9"
+  resolved "https://registry.yarnpkg.com/@internxt/sdk/-/sdk-1.17.9.tgz#5a9d55db61b1ea9087be269bdff801d72ab51362"
+  integrity sha512-KbxxeMWna9mVDlMCslUPvAPvx9GFcyMz5p2zEGmfwu3Dl6f6U1RpVrfR2YXexApJc5t8+0054jguTeMC54PuAw==
   dependencies:
     axios "^1.16.0"
 


### PR DESCRIPTION
## Description

### What
- Adds `hmacSha512` (proper HMAC-SHA512 via [RFC 2104](https://datatracker.ietf.org/doc/html/rfc2104)) to `utils.ts` and updates `getFileHmacFromShardHashes` to use it instead of the previous `SHA512(key || data)` concatenation
- Derives a dedicated HMAC key via `HKDF(fileKey, info="for hmac", 512 bits)` to enforce cryptographic key separation between the AES-256-CTR encryption key and the HMAC-SHA512 authentication key
- Wires `computeHmac` into `NetworkFacade`'s `cryptoLib` so the SDK computes and sends an HMAC-SHA512 in the `finishUpload` payload during every upload
- Fixes the download verification path to convert SHA256 shard hashes to RIPEMD160 before computing the HMAC, matching the shard hash format stored by the bridge
- Bumps `@internxt/sdk` to `1.17.9` which exposes `computeHmac` in the `Crypto` interface and threads it through `finishUpload`/`finishMultipartUpload`

### Why 
Files uploaded to the bridge are encrypted client-side. Without an HMAC, a compromised server could substitute shard content and the client would silently decrypt garbage. The HMAC binds the encrypted shard (via its RIPEMD160(SHA256) hash, the same identifier the bridge stores) to the file key, so only a client that holds the key could have produced it. Using proper HMAC-SHA512 instead of `SHA512(key || data)` eliminates the length extension vulnerability present in the previous construction.

Regarding the HMAC key: using the same key for both encryption and authentication violates the cryptographic principle of key separation; HKDF ensures the two keys are independent even though they share the same origin.


## Related Issues
None

## Related Pull Requests
- https://github.com/internxt/drive-web/pull/1997

## Checklist

- [X] Changes have been tested locally.
- [X] Unit tests have been written or updated as necessary.
- [X] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [X] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process
Specified on the Jira related ticket. 

## Additional Notes
None