### PR TITLE
[PB-6505] clear all local storage

### DIFF
--- a/src/services/local-storage.service.test.ts
+++ b/src/services/local-storage.service.test.ts
@@ -316,35 +316,23 @@ describe('Testing the local storage service', () => {
         expect(localStorage.getItem(seenAtKey)).toBeNull();
       });
     });
-
-    describe('clear', () => {
-      test('When the user logs out, then the last seen date is removed but the acknowledged flag is kept', () => {
-        const date = new Date().toISOString();
-        localStorage.setItem(seenAtKey, date);
-        localStorage.setItem(acknowledgedKey, 'true');
-
-        localStorageService.clear();
-
-        expect(localStorage.getItem(seenAtKey)).toBeNull();
-        expect(localStorage.getItem(acknowledgedKey)).toBe('true');
-      });
-    });
   });
 
   describe('Clearing local storage', () => {
     it('When clear storage is requested, then removes all keys', () => {
-      const expectedKeysToRemove = Object.values(LocalStorageItem);
-
-      const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
-      const removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem');
+      const clearSpy = vi.spyOn(Storage.prototype, 'clear');
+      localStorageService.setBackupKeysAcknowledged();
+      localStorageService.setBackupKeysSeenAt(new Date().toISOString());
 
       localStorageService.clear();
 
-      expect(setItemSpy).toHaveBeenCalledWith(LocalStorageItem.Theme, 'system');
+      expect(clearSpy).toHaveBeenCalledTimes(1);
 
-      for (const key of expectedKeysToRemove) {
-        expect(removeItemSpy).toHaveBeenCalledWith(key);
-      }
+      const userId = mockUserSettings.uuid;
+      const seenAtKey = `backup_key_seen_at_${userId}`;
+      const acknowledgedKey = `backup_key_acknowledged_at_${userId}`;
+      expect(localStorage.getItem(seenAtKey)).toBeNull();
+      expect(localStorage.getItem(acknowledgedKey)).toBeNull();
     });
   });
 });

--- a/src/services/local-storage.service.ts
+++ b/src/services/local-storage.service.ts
@@ -89,9 +89,7 @@ function removeItem(key: LocalStorageItem): void {
 }
 
 function clear(): void {
-  set(LocalStorageItem.Theme, 'system');
-  localStorage.removeItem(getBackupKeyStorageKeys().seenAt);
-  Object.values(LocalStorageItem).forEach((key) => localStorage.removeItem(key));
+  localStorage.clear();
 }
 
 const localStorageService = {


### PR DESCRIPTION
## Description

This PR changes the 'clear ' function, so it clears all local storage instead of only removing the known keys. Noticed that oldToken and mnemonic, and others, are still present even after logout:
<img width="1438" height="703" alt="Screenshot 2026-07-07 at 12 16 15" src="https://github.com/user-attachments/assets/1a29de44-678a-4157-b16b-6a83525f09b5" />


## Related Issues
Relates to [PB-6505](https://inxt.atlassian.net/browse/PB-6505)

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

Log out and check that all values from local storage have been removed.

## Additional Notes

**NOTE:** The old implementation kept the backup acknowledged key even after the cleanup to avoid showing banners. The task for a new way to handle this is https://inxt.atlassian.net/browse/PB-6595 

Theam defaults to 'system' in the only 2 gets we use, so no need to set it:
 https://github.com/internxt/drive-web/blob/44214d7ad4c5c1bdcb2f970faa4ea6976d6e60a9/index.html#L51
 https://github.com/internxt/drive-web/blob/44214d7ad4c5c1bdcb2f970faa4ea6976d6e60a9/src/app/theme/ThemeProvider.tsx#L82

[PB-6505]: https://inxt.atlassian.net/browse/PB-6505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ