### PR TITLE
[PB-6516]: fix/add-secure-flag-to-all-client-set-cookies

### DIFF
--- a/src/app/analytics/utils.test.ts
+++ b/src/app/analytics/utils.test.ts
@@ -94,4 +94,13 @@ describe('setImpactCookies', () => {
     expect(daysDiff).toBeGreaterThan(29);
     expect(daysDiff).toBeLessThan(31);
   });
+
+  it('When called, then all cookies include the Secure flag so they are never sent over HTTP', () => {
+    setImpactCookies('anon_123', 'click_abc', 'partner_456');
+
+    const cookies = getCookieCalls(cookieSetter);
+    for (const cookie of cookies) {
+      expect(cookie).toContain('Secure');
+    }
+  });
 });

--- a/src/app/analytics/utils.ts
+++ b/src/app/analytics/utils.ts
@@ -2,7 +2,7 @@ export function setCookie(cookieName: string, cookieValue: string, expDays = 30)
   const date = new Date();
   date.setTime(date.getTime() + expDays * 24 * 60 * 60 * 1000);
   const expires = `expires=${date.toUTCString()}`;
-  window.document.cookie = `${cookieName}=${cookieValue}; ${expires}; domain=internxt.com'`;
+  window.document.cookie = `${cookieName}=${cookieValue}; ${expires}; domain=internxt.com; Secure`;
 }
 
 export function setImpactCookies(anonymousId: string, irclickid: string, utmMedium?: string | null): void {
@@ -17,12 +17,12 @@ export function setImpactCookies(anonymousId: string, irclickid: string, utmMedi
   const trackingExpiration = new Date();
   trackingExpiration.setDate(trackingExpiration.getDate() + 30);
 
-  document.cookie = `impactSource=Impact;expires=${sourceExpiration.toUTCString()};domain=${cookieDomain};Path=/`;
-  document.cookie = `impactAnonymousId=${anonymousId};expires=${anonymousExpiration.toUTCString()};domain=${cookieDomain};Path=/`;
-  document.cookie = `impactClickId=${irclickid};expires=${trackingExpiration.toUTCString()};domain=${cookieDomain};Path=/`;
+  document.cookie = `impactSource=Impact;expires=${sourceExpiration.toUTCString()};domain=${cookieDomain};Path=/;Secure`;
+  document.cookie = `impactAnonymousId=${anonymousId};expires=${anonymousExpiration.toUTCString()};domain=${cookieDomain};Path=/;Secure`;
+  document.cookie = `impactClickId=${irclickid};expires=${trackingExpiration.toUTCString()};domain=${cookieDomain};Path=/;Secure`;
 
   if (utmMedium) {
-    document.cookie = `impactPartnerId=${utmMedium};expires=${trackingExpiration.toUTCString()};domain=${cookieDomain};Path=/`;
+    document.cookie = `impactPartnerId=${utmMedium};expires=${trackingExpiration.toUTCString()};domain=${cookieDomain};Path=/;Secure`;
   }
 }
 

--- a/src/views/Checkout/views/CheckoutViewWrapper.tsx
+++ b/src/views/Checkout/views/CheckoutViewWrapper.tsx
@@ -118,7 +118,7 @@ const CheckoutViewWrapper = () => {
     if (gclid) {
       const expiryDate = new Date();
       expiryDate.setTime(expiryDate.getTime() + GCLID_COOKIE_LIFESPAN_DAYS * MILLISECONDS_PER_DAY);
-      document.cookie = `gclid=${gclid}; expires=${expiryDate.toUTCString()}; path=/`;
+      document.cookie = `gclid=${gclid}; expires=${expiryDate.toUTCString()}; path=/; Secure`;
       localStorageService.set(STORAGE_KEYS.GCLID, gclid);
     }
     if (irclickid) {


### PR DESCRIPTION
## Description

### What

Add the `Secure` attribute to all client-set cookies (`impactSource`, `impactAnonymousId`, `impactClickId`, `impactPartnerId`, `gclid`, and any cookie written via `setCookie()`).

Also fixes a stray single-quote bug in `setCookie()` that was silently malforming the cookie string (`domain=internxt.com'`).

**Files changed:**
- `src/app/analytics/utils.ts` — `setCookie()` and `setImpactCookies()`
- `src/views/Checkout/views/CheckoutViewWrapper.tsx` — `gclid` cookie

### Why

A security audit flagged that session and tracking cookies were being set without the `Secure` flag, meaning the browser could transmit them over unencrypted HTTP connections. This opens the door to man-in-the-middle attacks where an attacker on the network path could intercept or replay cookie values.

Adding `Secure` ensures cookies are only sent over HTTPS, closing that transmission vector. No `SameSite` changes were made to avoid altering the existing cross-site behavior of analytics tracking.

## Related Issues

None

## Related Pull Requests

None

## Checklist

- [X] Changes have been tested locally.
- [X] Unit tests have been written or updated as necessary.
- [X] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [X] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

Set in the related Jira ticket. 

## Additional Notes

This needs a review from marketing as this may — or may not — affect analytics
