### PR TITLE
[PB-6503] Use localstorage functions to get and set token

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,7 @@ const App = (props: AppProps): JSX.Element => {
   const isOpen = isDialogOpen(ActionDialog.ModifyStorage);
   const { openBackupKeysDialog } = useDownloadBackupKeys(t);
   const token = localStorageService.get(LocalStorageItem.UserToken);
-  const newToken = localStorageService.get(LocalStorageItem.NewToken);
+  const newToken = localStorageService.getToken();
   const params = new URLSearchParams(window.location.search);
   const isVpnAuth = params.get('vpnAuth') === 'true';
   const skipSignupIfLoggedIn = params.get('skipSignupIfLoggedIn') === 'true';

--- a/src/app/core/factory/sdk/index.test.ts
+++ b/src/app/core/factory/sdk/index.test.ts
@@ -93,6 +93,7 @@ describe('SdkFactory', () => {
     mockDispatch = vi.fn();
     mockLocalStorage = {
       get: vi.fn(),
+      getToken: vi.fn(),
       getWorkspace: vi.fn(),
     } as any;
 
@@ -130,10 +131,7 @@ describe('SdkFactory', () => {
       const mockWorkspace = Workspace.Individuals;
 
       vi.spyOn(mockLocalStorage, 'getWorkspace').mockReturnValue(mockWorkspace);
-      vi.spyOn(mockLocalStorage, 'get').mockImplementation((key: string) => {
-        if (key === LocalStorageItem.NewToken) return mockToken;
-        return null;
-      });
+      vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
 
       const instance = SdkFactory.getNewApiInstance();
       const apiSecurity = (instance as any).getNewApiSecurity();
@@ -149,10 +147,7 @@ describe('SdkFactory', () => {
       const customCallback = vi.fn();
 
       vi.spyOn(mockLocalStorage, 'getWorkspace').mockReturnValue(mockWorkspace);
-      vi.spyOn(mockLocalStorage, 'get').mockImplementation((key: string) => {
-        if (key === LocalStorageItem.NewToken) return mockToken;
-        return null;
-      });
+      vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
 
       const instance = SdkFactory.getNewApiInstance();
       const apiSecurity = (instance as any).getNewApiSecurity(customCallback);
@@ -170,8 +165,8 @@ describe('SdkFactory', () => {
       };
 
       vi.spyOn(mockLocalStorage, 'getWorkspace').mockReturnValue(mockWorkspace);
+      vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
       vi.spyOn(mockLocalStorage, 'get').mockImplementation((key: string) => {
-        if (key === LocalStorageItem.NewToken) return mockToken;
         if (key === STORAGE_KEYS.B2B_WORKSPACE) return mockWorkspaceId;
         if (key === STORAGE_KEYS.WORKSPACE_CREDENTIALS) return JSON.stringify(mockCredentials);
         return null;
@@ -189,10 +184,7 @@ describe('SdkFactory', () => {
       const mockWorkspace = Workspace.Individuals;
 
       vi.spyOn(mockLocalStorage, 'getWorkspace').mockReturnValue(mockWorkspace);
-      vi.spyOn(mockLocalStorage, 'get').mockImplementation((key: string) => {
-        if (key === LocalStorageItem.NewToken) return mockToken;
-        return null;
-      });
+      vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
 
       const instance = SdkFactory.getNewApiInstance();
       const apiSecurity = (instance as any).getNewApiSecurity();
@@ -236,8 +228,8 @@ describe('SdkFactory', () => {
       const mockWorkspaceId = 'workspace-123';
 
       vi.spyOn(mockLocalStorage, 'getWorkspace').mockReturnValue(mockWorkspace);
+      vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
       vi.spyOn(mockLocalStorage, 'get').mockImplementation((key: string) => {
-        if (key === LocalStorageItem.NewToken) return mockToken;
         if (key === STORAGE_KEYS.B2B_WORKSPACE) return mockWorkspaceId;
         if (key === STORAGE_KEYS.WORKSPACE_CREDENTIALS) return null;
         return null;
@@ -256,10 +248,7 @@ describe('SdkFactory', () => {
         const mockWorkspace = Workspace.Individuals;
 
         vi.spyOn(mockLocalStorage, 'getWorkspace').mockReturnValue(mockWorkspace);
-        vi.spyOn(mockLocalStorage, 'get').mockImplementation((key: string) => {
-          if (key === LocalStorageItem.NewToken) return mockToken;
-          return null;
-        });
+        vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
 
         const instance = SdkFactory.getNewApiInstance();
         instance.createUsersClient();
@@ -280,10 +269,7 @@ describe('SdkFactory', () => {
         const captchaToken = 'captcha-token-123';
 
         vi.spyOn(mockLocalStorage, 'getWorkspace').mockReturnValue(mockWorkspace);
-        vi.spyOn(mockLocalStorage, 'get').mockImplementation((key: string) => {
-          if (key === LocalStorageItem.NewToken) return mockToken;
-          return null;
-        });
+        vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
 
         const instance = SdkFactory.getNewApiInstance();
         instance.createUsersClient(captchaToken);
@@ -308,10 +294,7 @@ describe('SdkFactory', () => {
         const mockWorkspace = Workspace.Individuals;
 
         vi.spyOn(mockLocalStorage, 'getWorkspace').mockReturnValue(mockWorkspace);
-        vi.spyOn(mockLocalStorage, 'get').mockImplementation((key: string) => {
-          if (key === LocalStorageItem.NewToken) return mockToken;
-          return null;
-        });
+        vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
 
         const instance = SdkFactory.getNewApiInstance();
         instance.createShareClient();
@@ -332,10 +315,7 @@ describe('SdkFactory', () => {
         const captchaToken = 'captcha-token-123';
 
         vi.spyOn(mockLocalStorage, 'getWorkspace').mockReturnValue(mockWorkspace);
-        vi.spyOn(mockLocalStorage, 'get').mockImplementation((key: string) => {
-          if (key === LocalStorageItem.NewToken) return mockToken;
-          return null;
-        });
+        vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
 
         const instance = SdkFactory.getNewApiInstance();
         instance.createShareClient(captchaToken);
@@ -360,10 +340,7 @@ describe('SdkFactory', () => {
         const mockWorkspace = Workspace.Individuals;
 
         vi.spyOn(mockLocalStorage, 'getWorkspace').mockReturnValue(mockWorkspace);
-        vi.spyOn(mockLocalStorage, 'get').mockImplementation((key: string) => {
-          if (key === LocalStorageItem.NewToken) return mockToken;
-          return null;
-        });
+        vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
 
         const instance = SdkFactory.getNewApiInstance();
         instance.createAuthClient();
@@ -384,10 +361,7 @@ describe('SdkFactory', () => {
         const captchaToken = 'captcha-token-123';
 
         vi.spyOn(mockLocalStorage, 'getWorkspace').mockReturnValue(mockWorkspace);
-        vi.spyOn(mockLocalStorage, 'get').mockImplementation((key: string) => {
-          if (key === LocalStorageItem.NewToken) return mockToken;
-          return null;
-        });
+        vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
 
         const instance = SdkFactory.getNewApiInstance();
         instance.createAuthClient({ captchaToken });
@@ -412,10 +386,7 @@ describe('SdkFactory', () => {
         const mockWorkspace = Workspace.Individuals;
 
         vi.spyOn(mockLocalStorage, 'getWorkspace').mockReturnValue(mockWorkspace);
-        vi.spyOn(mockLocalStorage, 'get').mockImplementation((key: string) => {
-          if (key === LocalStorageItem.NewToken) return mockToken;
-          return null;
-        });
+        vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
 
         const instance = SdkFactory.getNewApiInstance();
         instance.createLocationClient();

--- a/src/app/core/factory/sdk/index.ts
+++ b/src/app/core/factory/sdk/index.ts
@@ -181,7 +181,7 @@ export class SdkFactory {
 
   private getNewToken(workspace: string): Token {
     const tokenByWorkspace: { [key in Workspace]: string } = {
-      [Workspace.Individuals]: SdkFactory.sdk.localStorage.get(LocalStorageItem.NewToken) || '',
+      [Workspace.Individuals]: SdkFactory.sdk.localStorage.getToken() || '',
       [Workspace.Business]: SdkFactory.sdk.localStorage.get(LocalStorageItem.TeamToken) || '',
     };
     return tokenByWorkspace[workspace];

--- a/src/app/core/views/DeactivationView/DeactivationView.tsx
+++ b/src/app/core/views/DeactivationView/DeactivationView.tsx
@@ -10,7 +10,7 @@ import notificationsService, { ToastType } from '../../../notifications/services
 
 import { match } from 'react-router-dom';
 import navigationService from 'services/navigation.service';
-import { AppView, LocalStorageItem } from '../../types';
+import { AppView } from '../../types';
 import { SdkFactory } from '../../factory/sdk';
 import localStorageService from 'services/local-storage.service';
 
@@ -43,7 +43,7 @@ class DeactivationView extends React.Component<DeactivationViewProps> {
 
   ConfirmDeactivateUser = (token: string) => {
     const authClient = SdkFactory.getNewApiInstance().createAuthClient();
-    const userToken = localStorageService.get(LocalStorageItem.NewToken) ?? undefined;
+    const userToken = localStorageService.getToken() ?? undefined;
     return authClient
       .confirmUserDeactivation(token, userToken)
       .then(() => {

--- a/src/app/store/slices/user/index.ts
+++ b/src/app/store/slices/user/index.ts
@@ -194,7 +194,7 @@ const updateUserEmailCredentialsThunk = createAsyncThunk<
     username: newUserData.email,
   };
   localStorageService.set(LocalStorageItem.UserToken, token);
-  localStorageService.set(LocalStorageItem.NewToken, newToken);
+  localStorageService.setToken(newToken);
   dispatch(userActions.setUser(user));
 });
 

--- a/src/services/auth.service.test.ts
+++ b/src/services/auth.service.test.ts
@@ -102,7 +102,9 @@ beforeAll(() => {
       get: vi.fn(),
       clear: vi.fn(),
       getUser: vi.fn(),
+      getToken: vi.fn(),
       set: vi.fn(),
+      setToken: vi.fn(),
     },
   }));
   vi.mock('./vpnAuth.service', () => ({
@@ -382,7 +384,7 @@ describe('signUp', () => {
 
     const result = await authService.signUp(params);
 
-    expect(localStorageService.set).toHaveBeenCalledWith(LocalStorageItem.NewToken, mockNewToken);
+    expect(localStorageService.setToken).toHaveBeenCalledWith(mockNewToken);
 
     const plainPrivateKeyInBase64 = Buffer.from(
       keysService.decryptPrivateKey(mockUser.keys.ecc.privateKey, mockPassword),
@@ -493,7 +495,7 @@ describe('signUp', () => {
 
     const result = await authService.signUp(params);
 
-    expect(localStorageService.set).toHaveBeenCalledWith(LocalStorageItem.NewToken, mockNewToken);
+    expect(localStorageService.setToken).toHaveBeenCalledWith(mockNewToken);
 
     const plainPrivateKeyInBase64 = Buffer.from(
       keysService.decryptPrivateKey(mockUser.privateKey, mockPassword),
@@ -747,7 +749,7 @@ describe('Change password', () => {
         sendUserDeactivationEmail: mockSendDeactivationEmail,
       }),
     } as any);
-    vi.spyOn(localStorageService, 'get').mockReturnValue('token');
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue('token');
 
     await authService.cancelAccount();
     expect(mockSendDeactivationEmail).toHaveBeenCalledWith('token');
@@ -915,7 +917,7 @@ describe('areCredentialsCorrect', () => {
     const mockSalt = 'mockSalt';
     const mockToken = 'mockToken';
 
-    vi.spyOn(localStorageService, 'get').mockReturnValue(mockToken);
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue(mockToken);
 
     const encryptedSalt = encryptText(mockSalt);
     const mockAreCredentialsCorrect = vi.fn().mockResolvedValue(true);
@@ -938,7 +940,7 @@ describe('areCredentialsCorrect', () => {
     const mockSalt = 'mockSalt';
     const mockToken = 'mockToken';
 
-    vi.spyOn(localStorageService, 'get').mockReturnValue(mockToken);
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue(mockToken);
 
     const encryptedSalt = encryptText(mockSalt);
     const mockAreCredentialsCorrect = vi.fn().mockResolvedValue(false);
@@ -960,7 +962,7 @@ describe('areCredentialsCorrect', () => {
     const mockPassword = 'password123';
     const mockSalt = 'mockSalt';
 
-    vi.spyOn(localStorageService, 'get').mockReturnValue(null);
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue(null);
 
     const encryptedSalt = encryptText(mockSalt);
     const mockAreCredentialsCorrect = vi.fn().mockResolvedValue(true);
@@ -983,7 +985,7 @@ describe('areCredentialsCorrect', () => {
     const mockSalt = 'mockSalt';
     const mockToken = 'mockToken';
 
-    vi.spyOn(localStorageService, 'get').mockReturnValue(mockToken);
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue(mockToken);
 
     const encryptedSalt = encryptText(mockSalt);
     const mockError = new Error('API error');
@@ -1006,10 +1008,7 @@ describe('areCredentialsCorrect', () => {
     const mockEmail = 'test@example.com';
     const mockCreateAuthClient = vi.fn();
 
-    vi.spyOn(localStorageService, 'get').mockImplementation((key: string) => {
-      if (key === LocalStorageItem.NewToken) return mockToken;
-      return null;
-    });
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue(mockToken);
 
     vi.spyOn(localStorageService, 'getUser').mockReturnValue({
       email: mockEmail,
@@ -1119,7 +1118,7 @@ describe('logOut', () => {
       createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
     } as any);
 
-    vi.spyOn(localStorageService, 'get').mockReturnValue('test-token');
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue('test-token');
     vi.spyOn(localStorageService, 'clear').mockImplementation(() => {});
 
     await authService.logOut();
@@ -1129,7 +1128,7 @@ describe('logOut', () => {
   });
 
   it('should sign out user even when session has expired', async () => {
-    vi.spyOn(localStorageService, 'get').mockReturnValue(null);
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue(null);
     vi.spyOn(localStorageService, 'clear').mockImplementation(() => {});
 
     await authService.logOut();
@@ -1146,7 +1145,7 @@ describe('logOut', () => {
       createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
     } as any);
 
-    vi.spyOn(localStorageService, 'get').mockReturnValue('test-token');
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue('test-token');
     vi.spyOn(localStorageService, 'clear').mockImplementation(() => {});
 
     const loginParams = { redirect: 'dashboard' };
@@ -1166,7 +1165,7 @@ describe('cancelAccount', () => {
       createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
     } as any);
 
-    vi.spyOn(localStorageService, 'get').mockReturnValue('test-token');
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue('test-token');
 
     await authService.cancelAccount();
 
@@ -1300,7 +1299,7 @@ describe('generateNew2FA', () => {
       createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
     } as any);
 
-    vi.spyOn(localStorageService, 'get').mockReturnValue('test-token');
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue('test-token');
 
     const result = await authService.generateNew2FA();
 
@@ -1319,7 +1318,7 @@ describe('deactivate2FA', () => {
       createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
     } as any);
 
-    vi.spyOn(localStorageService, 'get').mockReturnValue('test-token');
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue('test-token');
 
     const encryptedSalt = encryptText('test-salt');
     await authService.deactivate2FA(encryptedSalt, 'test-password', '123456');
@@ -1426,7 +1425,7 @@ describe('authService default export', () => {
       createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
     } as any);
 
-    vi.spyOn(localStorageService, 'get').mockReturnValue('auth-token');
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue('auth-token');
 
     await authService.default.store2FA('secret-code', '123456');
     expect(mockAuthClient.storeTwoFactorAuthKey).toHaveBeenCalledWith('secret-code', '123456', 'auth-token');

--- a/src/services/auth.service.test.ts
+++ b/src/services/auth.service.test.ts
@@ -1171,6 +1171,22 @@ describe('cancelAccount', () => {
 
     expect(mockAuthClient.sendUserDeactivationEmail).toHaveBeenCalledWith('test-token');
   });
+
+  it('should request account closure without token', async () => {
+    const mockAuthClient = {
+      sendUserDeactivationEmail: vi.fn().mockResolvedValue(undefined),
+    };
+
+    vi.spyOn(SdkFactory, 'getNewApiInstance').mockReturnValue({
+      createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
+    } as any);
+
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue(null);
+
+    await authService.cancelAccount();
+
+    expect(mockAuthClient.sendUserDeactivationEmail).toHaveBeenCalledWith(undefined);
+  });
 });
 
 describe('getSalt', () => {
@@ -1306,6 +1322,23 @@ describe('generateNew2FA', () => {
     expect(result).toEqual({ qr: 'qr-code-data', secret: 'secret-key' });
     expect(mockAuthClient.generateTwoFactorAuthQR).toHaveBeenCalledWith('test-token');
   });
+
+  it('should generate new two-factor authentication QR code without token', async () => {
+    const mockAuthClient = {
+      generateTwoFactorAuthQR: vi.fn().mockResolvedValue({ qr: 'qr-code-data', secret: 'secret-key' }),
+    };
+
+    vi.spyOn(SdkFactory, 'getNewApiInstance').mockReturnValue({
+      createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
+    } as any);
+
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue(null);
+
+    const result = await authService.generateNew2FA();
+
+    expect(result).toEqual({ qr: 'qr-code-data', secret: 'secret-key' });
+    expect(mockAuthClient.generateTwoFactorAuthQR).toHaveBeenCalledWith(undefined);
+  });
 });
 
 describe('deactivate2FA', () => {
@@ -1323,7 +1356,24 @@ describe('deactivate2FA', () => {
     const encryptedSalt = encryptText('test-salt');
     await authService.deactivate2FA(encryptedSalt, 'test-password', '123456');
 
-    expect(mockAuthClient.disableTwoFactorAuth).toHaveBeenCalled();
+    expect(mockAuthClient.disableTwoFactorAuth).toHaveBeenCalledWith(expect.any(String), '123456', 'test-token');
+  });
+
+  it('should disable two-factor authentication with valid credentials without token', async () => {
+    const mockAuthClient = {
+      disableTwoFactorAuth: vi.fn().mockResolvedValue(undefined),
+    };
+
+    vi.spyOn(SdkFactory, 'getNewApiInstance').mockReturnValue({
+      createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
+    } as any);
+
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue(null);
+
+    const encryptedSalt = encryptText('test-salt');
+    await authService.deactivate2FA(encryptedSalt, 'test-password', '123456');
+
+    expect(mockAuthClient.disableTwoFactorAuth).toHaveBeenCalledWith(expect.any(String), '123456', undefined);
   });
 });
 
@@ -1429,6 +1479,26 @@ describe('authService default export', () => {
 
     await authService.default.store2FA('secret-code', '123456');
     expect(mockAuthClient.storeTwoFactorAuthKey).toHaveBeenCalledWith('secret-code', '123456', 'auth-token');
+
+    await authService.default.sendChangePasswordEmail('test@example.com');
+    expect(mockAuthClient.sendChangePasswordEmail).toHaveBeenCalledWith('test@example.com');
+  });
+
+  it('should allow storing two-factor authentication keys and sending password reset emails without token', async () => {
+    const mockAuthClient = {
+      storeTwoFactorAuthKey: vi.fn().mockResolvedValue(undefined),
+      sendChangePasswordEmail: vi.fn().mockResolvedValue(undefined),
+      resetAccountWithToken: vi.fn().mockResolvedValue(undefined),
+    };
+
+    vi.spyOn(SdkFactory, 'getNewApiInstance').mockReturnValue({
+      createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
+    } as any);
+
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue(null);
+
+    await authService.default.store2FA('secret-code', '123456');
+    expect(mockAuthClient.storeTwoFactorAuthKey).toHaveBeenCalledWith('secret-code', '123456', undefined);
 
     await authService.default.sendChangePasswordEmail('test@example.com');
     expect(mockAuthClient.sendChangePasswordEmail).toHaveBeenCalledWith('test@example.com');

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -109,7 +109,7 @@ const getCurrentUrlParams = (): Record<string, string> => {
 
 export async function logOut(loginParams?: Record<string, string>): Promise<void> {
   try {
-    const token = localStorageService.get(LocalStorageItem.NewToken) ?? undefined;
+    const token = localStorageService.getToken() ?? undefined;
     if (token) {
       const authClient = SdkFactory.getNewApiInstance().createAuthClient();
       await authClient.logout(token);
@@ -132,7 +132,7 @@ export async function logOut(loginParams?: Record<string, string>): Promise<void
 
 export function cancelAccount(): Promise<void> {
   const authClient = SdkFactory.getNewApiInstance().createAuthClient();
-  const token = localStorageService.get(LocalStorageItem.NewToken) ?? undefined;
+  const token = localStorageService.getToken() ?? undefined;
   return authClient.sendUserDeactivationEmail(token);
 }
 
@@ -213,7 +213,7 @@ export const doLogin = async (
 
       localStorageService.set(LocalStorageItem.UserToken, token);
       localStorageService.set(LocalStorageItem.UserMnemonic, clearMnemonic);
-      localStorageService.set(LocalStorageItem.NewToken, newToken);
+      localStorageService.setToken(newToken);
 
       return {
         user: clearUser,
@@ -420,7 +420,7 @@ export const changePassword = async (newPassword: string, currentPassword: strin
     .then((res) => {
       const { token, newToken } = res;
       if (token) localStorageService.set(LocalStorageItem.UserToken, token);
-      if (newToken) localStorageService.set(LocalStorageItem.NewToken, newToken);
+      if (newToken) localStorageService.setToken(newToken);
     })
     .catch((error) => {
       const appErr = errorService.castError(error);
@@ -438,7 +438,7 @@ export const userHas2FAStored = (): Promise<SecurityDetails> => {
 };
 
 export const generateNew2FA = (): Promise<TwoFactorAuthQR> => {
-  const token = localStorageService.get(LocalStorageItem.NewToken) || undefined;
+  const token = localStorageService.getToken() || undefined;
   const authClient = SdkFactory.getNewApiInstance().createAuthClient();
   return authClient.generateTwoFactorAuthQR(token);
 };
@@ -451,7 +451,7 @@ export const deactivate2FA = (
   const salt = decryptText(passwordSalt);
   const hashObj = passToHash({ password: deactivationPassword, salt });
   const encPass = encryptText(hashObj.hash);
-  const token = localStorageService.get(LocalStorageItem.NewToken) || undefined;
+  const token = localStorageService.getToken() || undefined;
   const authClient = SdkFactory.getNewApiInstance().createAuthClient();
   return authClient.disableTwoFactorAuth(encPass, deactivationCode, token);
 };
@@ -462,7 +462,7 @@ export async function areCredentialsCorrect(password: string): Promise<boolean> 
   const authClient = SdkFactory.getNewApiInstance().createAuthClient({
     unauthorizedCallback: () => undefined,
   });
-  const token = localStorageService.get(LocalStorageItem.NewToken) ?? undefined;
+  const token = localStorageService.getToken() ?? undefined;
   return authClient.areCredentialsCorrect(hashedPassword, token);
 }
 
@@ -487,7 +487,7 @@ export const getRedirectUrl = (urlSearchParams: URLSearchParams, token: string):
 };
 
 const store2FA = async (code: string, twoFactorCode: string): Promise<void> => {
-  const token = localStorageService.get(LocalStorageItem.NewToken) || undefined;
+  const token = localStorageService.getToken() || undefined;
   const authClient = SdkFactory.getNewApiInstance().createAuthClient();
   return authClient.storeTwoFactorAuthKey(code, twoFactorCode, token);
 };
@@ -562,7 +562,7 @@ export const signUp = async (params: SignUpParams) => {
 
   localStorageService.set(LocalStorageItem.UserToken, xToken);
   localStorageService.set(LocalStorageItem.UserMnemonic, mnemonic);
-  localStorageService.set(LocalStorageItem.NewToken, xNewToken);
+  localStorageService.setToken(xNewToken);
 
   const { publicKey, privateKey, publicKyberKey, privateKyberKey } = parseAndDecryptUserKeys(xUser, password);
 

--- a/src/services/local-storage.service.ts
+++ b/src/services/local-storage.service.ts
@@ -30,6 +30,10 @@ function setBackupKeysSeenAt(date: string): void {
   localStorage.setItem(seenAt, date);
 }
 
+function setToken(token: string): void {
+  return localStorage.setItem(LocalStorageItem.NewToken, token);
+}
+
 function removeBackupKeysSeenAt(): void {
   const { seenAt } = getBackupKeyStorageKeys();
   localStorage.removeItem(seenAt);
@@ -51,6 +55,10 @@ function getUser(): UserSettings | null {
   const stringUser: string | null = localStorage.getItem(LocalStorageItem.User);
 
   return stringUser ? JSON.parse(stringUser) : null;
+}
+
+function getToken(): string | null {
+  return localStorage.getItem(LocalStorageItem.NewToken);
 }
 
 function getWorkspace(): string {
@@ -104,9 +112,11 @@ const localStorageService = {
   get,
   setBackupKeysAcknowledged,
   setBackupKeysSeenAt,
+  setToken,
   removeBackupKeysSeenAt,
   getBackupKeys,
   getUser,
+  getToken,
   getWorkspace,
   hasCompletedTutorial,
   removeItem,
@@ -123,12 +133,14 @@ export interface LocalStorageService {
   get: (key: string) => string | null;
   setBackupKeysAcknowledged: () => void;
   setBackupKeysSeenAt: (date: string) => void;
+  setToken: (token: string) => void;
   removeBackupKeysSeenAt: () => void;
   getBackupKeys: () => {
     seenAt: string | null;
     saved: boolean;
   };
   getUser: () => UserSettings | null;
+  getToken: () => string | null;
   getWorkspace: () => string;
   removeItem: (key: string) => void;
   exists: (key: string) => boolean;

--- a/src/services/sockets/socket.service.test.ts
+++ b/src/services/sockets/socket.service.test.ts
@@ -52,7 +52,7 @@ describe('RealtimeService', () => {
       return '';
     });
 
-    vi.spyOn(localStorageService, 'get').mockReturnValue('mock-token-123');
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue('mock-token-123');
 
     mockSocket.id = 'mock-socket-id';
     mockSocket.connected = true;

--- a/src/services/sockets/socket.service.ts
+++ b/src/services/sockets/socket.service.ts
@@ -1,7 +1,6 @@
 import io, { Socket } from 'socket.io-client';
 import localStorageService from '../local-storage.service';
 import envService from '../env.service';
-import { LocalStorageItem } from 'app/core/types';
 
 import type { EventHandler } from './event-handler.service';
 
@@ -72,5 +71,5 @@ export default class RealtimeService {
 }
 
 function getToken(): string {
-  return localStorageService.get(LocalStorageItem.NewToken) as string;
+  return localStorageService.getToken() as string;
 }

--- a/src/services/user.service.test.ts
+++ b/src/services/user.service.test.ts
@@ -26,6 +26,7 @@ const authClientMock = {
 vi.mock('services/local-storage.service', () => ({
   default: {
     get: vi.fn(),
+    getToken: vi.fn(),
   },
 }));
 
@@ -49,7 +50,7 @@ describe('userService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
-    vi.spyOn(localStorageService, 'get').mockReturnValue(testToken);
+    vi.spyOn(localStorageService, 'getToken').mockReturnValue(testToken);
   });
 
   it('should pre-create user', async () => {

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -10,7 +10,6 @@ import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import localStorageService from 'services/local-storage.service';
 import { SdkFactory } from 'app/core/factory/sdk';
 import { generateCaptchaToken } from 'utils';
-import { LocalStorageItem } from 'app/core/types';
 
 const preCreateUser = (email: string): Promise<PreCreateUserResponse> => {
   const usersClient = SdkFactory.getNewApiInstance().createUsersClient();

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -37,7 +37,7 @@ const refreshAvatarUser = async (): Promise<{
 
 const updateUserProfile = (payload: Required<UpdateProfilePayload>): Promise<void> => {
   const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
-  const token = localStorageService.get(LocalStorageItem.NewToken) ?? undefined;
+  const token = localStorageService.getToken() ?? undefined;
   return usersClient.updateUserProfile(payload, token);
 };
 
@@ -48,14 +48,14 @@ const updateUserAvatar = (payload: { avatar: Blob }): Promise<{ avatar: string }
 
 const deleteUserAvatar = (): Promise<void> => {
   const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
-  const token = localStorageService.get(LocalStorageItem.NewToken) ?? undefined;
+  const token = localStorageService.getToken() ?? undefined;
   return usersClient.deleteUserAvatar(token);
 };
 
 const sendVerificationEmail = async (): Promise<void> => {
   const captchaToken = await generateCaptchaToken();
   const usersClient = SdkFactory.getNewApiInstance().createUsersClient(captchaToken);
-  const token = localStorageService.get(LocalStorageItem.NewToken) ?? undefined;
+  const token = localStorageService.getToken() ?? undefined;
   return usersClient.sendVerificationEmail(token);
 };
 

--- a/src/views/Checkout/services/checkout.service.ts
+++ b/src/views/Checkout/services/checkout.service.ts
@@ -15,7 +15,6 @@ import envService from 'services/env.service';
 import errorService from 'services/error.service';
 import { bytesToString } from 'app/drive/services/size.service';
 import userService from 'services/user.service';
-import { LocalStorageItem } from 'app/core/types';
 
 const BORDER_SHADOW = 'rgb(0 102 255)';
 
@@ -114,7 +113,7 @@ export const createPaymentIntent = async ({
 
 const checkoutSetupIntent = async (customerId: string) => {
   try {
-    const newToken = localStorageService.get(LocalStorageItem.NewToken);
+    const newToken = localStorageService.getToken();
 
     if (!newToken) {
       throw new Error('No authentication token available');

--- a/src/views/Home/components/PendingInvitationsDialog.tsx
+++ b/src/views/Home/components/PendingInvitationsDialog.tsx
@@ -10,7 +10,6 @@ import { workspaceThunks } from 'app/store/slices/workspaces/workspacesStore';
 import dayjs from 'dayjs';
 import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
 import { wait } from 'utils/timeUtils';
-import { LocalStorageItem } from 'app/core/types';
 
 const WORKSPACE_INVITATION_BAD_REQUEST = 400;
 
@@ -29,7 +28,7 @@ const PendingInvitationsDialog = ({
 }) => {
   const dispatch = useAppDispatch();
   const { translate } = useTranslationContext();
-  const token = localStorageService.get(LocalStorageItem.NewToken);
+  const token = localStorageService.getToken();
 
   function formatDate(dateString) {
     const date = dayjs(dateString);

--- a/src/views/Login/OAuthLinkView.tsx
+++ b/src/views/Login/OAuthLinkView.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@internxt/ui';
 import { authService, oauthService, navigationService, localStorageService } from 'services';
-import { AppView, LocalStorageItem } from 'app/core/types';
+import { AppView } from 'app/core/types';
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
 import InternxtLogo from 'assets/icons/big-logo.svg?react';
 import { isMobile } from 'react-device-detect';
@@ -31,7 +31,7 @@ const OAuthLinkView = (): JSX.Element => {
   };
 
   const handleContinueWithCurrentUser = () => {
-    const newToken = localStorageService.get(LocalStorageItem.NewToken);
+    const newToken = localStorageService.getToken();
     if (!newToken) {
       navigationService.history.replace(AppView.Login);
       return;

--- a/src/views/Login/UniversalLinkSuccessView.tsx
+++ b/src/views/Login/UniversalLinkSuccessView.tsx
@@ -28,7 +28,7 @@ export default function UniversalLinkView(): JSX.Element {
 
   const getUniversalLinkAuthUrl = (user: UserSettings) => {
     const token = localStorageService.get(LocalStorageItem.UserToken);
-    const newToken = localStorageService.get(LocalStorageItem.NewToken);
+    const newToken = localStorageService.getToken();
     if (!token) return AppView.Login;
     if (!newToken) return AppView.Login;
 

--- a/src/views/Login/components/LogIn.tsx
+++ b/src/views/Login/components/LogIn.tsx
@@ -149,7 +149,7 @@ export default function LogIn(): JSX.Element {
   };
 
   const handleSuccessfulAuth = (token: string, user: UserSettings, mnemonic: string): void => {
-    const newToken = localStorageService.get(LocalStorageItem.NewToken);
+    const newToken = localStorageService.getToken();
 
     if (isOAuthFlow && newToken) {
       const success = handleOAuthSuccess(user, newToken);

--- a/src/views/Login/hooks/useOAuthFlow.test.tsx
+++ b/src/views/Login/hooks/useOAuthFlow.test.tsx
@@ -1,7 +1,7 @@
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import { renderHook } from '@testing-library/react';
 import { localStorageService, navigationService } from 'services';
-import { AppView, LocalStorageItem } from 'app/core/types';
+import { AppView } from 'app/core/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import oauthService from 'services/oauth.service';
 import { useOAuthFlow } from './useOAuthFlow';
@@ -82,16 +82,13 @@ describe('OAuth custom hook', () => {
       const mockPush = vi.fn();
 
       vi.spyOn(localStorageService, 'getUser').mockReturnValue(mockUserSettings);
-      vi.spyOn(localStorageService, 'get').mockImplementation((key: string) => {
-        if (key === LocalStorageItem.NewToken) return mockNewToken;
-        return null;
-      });
+      vi.spyOn(localStorageService, 'getToken').mockReturnValue(mockNewToken);
       vi.mocked(navigationService.push).mockImplementation(mockPush);
 
       renderHook(() => useOAuthFlow({ authOrigin: 'https://meet.internxt.com' }));
 
       expect(localStorageService.getUser).toHaveBeenCalled();
-      expect(localStorageService.get).toHaveBeenCalledWith(LocalStorageItem.NewToken);
+      expect(localStorageService.getToken).toHaveBeenCalled();
       expect(mockPush).toHaveBeenCalledWith(AppView.OAuthLink, expect.any(Object));
       expect(mockSendAuthSuccess).not.toHaveBeenCalled();
     });
@@ -100,10 +97,7 @@ describe('OAuth custom hook', () => {
       const mockNewToken = 'test-new-token';
 
       vi.spyOn(localStorageService, 'getUser').mockReturnValue(mockUserSettings);
-      vi.spyOn(localStorageService, 'get').mockImplementation((key: string) => {
-        if (key === LocalStorageItem.NewToken) return mockNewToken;
-        return null;
-      });
+      vi.spyOn(localStorageService, 'getToken').mockReturnValue(mockNewToken);
 
       renderHook(() => useOAuthFlow({ authOrigin: null }));
 

--- a/src/views/Login/hooks/useOAuthFlow.ts
+++ b/src/views/Login/hooks/useOAuthFlow.ts
@@ -1,5 +1,5 @@
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
-import { AppView, LocalStorageItem } from 'app/core/types';
+import { AppView } from 'app/core/types';
 import { useEffect } from 'react';
 import { oauthService, localStorageService, navigationService } from 'services';
 
@@ -18,7 +18,7 @@ export const useOAuthFlow = ({ authOrigin }: UseOAuthFlowParams): UseOAuthFlowRe
   useEffect(() => {
     if (isOAuthFlow) {
       const user = localStorageService.getUser();
-      const newToken = localStorageService.get(LocalStorageItem.NewToken);
+      const newToken = localStorageService.getToken();
 
       if (user && newToken) {
         const params = new URLSearchParams(globalThis.location.search);

--- a/src/views/Signup/ShareGuestSignUpView.test.tsx
+++ b/src/views/Signup/ShareGuestSignUpView.test.tsx
@@ -30,6 +30,7 @@ describe('onSubmit', () => {
         clear: vi.fn(),
         getUser: vi.fn(),
         set: vi.fn(),
+        setToken: vi.fn(),
       },
     }));
 

--- a/src/views/Signup/WorkspaceGuestSignUpView.test.tsx
+++ b/src/views/Signup/WorkspaceGuestSignUpView.test.tsx
@@ -134,6 +134,7 @@ describe('onSubmit', () => {
         clear: vi.fn(),
         getUser: vi.fn(),
         set: vi.fn(),
+        setToken: vi.fn(),
       },
     }));
 

--- a/src/views/Signup/utils/guestSignupOnSubmit.test.ts
+++ b/src/views/Signup/utils/guestSignupOnSubmit.test.ts
@@ -95,7 +95,7 @@ describe('guestSignupOnSubmit', () => {
     expect(localStorageService.clear).toHaveBeenCalled();
     expect(localStorageService.set).toHaveBeenCalledWith(LocalStorageItem.UserToken, 'access-token');
     expect(localStorageService.set).toHaveBeenCalledWith(LocalStorageItem.UserMnemonic, 'test mnemonic');
-    expect(localStorageService.set).toHaveBeenCalledWith(LocalStorageItem.NewToken, 'refresh-token');
+    expect(localStorageService.setToken).toHaveBeenCalledWith('refresh-token');
     expect(parseAndDecryptUserKeys).toHaveBeenCalledWith(mockRegistrationResponse.xUser, 'password123');
     expect(mockDispatch).toHaveBeenCalledWith(userActions.setUser(expect.objectContaining({ uuid: 'user-uuid' })));
     expect(mockDispatch).toHaveBeenCalledWith(userThunks.initializeUserThunk());

--- a/src/views/Signup/utils/guestSignupOnSubmit.ts
+++ b/src/views/Signup/utils/guestSignupOnSubmit.ts
@@ -52,7 +52,7 @@ export const guestSignupOnSubmit = async ({
 
     localStorageService.set(LocalStorageItem.UserToken, xToken);
     localStorageService.set(LocalStorageItem.UserMnemonic, mnemonic);
-    localStorageService.set(LocalStorageItem.NewToken, xNewToken);
+    localStorageService.setToken(xNewToken);
 
     const { publicKey, privateKey, publicKyberKey, privateKyberKey } = parseAndDecryptUserKeys(xUser, password);
 


### PR DESCRIPTION
## Description

This PR changes all calls for setting/getting a new user token to use local storage functions. It's a preparation for a fix for [PB-6503](https://inxt.atlassian.net/browse/PB-6503)

## Related Issues

Relates to [PB-6503](https://inxt.atlassian.net/browse/PB-6503)

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

Unit tests, small QA to ensure login, sign up and downlod keep working


[PB-6503]: https://inxt.atlassian.net/browse/PB-6503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ