### PR TITLE
[PB-6505] Add encryption functions for local-storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "stylelint-config-standard": "^36.0.1",
     "stylelint-scss": "^6.8.1",
     "tailwindcss": "^3.4.19",
-    "typescript": "^4.4.2",
+    "typescript": "^6.0.0",
     "vite": "=6.4.3",
     "vite-plugin-bundle-obfuscator": "^1.7.0",
     "vite-plugin-node-polyfills": "=0.26.0",

--- a/src/app/core/types.ts
+++ b/src/app/core/types.ts
@@ -161,6 +161,14 @@ export enum LocalStorageItem {
   AnniversaryTheme = 'anniversary_theme_enabled',
 }
 
+export enum LocalStorageProtectedItem {
+  User = 'xUser',
+  NewToken = 'xNewToken',
+  B2Bworkspace = 'b2bWorkspace',
+  WorkspaceCredentials = 'workspace_credentials',
+  FolderAccessToken = 'folderAccessToken',
+  FileAccessToken = 'fileAccessToken',
+}
 export enum OrderDirection {
   Asc = 'ASC',
   Desc = 'DESC',

--- a/src/app/database/services/database.service/index.ts
+++ b/src/app/database/services/database.service/index.ts
@@ -52,6 +52,10 @@ export interface AppDatabase extends DBSchema {
     key: string;
     value: AvatarBlobData;
   };
+  crypto_keys: {
+    key: string;
+    value: CryptoKey;
+  };
 }
 
 export type DatabaseService = (

--- a/src/app/database/services/database.service/indexed-db.service.ts
+++ b/src/app/database/services/database.service/indexed-db.service.ts
@@ -21,6 +21,9 @@ const open = (name: string, version?: number): Promise<idb.IDBPDatabase<AppDatab
       if (oldVersion <= 5) {
         db.createObjectStore('workspaces_avatar_blobs');
       }
+      if (oldVersion <= 6) {
+        db.createObjectStore('crypto_keys');
+      }
     },
     blocked: () => undefined,
     blocking: () => undefined,

--- a/src/app/database/types.ts
+++ b/src/app/database/types.ts
@@ -10,6 +10,7 @@ export enum DatabaseCollection {
   Account_settings = 'account_settings',
   UploadItemStatus = 'upload_item_status',
   WorkspacesAvatarBlobs = 'workspaces_avatar_blobs',
+  CryptoKeys = 'crypto_keys',
 }
 
 export enum LRUCacheTypes {

--- a/src/services/local-storage-constants.ts
+++ b/src/services/local-storage-constants.ts
@@ -1,0 +1,7 @@
+export const DB_NAME = 'internxt-keystore';
+export const DB_VERSION = 1;
+export const STORE = 'keys';
+export const KEY_ID = 'mnemonicKey';
+export const KEY_LENGTH = 256;
+export const IV_LENGTH = 12;
+export const ALGORITHM = 'AES-GCM';

--- a/src/services/local-storage-constants.ts
+++ b/src/services/local-storage-constants.ts
@@ -1,6 +1,3 @@
-export const DB_NAME = 'internxt-keystore';
-export const DB_VERSION = 1;
-export const STORE = 'keys';
 export const KEY_ID = 'mnemonicKey';
 export const KEY_LENGTH = 256;
 export const IV_LENGTH = 12;

--- a/src/services/local-storage-crypto.test.ts
+++ b/src/services/local-storage-crypto.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createNewKey, encryptEntry, decryptEntry, deleteDb } from './local-storage-crypto';
+import {
+  FailedToDecryptEntry,
+  KeyAlreadyExistsError,
+  FailedToFindKey,
+  FailedToCreateKey,
+  FailedToEncryptEntry,
+} from './local-storage-errors';
+import { KEY_LENGTH, ALGORITHM, IV_LENGTH } from './local-storage-constants';
+
+beforeEach(async () => {
+  await deleteDb();
+  vi.clearAllMocks();
+  vi.resetAllMocks();
+});
+
+describe('createNewKey', () => {
+  it('creates a non-extractable AES-GCM 256 key', async () => {
+    const key = await createNewKey();
+
+    expect(key.type).toBe('secret');
+    expect(key.extractable).toBe(false);
+    expect(key.algorithm.name).toBe(ALGORITHM);
+    expect((key.algorithm as AesKeyAlgorithm).length).toBe(KEY_LENGTH);
+    expect(key.usages).toEqual(expect.arrayContaining(['encrypt', 'decrypt']));
+  });
+
+  it('throws KeyAlreadyExistsError on a second call without clearing storage first', async () => {
+    await createNewKey();
+
+    await expect(createNewKey()).rejects.toThrow(KeyAlreadyExistsError);
+  });
+
+  it('allows creating a new key after deleteDb clears storage', async () => {
+    await createNewKey();
+    await deleteDb();
+
+    await expect(createNewKey()).resolves.toBeInstanceOf(CryptoKey);
+  });
+
+  it('does not overwrite the existing key on a rejected second call', async () => {
+    await createNewKey();
+    const text = 'test value';
+    const ciphertext = await encryptEntry(text);
+    await expect(createNewKey()).rejects.toThrow(KeyAlreadyExistsError);
+    const decrypted = await decryptEntry(ciphertext);
+    expect(decrypted).toBe(text);
+  });
+
+  it('throws FailedToFindKey if key generation fails', async () => {
+    vi.spyOn(window.crypto.subtle, 'generateKey').mockImplementationOnce(() => {
+      throw new Error('Simulated key generation failure');
+    });
+    await expect(createNewKey()).rejects.toThrow(FailedToCreateKey);
+  });
+});
+
+describe('encryptEntry', () => {
+  const mockMnemonic = 'test mnemonic';
+  it('throws FailedToFindKey when no key exists yet', async () => {
+    await expect(encryptEntry(mockMnemonic)).rejects.toThrow(FailedToFindKey);
+  });
+
+  it('throws FailedToEncryptEntry if encryption fails', async () => {
+    await createNewKey();
+    vi.spyOn(window.crypto.subtle, 'encrypt').mockImplementationOnce(() => {
+      throw new Error('Simulated encryption failure');
+    });
+    await expect(encryptEntry(mockMnemonic)).rejects.toThrow(FailedToEncryptEntry);
+  });
+
+  it('returns a base64 string containing IV + ciphertext when a key exists', async () => {
+    await createNewKey();
+
+    const result = await encryptEntry(mockMnemonic);
+
+    expect(typeof result).toBe('string');
+    const decodedLength = Uint8Array.fromBase64(result).length;
+    expect(decodedLength).toBeGreaterThan(IV_LENGTH);
+  });
+
+  it('produces different ciphertext for the same plaintext on each call', async () => {
+    await createNewKey();
+
+    const first = await encryptEntry(mockMnemonic);
+    const second = await encryptEntry(mockMnemonic);
+
+    expect(first).not.toBe(second);
+  });
+});
+
+describe('decryptEntry', () => {
+  const mockMnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+  it('throws FailedToFindKey when no key exists yet', async () => {
+    await expect(decryptEntry('irrelevant-base64==')).rejects.toThrow(FailedToFindKey);
+  });
+
+  it('decryption works', async () => {
+    await createNewKey();
+
+    const ciphertext = await encryptEntry(mockMnemonic);
+    const decrypted = await decryptEntry(ciphertext);
+
+    expect(decrypted).toBe(mockMnemonic);
+  });
+  it('handles unicode string correctly', async () => {
+    await createNewKey();
+    const stringWithUnicode = '🔐 ñññññññ café';
+
+    const ciphertext = await encryptEntry(stringWithUnicode);
+    const decrypted = await decryptEntry(ciphertext);
+
+    expect(decrypted).toBe(stringWithUnicode);
+  });
+
+  it('throws FailedToDecryptEntry when ciphertext has been tampered with', async () => {
+    await createNewKey();
+    const ciphertext = await encryptEntry(mockMnemonic);
+
+    const bytes = Uint8Array.fromBase64(ciphertext);
+    bytes[bytes.length - 1] ^= 0xff;
+    const tampered = bytes.toBase64();
+
+    await expect(decryptEntry(tampered)).rejects.toThrow(FailedToDecryptEntry);
+  });
+
+  it('throws FailedToDecryptEntry on malformed input', async () => {
+    await createNewKey();
+
+    await expect(decryptEntry('not-valid-base64-!!!')).rejects.toThrow(FailedToDecryptEntry);
+  });
+
+  it('throws FailedToDecryptEntry when decrypting with the wrong key', async () => {
+    await createNewKey();
+    const ciphertext = await encryptEntry(mockMnemonic);
+
+    await deleteDb();
+    await createNewKey();
+
+    await expect(decryptEntry(ciphertext)).rejects.toThrow(FailedToDecryptEntry);
+  });
+});

--- a/src/services/local-storage-crypto.test.ts
+++ b/src/services/local-storage-crypto.test.ts
@@ -22,7 +22,7 @@ describe('createNewKey', () => {
     expect(key.type).toBe('secret');
     expect(key.extractable).toBe(false);
     expect(key.algorithm.name).toBe(ALGORITHM);
-    expect((key.algorithm as AesKeyAlgorithm).length).toBe(KEY_LENGTH);
+    expect(key.algorithm as AesKeyAlgorithm).toHaveLength(KEY_LENGTH);
     expect(key.usages).toEqual(expect.arrayContaining(['encrypt', 'decrypt']));
   });
 

--- a/src/services/local-storage-crypto.test.ts
+++ b/src/services/local-storage-crypto.test.ts
@@ -48,7 +48,7 @@ describe('createNewKey', () => {
     expect(decrypted).toBe(text);
   });
 
-  it('throws FailedToFindKey if key generation fails', async () => {
+  it('throws FailedToCreateKey if key generation fails', async () => {
     vi.spyOn(window.crypto.subtle, 'generateKey').mockImplementationOnce(() => {
       throw new Error('Simulated key generation failure');
     });

--- a/src/services/local-storage-crypto.ts
+++ b/src/services/local-storage-crypto.ts
@@ -5,48 +5,19 @@ import {
   FailedToFindKey,
   KeyAlreadyExistsError,
 } from './local-storage-errors';
-import { DB_NAME, DB_VERSION, STORE, KEY_ID, KEY_LENGTH, IV_LENGTH, ALGORITHM } from './local-storage-constants';
-
-function openDb(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
-    req.onupgradeneeded = () => {
-      const db = req.result;
-
-      if (!db.objectStoreNames.contains(STORE)) {
-        db.createObjectStore(STORE);
-      }
-    };
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error ?? new Error('Request to open database failed'));
-  });
-}
+import { KEY_ID, KEY_LENGTH, IV_LENGTH, ALGORITHM } from './local-storage-constants';
+import databaseService, { DatabaseCollection } from 'app/database/services/database.service';
 
 async function getKey(): Promise<CryptoKey | undefined> {
-  const db = await openDb();
   try {
-    const existing = await new Promise<CryptoKey | undefined>((resolve, reject) => {
-      const tx = db.transaction(STORE, 'readonly');
-      const r = tx.objectStore(STORE).get(KEY_ID);
-      r.onsuccess = () => resolve(r.result);
-      r.onerror = () => reject(r.error ?? new Error('Request to get key failed'));
-    });
-
-    return existing;
+    return await databaseService.get(DatabaseCollection.CryptoKeys, KEY_ID);
   } catch (error) {
     throw new FailedToFindKey(error instanceof Error ? error.message : String(error));
-  } finally {
-    db.close();
   }
 }
 
 export function deleteDb(): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.deleteDatabase(DB_NAME);
-    req.onsuccess = () => resolve();
-    req.onerror = () => reject(req.error ?? new Error('Request to delete database failed'));
-    req.onblocked = () => reject(new Error('deleteDatabase blocked by an open connection'));
-  });
+  return databaseService.delete(DatabaseCollection.CryptoKeys, KEY_ID) as unknown as Promise<void>;
 }
 
 export async function createNewKey(): Promise<CryptoKey> {
@@ -54,23 +25,12 @@ export async function createNewKey(): Promise<CryptoKey> {
   if (existing) {
     throw new KeyAlreadyExistsError('A key already exists; clear storage before creating a new one');
   }
-
-  const db = await openDb();
   try {
     const key = await crypto.subtle.generateKey({ name: ALGORITHM, length: KEY_LENGTH }, false, ['encrypt', 'decrypt']);
-
-    await new Promise<void>((resolve, reject) => {
-      const tx = db.transaction(STORE, 'readwrite');
-      tx.objectStore(STORE).add(key, KEY_ID);
-      tx.oncomplete = () => resolve();
-      tx.onerror = () => reject(tx.error ?? new Error('Request to store key failed'));
-    });
-
+    await databaseService.put(DatabaseCollection.CryptoKeys, KEY_ID, key);
     return key;
   } catch (error) {
     throw new FailedToCreateKey(error instanceof Error ? error.message : String(error));
-  } finally {
-    db.close();
   }
 }
 

--- a/src/services/local-storage-crypto.ts
+++ b/src/services/local-storage-crypto.ts
@@ -1,0 +1,112 @@
+import {
+  FailedToEncryptEntry,
+  FailedToDecryptEntry,
+  FailedToCreateKey,
+  FailedToFindKey,
+  KeyAlreadyExistsError,
+} from './local-storage-errors';
+import { DB_NAME, DB_VERSION, STORE, KEY_ID, KEY_LENGTH, IV_LENGTH, ALGORITHM } from './local-storage-constants';
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.createObjectStore(STORE);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function getKey(): Promise<CryptoKey | undefined> {
+  const db = await openDb();
+  try {
+    const existing = await new Promise<CryptoKey | undefined>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readonly');
+      const r = tx.objectStore(STORE).get(KEY_ID);
+      r.onsuccess = () => resolve(r.result);
+      r.onerror = () => reject(r.error);
+    });
+
+    return existing;
+  } catch (error) {
+    throw new FailedToFindKey(error instanceof Error ? error.message : String(error));
+  } finally {
+    db.close();
+  }
+}
+
+export function deleteDb(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(DB_NAME);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+    req.onblocked = () => reject(new Error('deleteDatabase blocked by an open connection'));
+  });
+}
+
+export async function createNewKey(): Promise<CryptoKey> {
+  const existing = await getKey();
+  if (existing) {
+    throw new KeyAlreadyExistsError('A key already exists; clear storage before creating a new one');
+  }
+
+  const db = await openDb();
+  try {
+    const key = await crypto.subtle.generateKey({ name: ALGORITHM, length: KEY_LENGTH }, false, ['encrypt', 'decrypt']);
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readwrite');
+      tx.objectStore(STORE).add(key, KEY_ID);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+
+    return key;
+  } catch (error) {
+    throw new FailedToCreateKey(error instanceof Error ? error.message : String(error));
+  } finally {
+    db.close();
+  }
+}
+
+export async function encryptEntry(plaintext: string): Promise<string> {
+  const key = await getKey();
+  if (!key) {
+    throw new FailedToFindKey('No encryption key found');
+  }
+  try {
+    const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+    const encoded = new TextEncoder().encode(plaintext);
+    const buf = new Uint8Array(await crypto.subtle.encrypt({ name: ALGORITHM, iv }, key, encoded));
+
+    const result = new Uint8Array(iv.length + buf.length);
+    result.set(iv, 0);
+    result.set(buf, iv.length);
+    return result.toBase64();
+  } catch (error) {
+    throw new FailedToEncryptEntry(error instanceof Error ? error.message : String(error));
+  }
+}
+
+export async function decryptEntry(ciphertextBase64: string): Promise<string> {
+  const key = await getKey();
+  if (!key) {
+    throw new FailedToFindKey('No encryption key found');
+  }
+
+  try {
+    const input = Uint8Array.fromBase64(ciphertextBase64);
+
+    const iv = input.slice(0, IV_LENGTH);
+    const data = input.slice(IV_LENGTH);
+    const buf = await crypto.subtle.decrypt({ name: ALGORITHM, iv }, key, data);
+    return new TextDecoder().decode(buf);
+  } catch (error) {
+    throw new FailedToDecryptEntry(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/src/services/local-storage-crypto.ts
+++ b/src/services/local-storage-crypto.ts
@@ -18,7 +18,7 @@ function openDb(): Promise<IDBDatabase> {
       }
     };
     req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error);
+    req.onerror = () => reject(req.error ?? new Error('Request to open database failed'));
   });
 }
 
@@ -29,7 +29,7 @@ async function getKey(): Promise<CryptoKey | undefined> {
       const tx = db.transaction(STORE, 'readonly');
       const r = tx.objectStore(STORE).get(KEY_ID);
       r.onsuccess = () => resolve(r.result);
-      r.onerror = () => reject(r.error);
+      r.onerror = () => reject(r.error ?? new Error('Request to get key failed'));
     });
 
     return existing;
@@ -44,7 +44,7 @@ export function deleteDb(): Promise<void> {
   return new Promise((resolve, reject) => {
     const req = indexedDB.deleteDatabase(DB_NAME);
     req.onsuccess = () => resolve();
-    req.onerror = () => reject(req.error);
+    req.onerror = () => reject(req.error ?? new Error('Request to delete database failed'));
     req.onblocked = () => reject(new Error('deleteDatabase blocked by an open connection'));
   });
 }
@@ -63,7 +63,7 @@ export async function createNewKey(): Promise<CryptoKey> {
       const tx = db.transaction(STORE, 'readwrite');
       tx.objectStore(STORE).add(key, KEY_ID);
       tx.oncomplete = () => resolve();
-      tx.onerror = () => reject(tx.error);
+      tx.onerror = () => reject(tx.error ?? new Error('Request to store key failed'));
     });
 
     return key;

--- a/src/services/local-storage-crypto.ts
+++ b/src/services/local-storage-crypto.ts
@@ -9,15 +9,11 @@ import { KEY_ID, KEY_LENGTH, IV_LENGTH, ALGORITHM } from './local-storage-consta
 import databaseService, { DatabaseCollection } from 'app/database/services/database.service';
 
 async function getKey(): Promise<CryptoKey | undefined> {
-  try {
-    return await databaseService.get(DatabaseCollection.CryptoKeys, KEY_ID);
-  } catch (error) {
-    throw new FailedToFindKey(error instanceof Error ? error.message : String(error));
-  }
+  return databaseService.get(DatabaseCollection.CryptoKeys, KEY_ID);
 }
 
 export function deleteDb(): Promise<void> {
-  return databaseService.delete(DatabaseCollection.CryptoKeys, KEY_ID) as unknown as Promise<void>;
+  return databaseService.delete(DatabaseCollection.CryptoKeys, KEY_ID);
 }
 
 export async function createNewKey(): Promise<CryptoKey> {

--- a/src/services/local-storage-errors.ts
+++ b/src/services/local-storage-errors.ts
@@ -1,0 +1,39 @@
+export class FailedToEncryptEntry extends Error {
+  constructor(errorMsg?: string) {
+    super('Failed to encrypt local storage entry: ' + errorMsg);
+
+    Object.setPrototypeOf(this, FailedToEncryptEntry.prototype);
+  }
+}
+
+export class FailedToDecryptEntry extends Error {
+  constructor(errorMsg?: string) {
+    super('Failed to decrypt local storage entry: ' + errorMsg);
+
+    Object.setPrototypeOf(this, FailedToDecryptEntry.prototype);
+  }
+}
+
+export class FailedToCreateKey extends Error {
+  constructor(errorMsg?: string) {
+    super('Failed to create encryption key: ' + errorMsg);
+
+    Object.setPrototypeOf(this, FailedToCreateKey.prototype);
+  }
+}
+
+export class FailedToFindKey extends Error {
+  constructor(errorMsg?: string) {
+    super('Failed to find encryption key: ' + errorMsg);
+
+    Object.setPrototypeOf(this, FailedToFindKey.prototype);
+  }
+}
+
+export class KeyAlreadyExistsError extends Error {
+  constructor(errorMsg?: string) {
+    super('Key already exists: ' + errorMsg);
+
+    Object.setPrototypeOf(this, KeyAlreadyExistsError.prototype);
+  }
+}

--- a/src/services/local-storage.service.test.ts
+++ b/src/services/local-storage.service.test.ts
@@ -1,8 +1,9 @@
-import { afterAll, beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, test, vi, afterEach } from 'vitest';
 import localStorageService from './local-storage.service';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
-import { LocalStorageItem } from 'app/core/types';
+import { LocalStorageItem, LocalStorageProtectedItem } from 'app/core/types';
 import { WorkspaceCredentialsDetails, WorkspaceData } from '@internxt/sdk/dist/workspaces';
+import { createNewKey, deleteDb } from './local-storage-crypto';
 
 export const mockUserSettings: UserSettings = {
   userId: 'user_123',
@@ -134,6 +135,10 @@ afterAll(() => {
   localStorage.clear();
 });
 
+afterEach(async () => {
+  await deleteDb();
+});
+
 describe('Testing the local storage service', () => {
   describe('Get a value from local storage', () => {
     it('When the requested key exists, then the value is returned', () => {
@@ -186,6 +191,42 @@ describe('Testing the local storage service', () => {
       expect(removeFromLocalStorageSpy).toHaveBeenCalled();
       expect(removeFromLocalStorageSpy).toHaveBeenCalledWith(removeLocalStorageKey);
       expect(nonExistentItem).toBeNull();
+    });
+  });
+
+  describe('Get and set encrypted values', () => {
+    it('When sets protected value, then the value is stored encrypted', async () => {
+      await createNewKey();
+      const getFromLocalStorageSpy = vi.spyOn(Storage.prototype, 'getItem');
+      const cryptoSpy = vi.spyOn(window.crypto.subtle, 'encrypt');
+
+      const key = LocalStorageProtectedItem.NewToken;
+      const value = 'test-value';
+      await localStorageService.setAndEncrypt(key, value);
+
+      const localStorageItem = localStorage.getItem(key);
+
+      expect(getFromLocalStorageSpy).toHaveBeenCalled();
+      expect(cryptoSpy).toHaveBeenCalled();
+      expect(getFromLocalStorageSpy).toHaveBeenCalledWith(key);
+      expect(localStorageItem).not.toEqual(value);
+    });
+
+    it('When gets a protected value, then the result is decrypted', async () => {
+      await createNewKey();
+      const getFromLocalStorageSpy = vi.spyOn(Storage.prototype, 'getItem');
+      const cryptoSpy = vi.spyOn(window.crypto.subtle, 'decrypt');
+
+      const key = LocalStorageProtectedItem.NewToken;
+      const value = 'test-value';
+      await localStorageService.setAndEncrypt(key, value);
+
+      const localStorageItem = await localStorageService.getAndDecrypt(key);
+
+      expect(getFromLocalStorageSpy).toHaveBeenCalled();
+      expect(cryptoSpy).toHaveBeenCalled();
+      expect(getFromLocalStorageSpy).toHaveBeenCalledWith(key);
+      expect(localStorageItem).toBe(value);
     });
   });
 

--- a/src/services/local-storage.service.ts
+++ b/src/services/local-storage.service.ts
@@ -1,7 +1,8 @@
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import { WorkspaceCredentialsDetails, WorkspaceData } from '@internxt/sdk/dist/workspaces';
-import { LocalStorageItem } from 'app/core/types';
+import { LocalStorageItem, LocalStorageProtectedItem } from 'app/core/types';
 import { BACKUP_KEY } from './storage-keys';
+import { decryptEntry, encryptEntry } from './local-storage-crypto';
 
 function get(key: LocalStorageItem): string | null {
   return localStorage.getItem(key);
@@ -9,6 +10,19 @@ function get(key: LocalStorageItem): string | null {
 
 function set(key: LocalStorageItem, value: string): void {
   return localStorage.setItem(key, value);
+}
+
+async function getAndDecrypt(key: LocalStorageProtectedItem): Promise<string | null> {
+  const item = localStorage.getItem(key);
+  if (item) {
+    return await decryptEntry(item);
+  }
+  return null;
+}
+
+async function setAndEncrypt(key: LocalStorageProtectedItem, value: string): Promise<void> {
+  const encryptedValue = await encryptEntry(value);
+  return localStorage.setItem(key, encryptedValue);
 }
 
 function getBackupKeyStorageKeys() {
@@ -97,6 +111,8 @@ function clear(): void {
 const localStorageService = {
   set,
   get,
+  setAndEncrypt,
+  getAndDecrypt,
   setBackupKeysAcknowledged,
   setBackupKeysSeenAt,
   setToken,
@@ -116,6 +132,8 @@ export default localStorageService;
 export interface LocalStorageService {
   set: (key: LocalStorageItem, value: string) => void;
   get: (key: LocalStorageItem) => string | null;
+  getAndDecrypt: (key: LocalStorageProtectedItem) => Promise<string | null>;
+  setAndEncrypt: (key: LocalStorageProtectedItem, value: string) => Promise<void>;
   setBackupKeysAcknowledged: () => void;
   setBackupKeysSeenAt: (date: string) => void;
   setToken: (token: string) => void;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "target": "es5",
+    "paths": {
+      "*": ["./src/*"]
+    },
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -11,13 +13,12 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
     "noImplicitAny": false,
-    "downlevelIteration": true,
     "incremental": true,
     "types": ["vite/client", "vite-plugin-svgr/client", "wicg-file-system-access"]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9529,10 +9529,10 @@ typed-array-buffer@^1.0.3:
     es-errors "^1.3.0"
     is-typed-array "^1.1.14"
 
-typescript@^4.4.2:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^6.0.0:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 ua-parser-js@^1.0.33:
   version "1.0.41"


### PR DESCRIPTION
## Description

This PR adds encryption/decryption methods with CryptoKey stored in IndexedDB. So far, the methods are not called.

## Related Issues

Relates to [PB-6505](https://inxt.atlassian.net/browse/PB-6505)

## Related Pull Requests


[Minimize workspace data](https://github.com/internxt/drive-web/pull/2020)

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

unit tests

## Additional Notes

Uint8Array.toBase64() and Uint8Array.fromBase64() required an update of typescript to a more modern version, which in turn required changes in config (update deprecated fields)


[PB-6505]: https://inxt.atlassian.net/browse/PB-6505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ