### PR TITLE
[PB-6516]: fix/add-secure-and-samesite-strict-flags-to-i18next-lang-cookie

### DIFF
--- a/src/app/i18n/services/i18n.service.test.ts
+++ b/src/app/i18n/services/i18n.service.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockInit = vi.fn().mockResolvedValue(undefined);
+const mockUse = vi.fn().mockReturnThis();
+
+vi.mock('i18next', () => ({
+  default: { use: mockUse, init: mockInit },
+}));
+vi.mock('i18next-browser-languagedetector', () => ({ default: class {} }));
+vi.mock('react-i18next', () => ({ initReactI18next: {} }));
+
+describe('i18n service', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    await import('./i18n.service');
+  });
+
+  it('When initialised, then the language cookie has the Secure flag so it is never sent over HTTP', async () => {
+    const initConfig = mockInit.mock.calls[0][0];
+    expect(initConfig.detection.cookieOptions).toEqual(expect.objectContaining({ secure: true }));
+  });
+
+  it('When initialised, then the language cookie has SameSite=Strict to prevent cross-site leakage', async () => {
+    const initConfig = mockInit.mock.calls[0][0];
+    expect(initConfig.detection.cookieOptions).toEqual(expect.objectContaining({ sameSite: 'strict' }));
+  });
+});

--- a/src/app/i18n/services/i18n.service.test.ts
+++ b/src/app/i18n/services/i18n.service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 const mockInit = vi.fn().mockResolvedValue(undefined);
 const mockUse = vi.fn().mockReturnThis();
@@ -15,12 +15,12 @@ describe('i18n service', () => {
     await import('./i18n.service');
   });
 
-  it('When initialised, then the language cookie has the Secure flag so it is never sent over HTTP', async () => {
+  test('When initialised, then the language cookie has the Secure flag so it is never sent over HTTP', async () => {
     const initConfig = mockInit.mock.calls[0][0];
     expect(initConfig.detection.cookieOptions).toEqual(expect.objectContaining({ secure: true }));
   });
 
-  it('When initialised, then the language cookie has SameSite=Strict to prevent cross-site leakage', async () => {
+  test('When initialised, then the language cookie has SameSite=Strict to prevent cross-site leakage', async () => {
     const initConfig = mockInit.mock.calls[0][0];
     expect(initConfig.detection.cookieOptions).toEqual(expect.objectContaining({ sameSite: 'strict' }));
   });

--- a/src/app/i18n/services/i18n.service.ts
+++ b/src/app/i18n/services/i18n.service.ts
@@ -58,6 +58,7 @@ export default i18next
     detection: {
       order: ['querystring', 'localStorage', 'cookie', 'navigator'],
       caches: ['localStorage', 'cookie'],
+      cookieOptions: { secure: true, sameSite: 'strict' },
     },
     defaultNS: 'translation',
     ns: ['translation'],


### PR DESCRIPTION
## Description

The i18next-browser-language detector was caching the language preference in a cookie without the Secure flag, allowing it to be sent over HTTP. Adds cookieOptions to the detection config to harden the cookie.

## Related Issues

None

## Related Pull Requests

https://github.com/internxt/drive-web/pull/2007

## Checklist

- [X] Changes have been tested locally.
- [X] Unit tests have been written or updated as necessary.
- [X] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [X] No new warnings or errors have been introduced.
- [X] SonarCloud issues have been reviewed and addressed.
- [X] QA Passed

## Testing Process

Switch between languages to ensure i18next did not broke. 

## Additional Notes

Nothing
