### PR TITLE
[PB-6505] make getToken async

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { DndProvider } from 'react-dnd';
 import { Toaster } from 'react-hot-toast';
 import { connect } from 'react-redux';
@@ -72,7 +72,7 @@ const App = (props: AppProps): JSX.Element => {
   const { isDialogOpen } = useActionDialog();
   const isOpen = isDialogOpen(ActionDialog.ModifyStorage);
   const { openBackupKeysDialog } = useDownloadBackupKeys(t);
-  const newToken = localStorageService.getToken();
+  const [newToken, setToken] = useState<string | null>(null);
   const params = new URLSearchParams(window.location.search);
   const isVpnAuth = params.get('vpnAuth') === 'true';
   const skipSignupIfLoggedIn = params.get('skipSignupIfLoggedIn') === 'true';
@@ -86,14 +86,22 @@ const App = (props: AppProps): JSX.Element => {
   const selectedWorkspace = useAppSelector(workspacesSelectors.getSelectedWorkspace);
   const isWorkspaceIdParam = params.get('workspaceid');
 
-  useVpnAuth(isVpnAuth, newToken);
-
   useBeforeUnload();
 
   useEffect(() => {
     initializeInitialAppState();
     i18next.changeLanguage();
   }, []);
+
+  useEffect(() => {
+    const loadToken = async () => {
+      const newToken = (await localStorageService.getToken()) ?? '';
+      setToken(newToken);
+    };
+    void loadToken();
+  }, []);
+
+  useVpnAuth(isVpnAuth, newToken);
 
   useEffect(() => {
     if (isAuthenticated) {

--- a/src/app/core/factory/sdk/index.test.ts
+++ b/src/app/core/factory/sdk/index.test.ts
@@ -107,47 +107,47 @@ describe('SdkFactory', () => {
       );
     });
 
-    it('When SDK clients are created without calling initialize, then enableGlobalRetry is not called again', () => {
+    it('When SDK clients are created without calling initialize, then enableGlobalRetry is not called again', async () => {
       vi.mocked(HttpClient.enableGlobalRetry).mockClear();
       vi.spyOn(mockLocalStorage, 'get').mockImplementation((key: string) => {
         if (key === 'xNewToken') return 'test-token';
         return null;
       });
 
-      const instance = SdkFactory.getNewApiInstance();
-      instance.createNewStorageClient();
-      instance.createShareClient();
+      const instance = await SdkFactory.getNewApiInstance();
+      await instance.createNewStorageClient();
+      await instance.createShareClient();
 
       expect(HttpClient.enableGlobalRetry).not.toHaveBeenCalled();
     });
   });
 
   describe('getNewApiSecurity', () => {
-    it('should return ApiSecurity with token and default unauthorized callback', () => {
+    it('should return ApiSecurity with token and default unauthorized callback', async () => {
       const mockToken = 'test-token';
-      vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
+      vi.spyOn(mockLocalStorage, 'getToken').mockResolvedValue(mockToken);
 
-      const instance = SdkFactory.getNewApiInstance();
-      const apiSecurity = (instance as any).getNewApiSecurity();
+      const instance = await SdkFactory.getNewApiInstance();
+      const apiSecurity = await (instance as any).getNewApiSecurity();
 
       expect(apiSecurity.token).toBe(mockToken);
       expect(apiSecurity.workspaceToken).toBeUndefined();
       expect(apiSecurity.unauthorizedCallback).toBeDefined();
     });
 
-    it('should use custom unauthorized callback when provided', () => {
+    it('should use custom unauthorized callback when provided', async () => {
       const mockToken = 'test-token';
       const customCallback = vi.fn();
 
-      vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
+      vi.spyOn(mockLocalStorage, 'getToken').mockResolvedValue(mockToken);
 
-      const instance = SdkFactory.getNewApiInstance();
-      const apiSecurity = (instance as any).getNewApiSecurity(customCallback);
+      const instance = await SdkFactory.getNewApiInstance();
+      const apiSecurity = await (instance as any).getNewApiSecurity(customCallback);
 
       expect(apiSecurity.unauthorizedCallback).toBe(customCallback);
     });
 
-    it('should include workspace token when workspace credentials exist', () => {
+    it('should include workspace token when workspace credentials exist', async () => {
       const mockToken = 'test-token';
       const mockWorkspaceToken = 'workspace-token';
       const mockWorkspaceId = 'workspace-123';
@@ -155,15 +155,15 @@ describe('SdkFactory', () => {
         tokenHeader: mockWorkspaceToken,
       };
 
-      vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
+      vi.spyOn(mockLocalStorage, 'getToken').mockResolvedValue(mockToken);
       vi.spyOn(mockLocalStorage, 'get').mockImplementation((key) => {
         if (key === LocalStorageItem.B2Bworkspace) return mockWorkspaceId;
         if (key === LocalStorageItem.WorkspaceCredentials) return JSON.stringify(mockCredentials);
         return null;
       });
 
-      const instance = SdkFactory.getNewApiInstance();
-      const apiSecurity = (instance as any).getNewApiSecurity();
+      const instance = await SdkFactory.getNewApiInstance();
+      const apiSecurity = await (instance as any).getNewApiSecurity();
 
       expect(apiSecurity.token).toBe(mockToken);
       expect(apiSecurity.workspaceToken).toBe(mockWorkspaceToken);
@@ -172,62 +172,62 @@ describe('SdkFactory', () => {
     it('should call default unauthorized callback and dispatch logout', async () => {
       const mockToken = 'test-token';
 
-      vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
+      vi.spyOn(mockLocalStorage, 'getToken').mockResolvedValue(mockToken);
 
-      const instance = SdkFactory.getNewApiInstance();
-      const apiSecurity = (instance as any).getNewApiSecurity();
+      const instance = await SdkFactory.getNewApiInstance();
+      const apiSecurity = await (instance as any).getNewApiSecurity();
 
       await apiSecurity.unauthorizedCallback();
 
       expect(mockDispatch).toHaveBeenCalledWith(userThunks.logoutThunk());
     });
 
-    it('should return token for Business workspace', () => {
+    it('should return token for Business workspace', async () => {
       const mockToken = 'team-token';
 
-      vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
+      vi.spyOn(mockLocalStorage, 'getToken').mockResolvedValue(mockToken);
 
-      const instance = SdkFactory.getNewApiInstance();
-      const apiSecurity = (instance as any).getNewApiSecurity();
+      const instance = await SdkFactory.getNewApiInstance();
+      const apiSecurity = await (instance as any).getNewApiSecurity();
 
       expect(apiSecurity.token).toBe(mockToken);
     });
 
-    it('should return empty string when no token exists', () => {
-      vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(null);
+    it('should return empty string when no token exists', async () => {
+      vi.spyOn(mockLocalStorage, 'getToken').mockResolvedValue(undefined);
 
-      const instance = SdkFactory.getNewApiInstance();
-      const apiSecurity = (instance as any).getNewApiSecurity();
+      const instance = await SdkFactory.getNewApiInstance();
+      const apiSecurity = await (instance as any).getNewApiSecurity();
 
       expect(apiSecurity.token).toBe('');
     });
 
-    it('should handle workspace token when workspace credentials is null', () => {
+    it('should handle workspace token when workspace credentials is null', async () => {
       const mockToken = 'test-token';
       const mockWorkspaceId = 'workspace-123';
 
-      vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
+      vi.spyOn(mockLocalStorage, 'getToken').mockResolvedValue(mockToken);
       vi.spyOn(mockLocalStorage, 'get').mockImplementation((key: string) => {
         if (key === LocalStorageItem.B2Bworkspace) return mockWorkspaceId;
         if (key === LocalStorageItem.WorkspaceCredentials) return null;
         return null;
       });
 
-      const instance = SdkFactory.getNewApiInstance();
-      const apiSecurity = (instance as any).getNewApiSecurity();
+      const instance = await SdkFactory.getNewApiInstance();
+      const apiSecurity = await (instance as any).getNewApiSecurity();
 
       expect(apiSecurity.token).toBe(mockToken);
       expect(apiSecurity.workspaceToken).toBeUndefined();
     });
 
     describe('Creating the user client', () => {
-      test('When the user creates the client without captcha, then the app details are the defined by default', () => {
+      test('When the user creates the client without captcha, then the app details are the defined by default', async () => {
         const mockToken = 'test-token';
 
-        vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
+        vi.spyOn(mockLocalStorage, 'getToken').mockResolvedValue(mockToken);
 
-        const instance = SdkFactory.getNewApiInstance();
-        instance.createUsersClient();
+        const instance = await SdkFactory.getNewApiInstance();
+        await instance.createUsersClient();
 
         expect(Users.client).toHaveBeenCalledWith(
           MOCKED_NEW_API,
@@ -239,14 +239,14 @@ describe('SdkFactory', () => {
         );
       });
 
-      test('When the user creates the client with captcha, then the app details include the captcha header', () => {
+      test('When the user creates the client with captcha, then the app details include the captcha header', async () => {
         const mockToken = 'test-token';
         const captchaToken = 'captcha-token-123';
 
-        vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
+        vi.spyOn(mockLocalStorage, 'getToken').mockResolvedValue(mockToken);
 
-        const instance = SdkFactory.getNewApiInstance();
-        instance.createUsersClient(captchaToken);
+        const instance = await SdkFactory.getNewApiInstance();
+        await instance.createUsersClient(captchaToken);
 
         expect(Users.client).toHaveBeenCalledWith(
           MOCKED_NEW_API,
@@ -263,13 +263,13 @@ describe('SdkFactory', () => {
     });
 
     describe('Creating the share client', () => {
-      test('When the Share creates the client without captcha, then the app details are the defined by default', () => {
+      test('When the Share creates the client without captcha, then the app details are the defined by default', async () => {
         const mockToken = 'test-token';
 
-        vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
+        vi.spyOn(mockLocalStorage, 'getToken').mockResolvedValue(mockToken);
 
-        const instance = SdkFactory.getNewApiInstance();
-        instance.createShareClient();
+        const instance = await SdkFactory.getNewApiInstance();
+        await instance.createShareClient();
 
         expect(Share.client).toHaveBeenCalledWith(
           MOCKED_NEW_API,
@@ -281,14 +281,14 @@ describe('SdkFactory', () => {
         );
       });
 
-      test('When the Share creates the client with captcha, then the app details include the captcha header', () => {
+      test('When the Share creates the client with captcha, then the app details include the captcha header', async () => {
         const mockToken = 'test-token';
         const captchaToken = 'captcha-token-123';
 
-        vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
+        vi.spyOn(mockLocalStorage, 'getToken').mockResolvedValue(mockToken);
 
-        const instance = SdkFactory.getNewApiInstance();
-        instance.createShareClient(captchaToken);
+        const instance = await SdkFactory.getNewApiInstance();
+        await instance.createShareClient(captchaToken);
 
         expect(Share.client).toHaveBeenCalledWith(
           MOCKED_NEW_API,
@@ -305,13 +305,13 @@ describe('SdkFactory', () => {
     });
 
     describe('Creating the auth client', () => {
-      test('When the Auth creates the client without captcha, then the app details are the defined by default', () => {
+      test('When the Auth creates the client without captcha, then the app details are the defined by default', async () => {
         const mockToken = 'test-token';
 
-        vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
+        vi.spyOn(mockLocalStorage, 'getToken').mockResolvedValue(mockToken);
 
-        const instance = SdkFactory.getNewApiInstance();
-        instance.createAuthClient();
+        const instance = await SdkFactory.getNewApiInstance();
+        await instance.createAuthClient();
 
         expect(Auth.client).toHaveBeenCalledWith(
           MOCKED_NEW_API,
@@ -323,14 +323,14 @@ describe('SdkFactory', () => {
         );
       });
 
-      test('When the Auth creates the client with captcha, then the app details include the captcha header', () => {
+      test('When the Auth creates the client with captcha, then the app details include the captcha header', async () => {
         const mockToken = 'test-token';
         const captchaToken = 'captcha-token-123';
 
-        vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
+        vi.spyOn(mockLocalStorage, 'getToken').mockResolvedValue(mockToken);
 
-        const instance = SdkFactory.getNewApiInstance();
-        instance.createAuthClient({ captchaToken });
+        const instance = await SdkFactory.getNewApiInstance();
+        await instance.createAuthClient({ captchaToken });
 
         expect(Auth.client).toHaveBeenCalledWith(
           MOCKED_NEW_API,
@@ -347,12 +347,12 @@ describe('SdkFactory', () => {
     });
 
     describe('Creating the location client', () => {
-      test('When the Location client is created, then it uses the location API URL and default app details', () => {
+      test('When the Location client is created, then it uses the location API URL and default app details', async () => {
         const mockToken = 'test-token';
 
-        vi.spyOn(mockLocalStorage, 'getToken').mockReturnValue(mockToken);
+        vi.spyOn(mockLocalStorage, 'getToken').mockResolvedValue(mockToken);
 
-        const instance = SdkFactory.getNewApiInstance();
+        const instance = await SdkFactory.getNewApiInstance();
         instance.createLocationClient();
 
         expect(Location.client).toHaveBeenCalledWith(MOCKED_LOCATION);

--- a/src/app/core/factory/sdk/index.ts
+++ b/src/app/core/factory/sdk/index.ts
@@ -47,78 +47,78 @@ export class SdkFactory {
     return this.sdk.newApiInstance;
   }
 
-  public createAuthClient(options?: { captchaToken?: string; unauthorizedCallback?: () => void }): Auth {
+  public async createAuthClient(options?: { captchaToken?: string; unauthorizedCallback?: () => void }): Promise<Auth> {
     const apiUrl = this.getApiUrl();
     const appDetails = this.getAppDetailsWithHeaders(options?.captchaToken);
-    const apiSecurity = this.getNewApiSecurity(options?.unauthorizedCallback);
+    const apiSecurity = await this.getNewApiSecurity(options?.unauthorizedCallback);
     return Auth.client(apiUrl, appDetails, apiSecurity);
   }
 
-  public createDesktopAuthClient(): Auth {
+  public async createDesktopAuthClient(): Promise<Auth> {
     const apiUrl = this.getApiUrl();
     const appDetails = SdkFactory.getDesktopAppDetails();
-    const apiSecurity = this.getNewApiSecurity();
+    const apiSecurity = await this.getNewApiSecurity();
     return Auth.client(apiUrl, appDetails, apiSecurity);
   }
 
-  public createNewStorageClient(): Storage {
+  public async createNewStorageClient(): Promise<Storage> {
     const apiUrl = this.getApiUrl();
     const appDetails = SdkFactory.getAppDetails();
-    const apiSecurity = this.getNewApiSecurity();
+    const apiSecurity = await this.getNewApiSecurity();
     return Storage.client(apiUrl, appDetails, apiSecurity);
   }
 
-  public createWorkspacesClient(): Workspaces {
+  public async createWorkspacesClient(): Promise<Workspaces> {
     const apiUrl = this.getApiUrl();
     const appDetails = SdkFactory.getAppDetails();
-    const apiSecurity = this.getNewApiSecurity();
+    const apiSecurity = await this.getNewApiSecurity();
     return Workspaces.client(apiUrl, appDetails, apiSecurity);
   }
 
-  public createShareClient(captchaToken?: string): Share {
+  public async createShareClient(captchaToken?: string): Promise<Share> {
     const apiUrl = this.getApiUrl();
     const appDetails = this.getAppDetailsWithHeaders(captchaToken);
-    const apiSecurity = this.getNewApiSecurity();
+    const apiSecurity = await this.getNewApiSecurity();
     return Share.client(apiUrl, appDetails, apiSecurity);
   }
 
-  public createTrashClient(): Trash {
+  public async createTrashClient(): Promise<Trash> {
     const apiUrl = this.getApiUrl();
     const appDetails = SdkFactory.getAppDetails();
-    const apiSecurity = this.getNewApiSecurity();
+    const apiSecurity = await this.getNewApiSecurity();
     return Trash.client(apiUrl, appDetails, apiSecurity);
   }
 
-  public createUsersClient(captchaToken?: string): Users {
+  public async createUsersClient(captchaToken?: string): Promise<Users> {
     const apiUrl = this.getApiUrl();
     const appDetails = this.getAppDetailsWithHeaders(captchaToken);
-    const apiSecurity = this.getNewApiSecurity();
+    const apiSecurity = await this.getNewApiSecurity();
     return Users.client(apiUrl, appDetails, apiSecurity);
   }
 
-  public createReferralsClient(): Referrals {
+  public async createReferralsClient(): Promise<Referrals> {
     const apiUrl = this.getApiUrl();
     const appDetails = SdkFactory.getAppDetails();
-    const apiSecurity = this.getNewApiSecurity();
+    const apiSecurity = await this.getNewApiSecurity();
     return Referrals.client(apiUrl, appDetails, apiSecurity);
   }
 
   public async createPaymentsClient(): Promise<Payments> {
     const appDetails = SdkFactory.getAppDetails();
-    const apiSecurity = this.getIndividualApiSecurity();
+    const apiSecurity = await this.getIndividualApiSecurity();
     return Payments.client(envService.getVariable('payments'), appDetails, apiSecurity);
   }
 
   public async createCheckoutClient(): Promise<Checkout> {
     const appDetails = SdkFactory.getAppDetails();
-    const apiSecurity = this.getIndividualApiSecurity();
+    const apiSecurity = await this.getIndividualApiSecurity();
     return Checkout.client(envService.getVariable('payments'), appDetails, apiSecurity);
   }
 
-  public createBackupsClient(): Backups {
+  public async createBackupsClient(): Promise<Backups> {
     const apiUrl = this.getApiUrl();
     const appDetails = SdkFactory.getAppDetails();
-    const apiSecurity = this.getNewApiSecurity();
+    const apiSecurity = await this.getNewApiSecurity();
     return Backups.client(apiUrl, appDetails, apiSecurity);
   }
 
@@ -130,10 +130,11 @@ export class SdkFactory {
 
   /** Helpers **/
 
-  private getNewApiSecurity(unauthorizedCallback?: () => void): ApiSecurity {
+  private async getNewApiSecurity(unauthorizedCallback?: () => void): Promise<ApiSecurity> {
     const workspaceToken = this.getWorkspaceToken();
+    const token = await this.getNewToken();
     return {
-      token: this.getNewToken(),
+      token,
       workspaceToken,
       unauthorizedCallback:
         unauthorizedCallback ??
@@ -143,8 +144,8 @@ export class SdkFactory {
     };
   }
 
-  private getIndividualApiSecurity(): ApiSecurity {
-    const token = this.getNewToken();
+  private async getIndividualApiSecurity(): Promise<ApiSecurity> {
+    const token = await this.getNewToken();
     return {
       token,
       unauthorizedCallback: () => {
@@ -177,8 +178,8 @@ export class SdkFactory {
     };
   }
 
-  private getNewToken(): Token {
-    return SdkFactory.sdk.localStorage.getToken() || '';
+  private async getNewToken(): Promise<Token> {
+    return (await SdkFactory.sdk.localStorage.getToken()) || '';
   }
 
   private getWorkspaceToken(): Token | undefined {

--- a/src/app/core/plugins/axios.plugin.ts
+++ b/src/app/core/plugins/axios.plugin.ts
@@ -9,8 +9,8 @@ const axiosPlugin: AppPlugin = {
   install(store): void {
     axios.defaults.baseURL = envService.getVariable('newApi');
 
-    axios.interceptors.request.use((requestConfig) => {
-      const token = localStorageService.getToken();
+    axios.interceptors.request.use(async (requestConfig) => {
+      const token = await localStorageService.getToken();
 
       const headers = new AxiosHeaders({
         'content-type': 'application/json; charset=utf-8',

--- a/src/app/core/views/DeactivationView/DeactivationView.tsx
+++ b/src/app/core/views/DeactivationView/DeactivationView.tsx
@@ -41,9 +41,9 @@ class DeactivationView extends React.Component<DeactivationViewProps> {
     }
   };
 
-  ConfirmDeactivateUser = (token: string) => {
-    const authClient = SdkFactory.getNewApiInstance().createAuthClient();
-    const userToken = localStorageService.getToken() ?? undefined;
+  ConfirmDeactivateUser = async (token: string) => {
+    const authClient = await SdkFactory.getNewApiInstance().createAuthClient();
+    const userToken = await localStorageService.getToken();
     return authClient
       .confirmUserDeactivation(token, userToken)
       .then(() => {

--- a/src/app/core/views/VerifyEmailView/index.tsx
+++ b/src/app/core/views/VerifyEmailView/index.tsx
@@ -30,7 +30,7 @@ export default function VerifyEmailView(): JSX.Element {
     setStatus('loading');
 
     try {
-      const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
+      const usersClient = await SdkFactory.getNewApiInstance().createUsersClient();
       await usersClient.verifyEmail({ verificationToken: decodeURIComponent(token) });
       setStatus('success');
     } catch (err) {

--- a/src/app/drive/components/ShareWithTeamDialog/ShareWithTeamDialog.tsx
+++ b/src/app/drive/components/ShareWithTeamDialog/ShareWithTeamDialog.tsx
@@ -73,7 +73,7 @@ const ShareWithTeamDialog = ({ item, roles }: ShareWithTeamDialogProps) => {
     const itemId = item.uuid;
     try {
       if (workspaceId) {
-        const [promise] = workspacesService.getUsersAndTeamsAnItemIsShareWidth({
+        const [promise] = await workspacesService.getUsersAndTeamsAnItemIsShareWidth({
           workspaceId,
           itemType,
           itemId,

--- a/src/app/drive/services/file.service/index.ts
+++ b/src/app/drive/services/file.service/index.ts
@@ -6,12 +6,12 @@ import errorService from 'services/error.service';
 import { DriveFileData, DriveFileMetadataPayload } from '../../types';
 import uploadFile from './uploadFile';
 
-export function updateMetaData(
+export async function updateMetaData(
   fileId: string,
   metadata: DriveFileMetadataPayload,
   resourcesToken?: string,
 ): Promise<void> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   const payload = { fileUuid: fileId, name: metadata.itemName };
 
   return storageClient.updateFileNameWithUUID(payload, resourcesToken);
@@ -22,7 +22,7 @@ export async function moveFileByUuid(
   destinationFolderUuid: string,
   newName?: string,
 ): Promise<StorageTypes.FileMeta> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   const payload: StorageTypes.MoveFileUuidPayload = {
     destinationFolder: destinationFolderUuid,
     name: newName,
@@ -42,12 +42,12 @@ export async function moveFileByUuid(
 }
 
 export async function deleteFile(fileData: DriveFileData): Promise<void> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   await storageClient.deleteFileByUuid(fileData.uuid);
 }
 
 async function fetchDeleted(): Promise<DriveFileData[]> {
-  const trashClient = SdkFactory.getNewApiInstance().createTrashClient();
+  const trashClient = await SdkFactory.getNewApiInstance().createTrashClient();
 
   const trashRequest = trashClient.getTrash();
 
@@ -57,8 +57,8 @@ async function fetchDeleted(): Promise<DriveFileData[]> {
   });
 }
 
-export function getFile(uuid: string, workspacesToken?: string): Promise<FileMeta> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+export async function getFile(uuid: string, workspacesToken?: string): Promise<FileMeta> {
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   const [responsePromise] = storageClient.getFile(uuid, workspacesToken);
 
   return responsePromise;

--- a/src/app/drive/services/file.service/uploadFile.ts
+++ b/src/app/drive/services/file.service/uploadFile.ts
@@ -64,7 +64,7 @@ export const createFileEntry = async ({
 
     return workspacesService.createFileEntry(workspaceFileEntry, workspaceId, resourcesToken);
   } else {
-    const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+    const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
     const fileEntry: StorageTypes.FileEntryByUuid = {
       fileId: fileId,
       type: file.type,

--- a/src/app/drive/services/folder.service.ts
+++ b/src/app/drive/services/folder.service.ts
@@ -81,15 +81,15 @@ interface DownloadFolderAsZipOptions {
   workspaceId?: string;
 }
 
-export function createFolderByUuid(
+export async function createFolderByUuid(
   parentFolderUuid: string,
   plainName: string,
-): [Promise<StorageTypes.CreateFolderResponse>, RequestCanceler] {
+): Promise<[Promise<StorageTypes.CreateFolderResponse>, RequestCanceler]> {
   const payload: StorageTypes.CreateFolderByUuidPayload = {
     plainName: plainName,
     parentFolderUuid: parentFolderUuid,
   };
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   const [promise, requestCanceler] = storageClient.createFolderByUuid(payload);
 
   const finalPromise = promise
@@ -108,7 +108,7 @@ export async function updateMetaData(
   metadata: DriveFolderMetadataPayload,
   resourcesToken?: string,
 ): Promise<void> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
 
   const payload = {
     folderUuid,
@@ -119,7 +119,7 @@ export async function updateMetaData(
 }
 
 export async function deleteFolder(folderData: DriveFolderData): Promise<void> {
-  const trashClient = SdkFactory.getNewApiInstance().createTrashClient();
+  const trashClient = await SdkFactory.getNewApiInstance().createTrashClient();
   await trashClient.deleteFolder(folderData.id);
 }
 
@@ -139,7 +139,7 @@ class DirectoryFolderIterator implements Iterator<DriveFolderData> {
 
     let folders;
     if (workspaceId) {
-      const [foldersPromise] = workspacesService.getWorkspaceFolders(
+      const [foldersPromise] = await workspacesService.getWorkspaceFolders(
         workspaceId,
         directoryUUID,
         this.offset,
@@ -147,7 +147,7 @@ class DirectoryFolderIterator implements Iterator<DriveFolderData> {
       );
       folders = (await foldersPromise).result;
     } else {
-      const [folderInfoPromise] = newStorageService.getFolderContentByUuid({
+      const [folderInfoPromise] = await newStorageService.getFolderContentByUuid({
         folderUuid: directoryUUID,
         offset: this.offset,
         limit: this.limit,
@@ -178,10 +178,15 @@ class DirectoryFilesIterator implements Iterator<DriveFileData> {
 
     let files;
     if (workspaceId) {
-      const [filesPromise] = workspacesService.getWorkspaceFiles(workspaceId, directoryUUID, this.offset, this.limit);
+      const [filesPromise] = await workspacesService.getWorkspaceFiles(
+        workspaceId,
+        directoryUUID,
+        this.offset,
+        this.limit,
+      );
       files = (await filesPromise).result;
     } else {
-      const [storageFolders] = newStorageService.getFolderContentByUuid({
+      const [storageFolders] = await newStorageService.getFolderContentByUuid({
         folderUuid: directoryUUID,
         offset: this.offset,
         limit: this.limit,
@@ -510,7 +515,7 @@ export async function moveFolderByUuid(
   destinationFolderUuid: string,
   newName?: string,
 ): Promise<StorageTypes.FolderMeta> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   const payload: StorageTypes.MoveFolderUuidPayload = {
     destinationFolder: destinationFolderUuid,
     name: newName,

--- a/src/app/drive/services/limit.service.ts
+++ b/src/app/drive/services/limit.service.ts
@@ -3,7 +3,7 @@ import { SdkFactory } from 'app/core/factory/sdk';
 import { HUNDRED_TB } from 'app/core/constants';
 
 async function fetchLimit(): Promise<number> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   return storageClient.spaceLimitV2().then((response) => {
     return response.maxSpaceBytes;
   });

--- a/src/app/drive/services/new-storage.service.test.ts
+++ b/src/app/drive/services/new-storage.service.test.ts
@@ -43,7 +43,7 @@ describe('newStorageService', () => {
         createNewStorageClient: () => mockStorageClient,
       });
 
-      const [promise, canceler] = newStorageService.getFolderContentByUuid({
+      const [promise, canceler] = await newStorageService.getFolderContentByUuid({
         folderUuid: 'test-folder-uuid',
       });
       const result = await promise;
@@ -66,7 +66,7 @@ describe('newStorageService', () => {
         createNewStorageClient: () => mockStorageClient,
       });
 
-      const [promise] = newStorageService.getFolderContentByUuid({
+      const [promise] = await newStorageService.getFolderContentByUuid({
         folderUuid: 'test-folder-uuid',
       });
       const result = await promise;
@@ -91,7 +91,7 @@ describe('newStorageService', () => {
         trash: true,
         workspacesToken: 'test-token',
       };
-      newStorageService.getFolderContentByUuid(params);
+      await newStorageService.getFolderContentByUuid(params);
 
       expect(mockGetFolderContentByUuid).toHaveBeenCalledWith(params);
     });

--- a/src/app/drive/services/new-storage.service.ts
+++ b/src/app/drive/services/new-storage.service.ts
@@ -14,12 +14,12 @@ import { ItemType } from '@internxt/sdk/dist/workspaces/types';
 import transformItemService from './item-transform.service';
 
 export async function hasUploadedFiles(): Promise<{ hasUploadedFiles: boolean }> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   return storageClient.hasUploadedFiles();
 }
 
 export async function getFolderAncestors(uuid: string): Promise<FolderAncestor[]> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   return storageClient.getFolderAncestors(uuid);
 }
 
@@ -29,17 +29,17 @@ export async function getFolderAncestorsInWorkspace(
   uuid: string,
   resourcesToken?: string,
 ): Promise<FolderAncestorWorkspace[]> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   return storageClient.getFolderAncestorsInWorkspace(workspaceId, itemType, uuid, resourcesToken);
 }
 
 export async function getFolderMeta(uuid: string, workspaceId?: string, resourcesToken?: string): Promise<FolderMeta> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   return storageClient.getFolderMeta(uuid, workspaceId, resourcesToken);
 }
 
 export async function getFolderStats(uuid: string): Promise<FolderStatsResponse> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   return storageClient.getFolderStats(uuid);
 }
 
@@ -47,7 +47,7 @@ export async function checkDuplicatedFiles(
   folderUuid: string,
   filesList: FileStructure[],
 ): Promise<CheckDuplicatedFilesResponse> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   return storageClient.checkDuplicatedFiles({ folderUuid, filesList });
 }
 
@@ -55,11 +55,11 @@ export async function checkDuplicatedFolders(
   folderUuid: string,
   folderNamesList: string[],
 ): Promise<CheckDuplicatedFoldersResponse> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   return storageClient.checkDuplicatedFolders({ folderUuid, folderNamesList });
 }
 
-export function getFolderContentByUuid({
+export async function getFolderContentByUuid({
   folderUuid,
   limit,
   offset,
@@ -71,8 +71,8 @@ export function getFolderContentByUuid({
   offset?: number;
   trash?: boolean;
   workspacesToken?: string;
-}): [Promise<FetchFolderContentResponse>, RequestCanceler] {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+}): Promise<[Promise<FetchFolderContentResponse>, RequestCanceler]> {
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   const [responsePromise, canceler] = storageClient.getFolderContentByUuid({
     folderUuid,
     limit,
@@ -89,8 +89,8 @@ export function getFolderContentByUuid({
   return [transformedPromise, canceler];
 }
 
-export function deleteFolderByUuid(folderId: string) {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+export async function deleteFolderByUuid(folderId: string) {
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   return storageClient.deleteFolderByUuid(folderId);
 }
 

--- a/src/app/drive/services/thumbnail.service.ts
+++ b/src/app/drive/services/thumbnail.service.ts
@@ -184,7 +184,7 @@ export const uploadThumbnail = async (
     abortController,
   });
 
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   const thumbnailEntry: StorageTypes.CreateThumbnailEntryPayload = {
     bucketFile,
     bucketId,

--- a/src/app/drive/services/usage.service.ts
+++ b/src/app/drive/services/usage.service.ts
@@ -9,14 +9,14 @@ export interface UsageDetailsProps {
 }
 
 export async function fetchUsage(): Promise<UsageResponseV2> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   const driveUsage = await storageClient.spaceUsageV2();
 
   return driveUsage;
 }
 
 async function getUsageDetails(): Promise<UsageDetailsProps> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
 
   let drive = 0;
   let backups = 0;

--- a/src/app/share/services/redirections.service.ts
+++ b/src/app/share/services/redirections.service.ts
@@ -60,7 +60,7 @@ const handlePrivateSharedFolderAccess = async ({
 const getPrivateSharedFolderAccessData = async (folderUUID: string, workspaceId?: string) => {
   let response;
   if (workspaceId) {
-    const [promise] = workspacesService.getAllWorkspaceTeamSharedFolderFiles(workspaceId, folderUUID, 0, 0);
+    const [promise] = await workspacesService.getAllWorkspaceTeamSharedFolderFiles(workspaceId, folderUUID, 0, 0);
     response = await promise;
   } else {
     response = await shareService.getSharedFolderContent(folderUUID, 'folders', '', 0, 0);

--- a/src/app/share/services/share.service.ts
+++ b/src/app/share/services/share.service.ts
@@ -46,61 +46,62 @@ interface CreateShareResponse {
 }
 const NEW_SHARING_VERSION = 'inxt-v3';
 export async function createShare(params: ShareTypes.GenerateShareLinkPayload): Promise<CreateShareResponse> {
-  return await SdkFactory.getNewApiInstance().createShareClient().createShareLink(params);
+  const sdkInstance = await SdkFactory.getNewApiInstance().createShareClient();
+  return await sdkInstance.createShareLink(params);
 }
 
-export function updateShareLink(params: ShareTypes.UpdateShareLinkPayload): Promise<ShareTypes.ShareLink> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+export async function updateShareLink(params: ShareTypes.UpdateShareLinkPayload): Promise<ShareTypes.ShareLink> {
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.updateShareLink(params).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getReceivedSharedFolders(
+export async function getReceivedSharedFolders(
   page: number,
   perPage: number,
   orderBy?: 'views:ASC' | 'views:DESC' | 'createdAt:ASC' | 'createdAt:DESC',
 ): Promise<ListPrivateSharedFoldersResponse> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getReceivedSharedFolders(page, perPage, orderBy).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getSentSharedFolders(
+export async function getSentSharedFolders(
   page: number,
   perPage: number,
   orderBy?: 'views:ASC' | 'views:DESC' | 'createdAt:ASC' | 'createdAt:DESC',
 ): Promise<ListPrivateSharedFoldersResponse> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getSentSharedFolders(page, perPage, orderBy).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getAllSharedFolders(
+export async function getAllSharedFolders(
   page: number,
   perPage: number,
   orderBy?: 'views:ASC' | 'views:DESC' | 'createdAt:ASC' | 'createdAt:DESC',
 ): Promise<ListAllSharedFoldersResponse> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getAllSharedFolders(page, perPage, orderBy).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getAllSharedFiles(
+export async function getAllSharedFiles(
   page: number,
   perPage: number,
   orderBy?: 'views:ASC' | 'views:DESC' | 'createdAt:ASC' | 'createdAt:DESC',
 ): Promise<ListAllSharedFoldersResponse> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getAllSharedFiles(page, perPage, orderBy).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getSharedFolderContent(
+export async function getSharedFolderContent(
   sharedFolderId: string,
   type: 'folders' | 'files',
   invitedToken: string | null,
@@ -108,7 +109,7 @@ export function getSharedFolderContent(
   perPage: number,
   orderBy?: 'views:ASC' | 'views:DESC' | 'createdAt:ASC' | 'createdAt:DESC',
 ): Promise<ListSharedItemsResponse> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient
     .getSharedFolderContent(sharedFolderId, type, invitedToken, page, perPage, orderBy)
     .catch((error) => {
@@ -116,7 +117,7 @@ export function getSharedFolderContent(
     });
 }
 
-export function getPublicSharedFolderContent(
+export async function getPublicSharedFolderContent(
   sharedFolderId: string,
   type: 'folders' | 'files',
   token: string | null,
@@ -125,7 +126,7 @@ export function getPublicSharedFolderContent(
   code?: string,
   orderBy?: 'views:ASC' | 'views:DESC' | 'createdAt:ASC' | 'createdAt:DESC',
 ): Promise<ListSharedItemsResponse> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient
     .getPublicSharedFolderContent(sharedFolderId, type, token, page, perPage, code, orderBy)
     .catch((error) => {
@@ -133,29 +134,29 @@ export function getPublicSharedFolderContent(
     });
 }
 
-export function deleteShareLink(shareId: string): Promise<{ deleted: boolean; shareId: string }> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+export async function deleteShareLink(shareId: string): Promise<{ deleted: boolean; shareId: string }> {
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.deleteShareLink(shareId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getSharedFolderInfo(token: string, password?: string): Promise<ShareTypes.ShareLink> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+export async function getSharedFolderInfo(token: string, password?: string): Promise<ShareTypes.ShareLink> {
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getShareLink(token, password).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getShareDomains(): Promise<ShareDomainsResponse> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+export async function getShareDomains(): Promise<ShareDomainsResponse> {
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getShareDomains().catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getSharingRoles(): Promise<Role[]> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+export async function getSharingRoles(): Promise<Role[]> {
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getSharingRoles().catch((error) => {
     throw errorService.castError(error);
   });
@@ -163,52 +164,52 @@ export function getSharingRoles(): Promise<Role[]> {
 
 export async function inviteUserToSharedFolder(props: ShareFolderWithUserPayload): Promise<SharingInvite> {
   const captchaToken = await generateCaptchaToken();
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient(captchaToken);
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient(captchaToken);
   return shareClient.inviteUserToSharedFolder({ ...props }).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getUsersOfSharedFolder({
+export async function getUsersOfSharedFolder({
   itemType,
   folderId,
 }: {
   itemType: string;
   folderId: string;
 }): Promise<Record<'users', any[]> | Record<'error', string>> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getAllAccessUsers({ itemType, folderId }).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getSharedFolderInvitationsAsInvitedUser({
+export async function getSharedFolderInvitationsAsInvitedUser({
   limit = 10,
   offset = 0,
 }: {
   limit?: number;
   offset?: number;
 }): Promise<{ invites: SharedFoldersInvitationsAsInvitedUserResponse[] }> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getSharedFolderInvitationsAsInvitedUser({ limit, offset }).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function declineSharedFolderInvite({
+export async function declineSharedFolderInvite({
   invitationId,
   token,
 }: {
   invitationId: string;
   token?: string;
 }): Promise<void> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.declineSharedFolderInvite(invitationId, token).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function acceptSharedFolderInvite({
+export async function acceptSharedFolderInvite({
   invitationId,
   acceptInvite,
   token,
@@ -217,31 +218,31 @@ export function acceptSharedFolderInvite({
   acceptInvite?: AcceptInvitationToSharedFolderPayload;
   token?: string;
 }): Promise<void> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.acceptSharedFolderInvite({ invitationId, acceptInvite, token }).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getUserRoleOfSharedFolder(sharingId: string): Promise<Role> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+export async function getUserRoleOfSharedFolder(sharingId: string): Promise<Role> {
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getUserRole(sharingId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getPublicSharedItemInfo(sharingId: string): Promise<PublicSharedItemInfo> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+export async function getPublicSharedItemInfo(sharingId: string): Promise<PublicSharedItemInfo> {
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getPublicSharedItemInfo(sharingId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function updateUserRoleOfSharedFolder({
+export async function updateUserRoleOfSharedFolder({
   newRoleId,
   sharingId,
 }: UpdateUserRolePayload): Promise<UpdateUserRoleResponse> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient
     .updateUserRole({
       newRoleId,
@@ -252,7 +253,7 @@ export function updateUserRoleOfSharedFolder({
     });
 }
 
-export function removeUserRole({
+export async function removeUserRole({
   itemType,
   itemId,
   userId,
@@ -261,14 +262,14 @@ export function removeUserRole({
   itemId: string;
   userId: string;
 }): Promise<{ message: string }> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.removeUserRole({ itemType, itemId, userId }).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function stopSharingItem(itemType: string, itemId: string): Promise<void> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+export async function stopSharingItem(itemType: string, itemId: string): Promise<void> {
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.stopSharingFolder(itemType, itemId);
 }
 
@@ -407,10 +408,10 @@ interface SharedDirectoryFilesPayload {
   password?: string;
 }
 
-export function getSharedDirectoryFolders(
+export async function getSharedDirectoryFolders(
   payload: SharedDirectoryFoldersPayload,
 ): Promise<ShareTypes.SharedDirectoryFolders> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getShareLinkDirectory({
     type: 'folder',
     token: payload.token,
@@ -422,10 +423,10 @@ export function getSharedDirectoryFolders(
   });
 }
 
-export function getSharedDirectoryFiles(
+export async function getSharedDirectoryFiles(
   payload: SharedDirectoryFilesPayload,
 ): Promise<ShareTypes.SharedDirectoryFiles> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getShareLinkDirectory({
     type: 'file',
     token: payload.token,
@@ -457,7 +458,7 @@ class DirectorySharedFolderIterator implements Iterator<SharedFolders> {
     const { directoryId, resourcesToken, workspaceId } = this.queryValues;
     let items;
     if (workspaceId) {
-      const [promise] = workspacesService.getAllWorkspaceTeamSharedFolderFolders(
+      const [promise] = await workspacesService.getAllWorkspaceTeamSharedFolderFolders(
         workspaceId,
         directoryId,
         this.page,
@@ -497,7 +498,7 @@ class DirectorySharedFilesIterator implements Iterator<SharedFiles> {
     const { directoryId, resourcesToken, workspaceId } = this.queryValues;
     let items;
     if (workspaceId) {
-      const [promise] = workspacesService.getAllWorkspaceTeamSharedFolderFiles(
+      const [promise] = await workspacesService.getAllWorkspaceTeamSharedFolderFiles(
         workspaceId,
         directoryId,
         this.page,
@@ -786,42 +787,46 @@ export const processInvitation = async (
   return response;
 };
 
-export function createPublicSharingItem(publicSharingPayload: CreateSharingPayload): Promise<SharingMeta> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+export async function createPublicSharingItem(publicSharingPayload: CreateSharingPayload): Promise<SharingMeta> {
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.createSharing(publicSharingPayload).catch((error) => {
     throw errorService.castError(error);
   });
 }
-export function validateSharingInvitation(sharingId: string): Promise<{ uuid: string }> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+export async function validateSharingInvitation(sharingId: string): Promise<{ uuid: string }> {
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.validateInviteExpiration(sharingId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getPublicSharingMeta(sharingId: string, code: string, password?: string): Promise<SharingMeta> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+export async function getPublicSharingMeta(sharingId: string, code: string, password?: string): Promise<SharingMeta> {
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getSharingMeta(sharingId, code, password).catch((error) => {
     throw error;
   });
 }
 
-export function updateSharingType(itemId: string, itemType: 'file' | 'folder', sharingType: string): Promise<void> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+export async function updateSharingType(
+  itemId: string,
+  itemType: 'file' | 'folder',
+  sharingType: string,
+): Promise<void> {
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.updateSharingType({ itemId, itemType, sharingType }).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getSharingType(itemId: string, itemType: 'file' | 'folder'): Promise<SharingMeta> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+export async function getSharingType(itemId: string, itemType: 'file' | 'folder'): Promise<SharingMeta> {
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getSharingType({ itemId, itemType }).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getSharingInfo(itemId: string, itemType: 'file' | 'folder'): Promise<SharingInfo> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+export async function getSharingInfo(itemId: string, itemType: 'file' | 'folder'): Promise<SharingInfo> {
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getSharingInfo({ itemId, itemType }).catch((error) => {
     throw errorService.castError(error);
   });
@@ -836,21 +841,21 @@ export async function saveSharingPassword(
   const code = await decryptPublicSharingCodeWithOwner(encryptedCode, encryptionAlgorithm);
   const encryptedPassword = aes.encrypt(plainPassword, code);
 
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.saveSharingPassword(sharingId, encryptedPassword).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function removeSharingPassword(sharingId: string): Promise<void> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+export async function removeSharingPassword(sharingId: string): Promise<void> {
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.removeSharingPassword(sharingId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
 export async function getSharedFolderSize(id: string): Promise<SharedFolderSize> {
-  const shareClient = SdkFactory.getNewApiInstance().createShareClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createShareClient();
   return shareClient.getSharedFolderSize(id).catch((error) => {
     throw errorService.castError(error);
   });

--- a/src/app/store/slices/storage/folderUtils/createFolder.test.ts
+++ b/src/app/store/slices/storage/folderUtils/createFolder.test.ts
@@ -72,7 +72,7 @@ describe('checkCreateFolder', () => {
       uuid: 'uuid',
     };
 
-    vi.spyOn(folderService, 'createFolderByUuid').mockReturnValue([Promise.resolve(mockFolder), { cancel: vi.fn() }]);
+    vi.spyOn(folderService, 'createFolderByUuid').mockResolvedValue([Promise.resolve(mockFolder), { cancel: vi.fn() }]);
     vi.spyOn(tasksService, 'create').mockReturnValue('task-id');
     vi.spyOn(tasksService, 'updateTask').mockReturnValue();
     vi.spyOn(errorService, 'castError').mockResolvedValue(new AppError('error'));

--- a/src/app/store/slices/storage/folderUtils/createFolder.ts
+++ b/src/app/store/slices/storage/folderUtils/createFolder.ts
@@ -36,13 +36,13 @@ export const createFolder = async (
 
   try {
     if (workspaceId) {
-      [createdFolderPromise, requestCanceler] = workspacesService.createFolder({
+      [createdFolderPromise, requestCanceler] = await workspacesService.createFolder({
         workspaceId,
         parentFolderUuid: parentFolderId,
         plainName: folderName,
       });
     } else {
-      [createdFolderPromise, requestCanceler] = folderService.createFolderByUuid(parentFolderId, folderName);
+      [createdFolderPromise, requestCanceler] = await folderService.createFolderByUuid(parentFolderId, folderName);
     }
 
     const taskId = tasksService.create<CreateFolderTask>({

--- a/src/app/store/slices/storage/storage.thunks/createFolderThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/createFolderThunk.ts
@@ -35,13 +35,13 @@ export const createFolderThunk = createAsyncThunk<DriveFolderData, CreateFolderP
 
     try {
       if (workspaceId) {
-        [createdFolderPromise, requestCanceler] = workspacesService.createFolder({
+        [createdFolderPromise, requestCanceler] = await workspacesService.createFolder({
           workspaceId,
           parentFolderUuid: parentFolderId,
           plainName: folderName,
         });
       } else {
-        [createdFolderPromise, requestCanceler] = folderService.createFolderByUuid(parentFolderId, folderName);
+        [createdFolderPromise, requestCanceler] = await folderService.createFolderByUuid(parentFolderId, folderName);
       }
 
       const taskId = tasksService.create<CreateFolderTask>({

--- a/src/app/store/slices/storage/storage.thunks/fetchDialogContentThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/fetchDialogContentThunk.ts
@@ -14,7 +14,7 @@ export const fetchDialogContentThunk = createAsyncThunk<void, string, { state: R
     const state = getState();
     const workspaceCredentials = workspacesSelectors.getWorkspaceCredentials(state);
 
-    const [responsePromise] = newStorageService.getFolderContentByUuid({
+    const [responsePromise] = await newStorageService.getFolderContentByUuid({
       folderUuid: folderId,
       workspacesToken: workspaceCredentials?.tokenHeader,
     });

--- a/src/app/store/slices/storage/storage.thunks/fetchFolderContentThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/fetchFolderContentThunk.ts
@@ -35,8 +35,8 @@ export const fetchPaginatedFolderContentThunk = createAsyncThunk<void, string, {
       if (folderId) {
         let itemsPromise;
 
-        const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
-        const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+        const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
+        const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
 
         if (hasMoreDriveFolders) {
           if (selectedWorkspace) {

--- a/src/app/store/slices/storage/storage.thunks/fetchSortedFolderContentThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/fetchSortedFolderContentThunk.ts
@@ -30,8 +30,8 @@ export const fetchSortedFolderContentThunk = createAsyncThunk<void, string, { st
 
     try {
       dispatch(storageActions.setIsLoadingFolder({ folderId, value: true }));
-      const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
-      const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+      const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
+      const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
 
       let folderPromise;
 

--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
@@ -305,7 +305,7 @@ export const uploadSharedItemsThunk = createAsyncThunk<void, UploadSharedItemsPa
       while (hasMoreItems) {
         let parentFolderContent;
         if (workspaceId && teamId) {
-          const [promise] = workspacesService.getAllWorkspaceTeamSharedFolderFiles(
+          const [promise] = await workspacesService.getAllWorkspaceTeamSharedFolderFiles(
             workspaceId,
             currentFolderId,
             page,

--- a/src/app/store/slices/user/index.ts
+++ b/src/app/store/slices/user/index.ts
@@ -64,7 +64,7 @@ export const initializeUserThunk = createAsyncThunk<
 export const refreshUserThunk = createAsyncThunk<void, { forceRefresh?: boolean } | undefined, { state: RootState }>(
   'user/refresh',
   async ({ forceRefresh } = {}, { dispatch, getState }) => {
-    const userToken = localStorageService.getToken();
+    const userToken = await localStorageService.getToken();
     const isExpired = isTokenExpired(userToken);
 
     const currentUser = getState().user.user;

--- a/src/app/store/slices/user/user.test.ts
+++ b/src/app/store/slices/user/user.test.ts
@@ -41,7 +41,7 @@ describe('user thunks', () => {
     const base64 = (str: string) => (typeof btoa === 'function' ? btoa(str) : Buffer.from(str).toString('base64'));
     const payloadB64 = base64(JSON.stringify({ exp: futureExp }));
     const validToken = `aaa.${payloadB64}.bbb`;
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue(validToken);
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue(validToken);
 
     vi.spyOn(userService, 'refreshAvatarUser').mockResolvedValue({ avatar: null });
 
@@ -64,7 +64,6 @@ describe('user thunks', () => {
       const refreshed = {
         user: { emailVerified: true, name: 'Jane', lastname: 'Smith', uuid: baseUser.uuid },
         newToken: 'new-token-abc',
-        oldToken: 'old-token-abc',
       } as unknown as Awaited<ReturnType<typeof userService.refreshUserData>>;
       vi.spyOn(userService, 'refreshUserData').mockResolvedValue(refreshed);
       vi.spyOn(userService, 'refreshAvatarUser').mockResolvedValue({ avatar: 'avatar-url' });
@@ -97,7 +96,6 @@ describe('user thunks', () => {
       const refreshed = {
         user: { emailVerified: true, name: 'Alice', lastname: 'Johnson', uuid: baseUser.uuid },
         newToken: 'forced-token-xyz',
-        oldToken: 'old-token-xyz',
       } as unknown as Awaited<ReturnType<typeof userService.refreshUserData>>;
       vi.spyOn(userService, 'refreshUserData').mockResolvedValue(refreshed);
       vi.spyOn(userService, 'refreshAvatarUser').mockResolvedValue({ avatar: 'forced-avatar-url' });

--- a/src/services/auth.service.test.ts
+++ b/src/services/auth.service.test.ts
@@ -731,7 +731,7 @@ describe('Change password', () => {
         sendUserDeactivationEmail: mockSendDeactivationEmail,
       }),
     } as any);
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue('token');
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue('token');
 
     await authService.cancelAccount();
     expect(mockSendDeactivationEmail).toHaveBeenCalledWith('token');
@@ -899,7 +899,7 @@ describe('areCredentialsCorrect', () => {
     const mockSalt = 'mockSalt';
     const mockToken = 'mockToken';
 
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue(mockToken);
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue(mockToken);
 
     const encryptedSalt = encryptText(mockSalt);
     const mockAreCredentialsCorrect = vi.fn().mockResolvedValue(true);
@@ -922,7 +922,7 @@ describe('areCredentialsCorrect', () => {
     const mockSalt = 'mockSalt';
     const mockToken = 'mockToken';
 
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue(mockToken);
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue(mockToken);
 
     const encryptedSalt = encryptText(mockSalt);
     const mockAreCredentialsCorrect = vi.fn().mockResolvedValue(false);
@@ -944,7 +944,7 @@ describe('areCredentialsCorrect', () => {
     const mockPassword = 'password123';
     const mockSalt = 'mockSalt';
 
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue(null);
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue(undefined);
 
     const encryptedSalt = encryptText(mockSalt);
     const mockAreCredentialsCorrect = vi.fn().mockResolvedValue(true);
@@ -967,7 +967,7 @@ describe('areCredentialsCorrect', () => {
     const mockSalt = 'mockSalt';
     const mockToken = 'mockToken';
 
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue(mockToken);
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue(mockToken);
 
     const encryptedSalt = encryptText(mockSalt);
     const mockError = new Error('API error');
@@ -990,7 +990,7 @@ describe('areCredentialsCorrect', () => {
     const mockEmail = 'test@example.com';
     const mockCreateAuthClient = vi.fn();
 
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue(mockToken);
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue(mockToken);
 
     vi.spyOn(localStorageService, 'getUser').mockReturnValue({
       email: mockEmail,
@@ -1100,7 +1100,7 @@ describe('logOut', () => {
       createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
     } as any);
 
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue('test-token');
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue('test-token');
     vi.spyOn(localStorageService, 'clear').mockImplementation(() => {});
 
     await authService.logOut();
@@ -1110,7 +1110,7 @@ describe('logOut', () => {
   });
 
   it('should sign out user even when session has expired', async () => {
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue(null);
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue(undefined);
     vi.spyOn(localStorageService, 'clear').mockImplementation(() => {});
 
     await authService.logOut();
@@ -1127,7 +1127,7 @@ describe('logOut', () => {
       createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
     } as any);
 
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue('test-token');
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue('test-token');
     vi.spyOn(localStorageService, 'clear').mockImplementation(() => {});
 
     const loginParams = { redirect: 'dashboard' };
@@ -1147,7 +1147,7 @@ describe('cancelAccount', () => {
       createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
     } as any);
 
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue('test-token');
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue('test-token');
 
     await authService.cancelAccount();
 
@@ -1163,7 +1163,7 @@ describe('cancelAccount', () => {
       createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
     } as any);
 
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue(null);
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue(undefined);
 
     await authService.cancelAccount();
 
@@ -1297,7 +1297,7 @@ describe('generateNew2FA', () => {
       createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
     } as any);
 
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue('test-token');
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue('test-token');
 
     const result = await authService.generateNew2FA();
 
@@ -1314,7 +1314,7 @@ describe('generateNew2FA', () => {
       createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
     } as any);
 
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue(null);
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue(undefined);
 
     const result = await authService.generateNew2FA();
 
@@ -1333,7 +1333,7 @@ describe('deactivate2FA', () => {
       createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
     } as any);
 
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue('test-token');
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue('test-token');
 
     const encryptedSalt = encryptText('test-salt');
     await authService.deactivate2FA(encryptedSalt, 'test-password', '123456');
@@ -1350,7 +1350,7 @@ describe('deactivate2FA', () => {
       createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
     } as any);
 
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue(null);
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue(undefined);
 
     const encryptedSalt = encryptText('test-salt');
     await authService.deactivate2FA(encryptedSalt, 'test-password', '123456');
@@ -1457,7 +1457,7 @@ describe('authService default export', () => {
       createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
     } as any);
 
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue('auth-token');
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue('auth-token');
 
     await authService.default.store2FA('secret-code', '123456');
     expect(mockAuthClient.storeTwoFactorAuthKey).toHaveBeenCalledWith('secret-code', '123456', 'auth-token');
@@ -1477,7 +1477,7 @@ describe('authService default export', () => {
       createAuthClient: vi.fn().mockReturnValue(mockAuthClient),
     } as any);
 
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue(null);
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue(undefined);
 
     await authService.default.store2FA('secret-code', '123456');
     expect(mockAuthClient.storeTwoFactorAuthKey).toHaveBeenCalledWith('secret-code', '123456', undefined);

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -108,9 +108,9 @@ const getCurrentUrlParams = (): Record<string, string> => {
 
 export async function logOut(loginParams?: Record<string, string>): Promise<void> {
   try {
-    const token = localStorageService.getToken() ?? undefined;
+    const token = await localStorageService.getToken();
     if (token) {
-      const authClient = SdkFactory.getNewApiInstance().createAuthClient();
+      const authClient = await SdkFactory.getNewApiInstance().createAuthClient();
       await authClient.logout(token);
     }
   } catch (error) {
@@ -129,14 +129,14 @@ export async function logOut(loginParams?: Record<string, string>): Promise<void
   }
 }
 
-export function cancelAccount(): Promise<void> {
-  const authClient = SdkFactory.getNewApiInstance().createAuthClient();
-  const token = localStorageService.getToken() ?? undefined;
+export async function cancelAccount(): Promise<void> {
+  const authClient = await SdkFactory.getNewApiInstance().createAuthClient();
+  const token = await localStorageService.getToken();
   return authClient.sendUserDeactivationEmail(token);
 }
 
 export const is2FANeeded = async (email: string): Promise<boolean> => {
-  const authClient = SdkFactory.getNewApiInstance().createAuthClient();
+  const authClient = await SdkFactory.getNewApiInstance().createAuthClient();
   const securityDetails = await authClient.securityDetails(email).catch((error) => {
     throw errorService.castError(error);
   });
@@ -159,7 +159,7 @@ export const doLogin = async (
   twoFactorCode: string,
   loginType: 'web' | 'desktop' | undefined = 'web',
 ): Promise<ProfileInfo> => {
-  const authClient = getAuthClient(loginType);
+  const authClient = await getAuthClient(loginType);
   const loginDetails: LoginDetails = {
     email: email.toLowerCase(),
     password: password,
@@ -231,7 +231,7 @@ export const readReferalCookie = (): string | undefined => {
 
 export const getSalt = async (): Promise<string> => {
   const email = localStorageService.getUser()?.email;
-  const authClient = SdkFactory.getNewApiInstance().createAuthClient();
+  const authClient = await SdkFactory.getNewApiInstance().createAuthClient();
   const securityDetails = await authClient.securityDetails(String(email));
   return decryptText(securityDetails.encryptedSalt);
 };
@@ -284,7 +284,7 @@ export const recoverAccountWithBackupKey = async (
  */
 const recoveryOldBackuptWithToken = async (token: string, password: string, mnemonic: string): Promise<void> => {
   try {
-    const authClient = SdkFactory.getNewApiInstance().createAuthClient();
+    const authClient = await SdkFactory.getNewApiInstance().createAuthClient();
     const recoverPayload = await prepareOldBackupRecoverPayloadForBackend({ mnemonic, password, token });
 
     return authClient.legacyRecoverAccount(recoverPayload);
@@ -334,7 +334,7 @@ export const updateCredentialsWithToken = async (
     }
   }
 
-  const authClient = SdkFactory.getNewApiInstance().createAuthClient();
+  const authClient = await SdkFactory.getNewApiInstance().createAuthClient();
 
   const hasPrivateKeys = encryptedEccPrivateKey || encryptedKyberPrivateKey;
   const keys: RecoveryKeys | undefined = hasPrivateKeys
@@ -367,7 +367,7 @@ const resetAccountWithToken = async (token: string | undefined, newPassword: str
   const encryptedHashedNewPassword = encryptText(hashedNewPassword.hash);
   const encryptedHashedNewPasswordSalt = encryptText(hashedNewPassword.salt);
 
-  const authClient = SdkFactory.getNewApiInstance().createAuthClient();
+  const authClient = await SdkFactory.getNewApiInstance().createAuthClient();
 
   return authClient.resetAccountWithToken(
     token,
@@ -398,7 +398,7 @@ export const changePassword = async (newPassword: string, currentPassword: strin
     privateKyberKeyEncrypted = aes.encrypt(user.keys.kyber.privateKey, newPassword);
   }
 
-  const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
+  const usersClient = await SdkFactory.getNewApiInstance().createUsersClient();
 
   return usersClient
     .changePassword({
@@ -426,19 +426,19 @@ export const changePassword = async (newPassword: string, currentPassword: strin
     });
 };
 
-export const userHas2FAStored = (): Promise<SecurityDetails> => {
+export const userHas2FAStored = async (): Promise<SecurityDetails> => {
   const email = localStorageService.getUser()?.email;
-  const authClient = SdkFactory.getNewApiInstance().createAuthClient();
+  const authClient = await SdkFactory.getNewApiInstance().createAuthClient();
   return authClient.securityDetails(<string>email);
 };
 
-export const generateNew2FA = (): Promise<TwoFactorAuthQR> => {
-  const token = localStorageService.getToken() || undefined;
-  const authClient = SdkFactory.getNewApiInstance().createAuthClient();
+export const generateNew2FA = async (): Promise<TwoFactorAuthQR> => {
+  const token = await localStorageService.getToken();
+  const authClient = await SdkFactory.getNewApiInstance().createAuthClient();
   return authClient.generateTwoFactorAuthQR(token);
 };
 
-export const deactivate2FA = (
+export const deactivate2FA = async (
   passwordSalt: string,
   deactivationPassword: string,
   deactivationCode: string,
@@ -446,18 +446,18 @@ export const deactivate2FA = (
   const salt = decryptText(passwordSalt);
   const hashObj = passToHash({ password: deactivationPassword, salt });
   const encPass = encryptText(hashObj.hash);
-  const token = localStorageService.getToken() || undefined;
-  const authClient = SdkFactory.getNewApiInstance().createAuthClient();
+  const token = await localStorageService.getToken();
+  const authClient = await SdkFactory.getNewApiInstance().createAuthClient();
   return authClient.disableTwoFactorAuth(encPass, deactivationCode, token);
 };
 
 export async function areCredentialsCorrect(password: string): Promise<boolean> {
   const salt = await getSalt();
   const { hash: hashedPassword } = passToHash({ password, salt });
-  const authClient = SdkFactory.getNewApiInstance().createAuthClient({
+  const authClient = await SdkFactory.getNewApiInstance().createAuthClient({
     unauthorizedCallback: () => undefined,
   });
-  const token = localStorageService.getToken() ?? undefined;
+  const token = await localStorageService.getToken();
   return authClient.areCredentialsCorrect(hashedPassword, token);
 }
 
@@ -482,8 +482,8 @@ export const getRedirectUrl = (urlSearchParams: URLSearchParams, token: string):
 };
 
 const store2FA = async (code: string, twoFactorCode: string): Promise<void> => {
-  const token = localStorageService.getToken() || undefined;
-  const authClient = SdkFactory.getNewApiInstance().createAuthClient();
+  const token = await localStorageService.getToken();
+  const authClient = await SdkFactory.getNewApiInstance().createAuthClient();
   return authClient.storeTwoFactorAuthKey(code, twoFactorCode, token);
 };
 
@@ -534,18 +534,18 @@ const extractOneUseCredentialsForAutoSubmit = (
 
 const sendChangePasswordEmail = async (email: string): Promise<void> => {
   const captchaToken = await generateCaptchaToken();
-  const authClient = SdkFactory.getNewApiInstance().createAuthClient({ captchaToken });
+  const authClient = await SdkFactory.getNewApiInstance().createAuthClient({ captchaToken });
   return authClient.sendChangePasswordEmail(email);
 };
 
 export const requestUnblockAccount = async (email: string): Promise<void> => {
   const captchaToken = await generateCaptchaToken();
-  const authClient = SdkFactory.getNewApiInstance().createAuthClient({ captchaToken });
+  const authClient = await SdkFactory.getNewApiInstance().createAuthClient({ captchaToken });
   return authClient.requestUnblockAccount(email);
 };
 
-export const unblockAccount = (token: string): Promise<void> => {
-  const authClient = SdkFactory.getNewApiInstance().createAuthClient();
+export const unblockAccount = async (token: string): Promise<void> => {
+  const authClient = await SdkFactory.getNewApiInstance().createAuthClient();
   return authClient.unblockAccount(token);
 };
 

--- a/src/services/local-storage.service.ts
+++ b/src/services/local-storage.service.ts
@@ -71,8 +71,8 @@ function getUser(): UserSettings | null {
   return stringUser ? JSON.parse(stringUser) : null;
 }
 
-function getToken(): string | null {
-  return get(LocalStorageItem.NewToken);
+async function getToken(): Promise<string | undefined> {
+  return get(LocalStorageItem.NewToken) ?? undefined;
 }
 
 function getB2BWorkspace(): WorkspaceData | null {
@@ -145,7 +145,7 @@ export interface LocalStorageService {
   getStorageToken: (isFolder: boolean) => string | null;
   getB2BWorkspace: () => WorkspaceData | null;
   getUser: () => UserSettings | null;
-  getToken: () => string | null;
+  getToken: () => Promise<string | undefined>;
   removeItem: (key: LocalStorageItem) => void;
   clear: () => void;
 }

--- a/src/services/referral.service.ts
+++ b/src/services/referral.service.ts
@@ -302,8 +302,8 @@ const isEligibleForReferral = async (accountCreatedAt?: Date): Promise<boolean> 
   }
 
   try {
-    const referalCklient = await getReferralsClient();
-    const { isEnabled } = await referalCklient.isReferralEnabled();
+    const referalClient = await getReferralsClient();
+    const { isEnabled } = await referalClient.isReferralEnabled();
     return isEnabled;
   } catch {
     return false;

--- a/src/services/referral.service.ts
+++ b/src/services/referral.service.ts
@@ -66,7 +66,7 @@ const getReferralsClient = () => SdkFactory.getNewApiInstance().createReferralsC
 
 const fetchEmailVerifiedStatus = async (fallback: boolean): Promise<boolean> => {
   try {
-    const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
+    const usersClient = await SdkFactory.getNewApiInstance().createUsersClient();
     const { user } = await usersClient.refreshUser();
     return user.emailVerified;
   } catch {
@@ -75,7 +75,8 @@ const fetchEmailVerifiedStatus = async (fallback: boolean): Promise<boolean> => 
 };
 
 const fetchReferralToken = async (): Promise<string> => {
-  const { token } = await getReferralsClient().createReferralToken();
+  const referalClient = await getReferralsClient();
+  const { token } = await referalClient.createReferralToken();
   return token;
 };
 
@@ -301,7 +302,8 @@ const isEligibleForReferral = async (accountCreatedAt?: Date): Promise<boolean> 
   }
 
   try {
-    const { isEnabled } = await getReferralsClient().isReferralEnabled();
+    const referalCklient = await getReferralsClient();
+    const { isEnabled } = await referalCklient.isReferralEnabled();
     return isEnabled;
   } catch {
     return false;

--- a/src/services/sockets/socket.service.test.ts
+++ b/src/services/sockets/socket.service.test.ts
@@ -52,7 +52,7 @@ describe('RealtimeService', () => {
       return '';
     });
 
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue('mock-token-123');
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue('mock-token-123');
 
     mockSocket.id = 'mock-socket-id';
     mockSocket.connected = true;
@@ -88,15 +88,15 @@ describe('RealtimeService', () => {
   describe('Establishing realtime connection', () => {
     test.each(['connect', 'event', 'disconnect', 'connect_error'])(
       'When init is called, then it monitors connection lifecycle through %s events',
-      (eventName) => {
-        service.init(mockEventHandler as unknown as EventHandler);
+      async (eventName) => {
+        await service.init(mockEventHandler as unknown as EventHandler);
         expect(mockSocket.on).toHaveBeenCalledWith(eventName, expect.any(Function));
       },
     );
 
-    test('When connection is successfully established, then it notifies the application via callback', () => {
+    test('When connection is successfully established, then it notifies the application via callback', async () => {
       const onConnectedCallback = vi.fn();
-      service.init(mockEventHandler as unknown as EventHandler, onConnectedCallback);
+      await service.init(mockEventHandler as unknown as EventHandler, onConnectedCallback);
 
       const connectHandler = mockSocket.on.mock.calls.find((call) => call[0] === 'connect')?.[1];
       connectHandler?.();
@@ -109,12 +109,12 @@ describe('RealtimeService', () => {
       { isProduction: false, reconnection: false, withCredentials: false, logs: true },
     ])(
       'When running in isProduction=$isProduction environment, then it adjusts reconnection=$reconnection, withCredentials=$withCredentials and logging=$logs',
-      ({ isProduction, reconnection, withCredentials, logs }) => {
+      async ({ isProduction, reconnection, withCredentials, logs }) => {
         vi.spyOn(envService, 'isProduction').mockReturnValue(isProduction);
         (RealtimeService as unknown as { instance: RealtimeService | undefined }).instance = undefined;
         service = RealtimeService.getInstance();
 
-        service.init(mockEventHandler as unknown as EventHandler);
+        await service.init(mockEventHandler as unknown as EventHandler);
 
         expect(ioMock).toHaveBeenCalledWith('https://notifications.example.com', {
           auth: { token: 'mock-token-123' },
@@ -138,53 +138,53 @@ describe('RealtimeService', () => {
       return RealtimeService.getInstance();
     };
 
-    test('When not in production, then it logs connecting on init', () => {
+    test('When not in production, then it logs connecting on init', async () => {
       service = resetServiceWithProduction(false);
-      service.init(mockEventHandler as unknown as EventHandler);
+      await service.init(mockEventHandler as unknown as EventHandler);
       expect(consoleLogSpy).toHaveBeenCalledWith('[REALTIME]: CONNECTING...');
     });
 
-    test('When in production, then it does not log connecting on init', () => {
+    test('When in production, then it does not log connecting on init', async () => {
       service = resetServiceWithProduction(true);
-      service.init(mockEventHandler as unknown as EventHandler);
+      await service.init(mockEventHandler as unknown as EventHandler);
       expect(consoleLogSpy).not.toHaveBeenCalledWith('[REALTIME]: CONNECTING...');
     });
 
-    test('When connected, then it logs the socket id', () => {
-      service.init(mockEventHandler as unknown as EventHandler);
+    test('When connected, then it logs the socket id', async () => {
+      await service.init(mockEventHandler as unknown as EventHandler);
       const connectHandler = mockSocket.on.mock.calls.find((call) => call[0] === 'connect')?.[1];
       connectHandler?.();
       expect(consoleLogSpy).toHaveBeenCalledWith('[REALTIME]: CONNECTED WITH ID', mockSocket.id);
     });
 
-    test('When not in production, then it logs on disconnect event', () => {
+    test('When not in production, then it logs on disconnect event', async () => {
       service = resetServiceWithProduction(false);
-      service.init(mockEventHandler as unknown as EventHandler);
+      await service.init(mockEventHandler as unknown as EventHandler);
       const disconnectHandler = mockSocket.on.mock.calls.find((call) => call[0] === 'disconnect')?.[1];
       disconnectHandler?.('transport close');
       expect(consoleLogSpy).toHaveBeenCalledWith('[REALTIME] DISCONNECTED:', 'transport close');
     });
 
-    test('When in production, then it does not log on disconnect event', () => {
+    test('When in production, then it does not log on disconnect event', async () => {
       service = resetServiceWithProduction(true);
-      service.init(mockEventHandler as unknown as EventHandler);
+      await service.init(mockEventHandler as unknown as EventHandler);
       const disconnectHandler = mockSocket.on.mock.calls.find((call) => call[0] === 'disconnect')?.[1];
       disconnectHandler?.('transport close');
       expect(consoleLogSpy).not.toHaveBeenCalledWith('[REALTIME] DISCONNECTED:', 'transport close');
     });
 
-    test('When not in production, then it logs errors on connect_error event', () => {
+    test('When not in production, then it logs errors on connect_error event', async () => {
       service = resetServiceWithProduction(false);
-      service.init(mockEventHandler as unknown as EventHandler);
+      await service.init(mockEventHandler as unknown as EventHandler);
       const connectErrorHandler = mockSocket.on.mock.calls.find((call) => call[0] === 'connect_error')?.[1];
       const error = new Error('connection refused');
       connectErrorHandler?.(error);
       expect(consoleErrorSpy).toHaveBeenCalledWith('[REALTIME] CONNECTION ERROR:', error);
     });
 
-    test('When in production, then it does not log errors on connect_error event', () => {
+    test('When in production, then it does not log errors on connect_error event', async () => {
       service = resetServiceWithProduction(true);
-      service.init(mockEventHandler as unknown as EventHandler);
+      await service.init(mockEventHandler as unknown as EventHandler);
       const connectErrorHandler = mockSocket.on.mock.calls.find((call) => call[0] === 'connect_error')?.[1];
       const error = new Error('connection refused');
       connectErrorHandler?.(error);
@@ -193,8 +193,8 @@ describe('RealtimeService', () => {
   });
 
   describe('Receiving realtime notifications', () => {
-    test('When a PLAN_UPDATED event is received, then it calls handleEvent on the event handler', () => {
-      service.init(mockEventHandler as unknown as EventHandler);
+    test('When a PLAN_UPDATED event is received, then it calls handleEvent on the event handler', async () => {
+      await service.init(mockEventHandler as unknown as EventHandler);
       const eventData = { event: SOCKET_EVENTS.PLAN_UPDATED, payload: { maxSpaceBytes: 2000 } };
 
       const eventHandler = mockSocket.on.mock.calls.find((call) => call[0] === 'event')?.[1];
@@ -203,8 +203,8 @@ describe('RealtimeService', () => {
       expect(mockEventHandler.handleEvent).toHaveBeenCalledWith(eventData);
     });
 
-    test('When a FILE_CREATED event is received, then it calls handleEvent on the event handler', () => {
-      service.init(mockEventHandler as unknown as EventHandler);
+    test('When a FILE_CREATED event is received, then it calls handleEvent on the event handler', async () => {
+      await service.init(mockEventHandler as unknown as EventHandler);
       const eventData = { event: SOCKET_EVENTS.FILE_CREATED, payload: { fileId: '123' } };
 
       const eventHandler = mockSocket.on.mock.calls.find((call) => call[0] === 'event')?.[1];
@@ -218,8 +218,8 @@ describe('RealtimeService', () => {
     test.each([
       { connected: true, closes: true },
       { connected: false, closes: false },
-    ])('When the socket is connected=$connected, then closes=$closes', ({ connected, closes }) => {
-      service.init(mockEventHandler as unknown as EventHandler);
+    ])('When the socket is connected=$connected, then closes=$closes', async ({ connected, closes }) => {
+      await service.init(mockEventHandler as unknown as EventHandler);
       mockSocket.connected = connected;
 
       service.stop();
@@ -233,9 +233,9 @@ describe('RealtimeService', () => {
   });
 
   describe('Complete workflow', () => {
-    test('When the socket is connected, then receives notifications and disconnects successfully', () => {
+    test('When the socket is connected, then receives notifications and disconnects successfully', async () => {
       const onConnected = vi.fn();
-      service.init(mockEventHandler as unknown as EventHandler, onConnected);
+      await service.init(mockEventHandler as unknown as EventHandler, onConnected);
 
       const connectHandler = mockSocket.on.mock.calls.find((call) => call[0] === 'connect')?.[1];
       connectHandler?.();

--- a/src/services/sockets/socket.service.ts
+++ b/src/services/sockets/socket.service.ts
@@ -17,7 +17,7 @@ export default class RealtimeService {
     return this.instance;
   }
 
-  init(eventHandler: EventHandler, onConnected?: () => void): void {
+  async init(eventHandler: EventHandler, onConnected?: () => void): Promise<void> {
     if (this.socket?.connected || this.socket?.active) return;
 
     if (!this.isProduction) {
@@ -25,10 +25,11 @@ export default class RealtimeService {
     }
 
     const notificationsUrl = envService.getVariable('notifications');
+    const token = await getToken();
 
     this.socket = io(notificationsUrl, {
       auth: {
-        token: getToken(),
+        token,
       },
       reconnection: this.isProduction,
       withCredentials: this.isProduction,
@@ -70,6 +71,6 @@ export default class RealtimeService {
   }
 }
 
-function getToken(): string {
-  return localStorageService.getToken() as string;
+async function getToken(): Promise<string> {
+  return (await localStorageService.getToken()) ?? '';
 }

--- a/src/services/user.service.test.ts
+++ b/src/services/user.service.test.ts
@@ -50,7 +50,7 @@ describe('userService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
-    vi.spyOn(localStorageService, 'getToken').mockReturnValue(testToken);
+    vi.spyOn(localStorageService, 'getToken').mockResolvedValue(testToken);
   });
 
   it('should pre-create user', async () => {

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -11,8 +11,8 @@ import localStorageService from 'services/local-storage.service';
 import { SdkFactory } from 'app/core/factory/sdk';
 import { generateCaptchaToken } from 'utils';
 
-const preCreateUser = (email: string): Promise<PreCreateUserResponse> => {
-  const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
+const preCreateUser = async (email: string): Promise<PreCreateUserResponse> => {
+  const usersClient = await SdkFactory.getNewApiInstance().createUsersClient();
   return usersClient.preRegister(email);
 };
 
@@ -20,68 +20,67 @@ const refreshUserData = async (
   userUUID: string,
 ): Promise<{
   newToken: string;
-  oldToken: string;
   user: UserSettings;
 }> => {
-  const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
+  const usersClient = await SdkFactory.getNewApiInstance().createUsersClient();
   return usersClient.getUserData({ userUuid: userUUID });
 };
 
 const refreshAvatarUser = async (): Promise<{
   avatar: string | null;
 }> => {
-  const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
+  const usersClient = await SdkFactory.getNewApiInstance().createUsersClient();
   return usersClient.refreshAvatarUser();
 };
 
-const updateUserProfile = (payload: Required<UpdateProfilePayload>): Promise<void> => {
-  const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
-  const token = localStorageService.getToken() ?? undefined;
+const updateUserProfile = async (payload: Required<UpdateProfilePayload>): Promise<void> => {
+  const usersClient = await SdkFactory.getNewApiInstance().createUsersClient();
+  const token = await localStorageService.getToken();
   return usersClient.updateUserProfile(payload, token);
 };
 
-const updateUserAvatar = (payload: { avatar: Blob }): Promise<{ avatar: string }> => {
-  const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
+const updateUserAvatar = async (payload: { avatar: Blob }): Promise<{ avatar: string }> => {
+  const usersClient = await SdkFactory.getNewApiInstance().createUsersClient();
   return usersClient.updateUserAvatar(payload);
 };
 
-const deleteUserAvatar = (): Promise<void> => {
-  const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
-  const token = localStorageService.getToken() ?? undefined;
+const deleteUserAvatar = async (): Promise<void> => {
+  const usersClient = await SdkFactory.getNewApiInstance().createUsersClient();
+  const token = await localStorageService.getToken();
   return usersClient.deleteUserAvatar(token);
 };
 
 const sendVerificationEmail = async (): Promise<void> => {
   const captchaToken = await generateCaptchaToken();
-  const usersClient = SdkFactory.getNewApiInstance().createUsersClient(captchaToken);
-  const token = localStorageService.getToken() ?? undefined;
+  const usersClient = await SdkFactory.getNewApiInstance().createUsersClient(captchaToken);
+  const token = await localStorageService.getToken();
   return usersClient.sendVerificationEmail(token);
 };
 
-const getPublicKeyByEmail = (email: string): Promise<UserPublicKeyResponse> => {
-  const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
+const getPublicKeyByEmail = async (email: string): Promise<UserPublicKeyResponse> => {
+  const usersClient = await SdkFactory.getNewApiInstance().createUsersClient();
   return usersClient.getPublicKeyByEmail({ email });
 };
 
 const getPublicKeyWithPrecreation = async (email: string): Promise<UserPublicKeyWithCreationResponse> => {
   const captchaToken = await generateCaptchaToken();
-  const usersClient = SdkFactory.getNewApiInstance().createUsersClient(captchaToken);
+  const usersClient = await SdkFactory.getNewApiInstance().createUsersClient(captchaToken);
   return usersClient.getPublicKeyWithPrecreation({ email });
 };
 
 const changeEmail = async (newEmail: string): Promise<void> => {
   const captchaToken = await generateCaptchaToken();
-  const authClient = SdkFactory.getNewApiInstance().createUsersClient(captchaToken);
+  const authClient = await SdkFactory.getNewApiInstance().createUsersClient(captchaToken);
   return authClient.changeUserEmail(newEmail);
 };
 
-const verifyEmailChange = (verifyToken: string): Promise<VerifyEmailChangeResponse> => {
-  const authClient = SdkFactory.getNewApiInstance().createUsersClient();
+const verifyEmailChange = async (verifyToken: string): Promise<VerifyEmailChangeResponse> => {
+  const authClient = await SdkFactory.getNewApiInstance().createUsersClient();
   return authClient.verifyEmailChange(verifyToken);
 };
 
-const checkChangeEmailLinkExpiration = (verifyToken: string): Promise<CheckChangeEmailExpirationResponse> => {
-  const authClient = SdkFactory.getNewApiInstance().createUsersClient();
+const checkChangeEmailLinkExpiration = async (verifyToken: string): Promise<CheckChangeEmailExpirationResponse> => {
+  const authClient = await SdkFactory.getNewApiInstance().createUsersClient();
   return authClient.checkChangeEmailExpiration(verifyToken);
 };
 
@@ -92,7 +91,7 @@ const downloadAvatar = async (url: string, signal?: AbortSignal): Promise<Blob> 
 };
 
 const sendIncompleteCheckout = async (completeCheckoutUrl: string, planName: string, price?: number): Promise<void> => {
-  const usersClient = SdkFactory.getNewApiInstance().createUsersClient();
+  const usersClient = await SdkFactory.getNewApiInstance().createUsersClient();
   await usersClient.handleIncompleteCheckout({
     completeCheckoutUrl,
     planName,

--- a/src/services/workspace.service.test.ts
+++ b/src/services/workspace.service.test.ts
@@ -326,21 +326,21 @@ describe('workspace service', () => {
       expect(mockWorkspacesClient.createFileEntry).toHaveBeenCalledWith(fileEntry, mockIds.workspaceId, 'token');
     });
 
-    it('should create a folder', () => {
+    it('should create a folder', async () => {
       const payload = { workspaceId: mockIds.workspaceId, plainName: 'Folder', parentFolderUuid: 'parent-uuid' };
       const mockPromise = Promise.resolve({ id: 'folder-123' });
       const mockCanceler = vi.fn();
       mockWorkspacesClient.createFolder.mockReturnValue([mockPromise, mockCanceler]);
-      const [promise, canceler] = workspaceService.createFolder(payload);
+      const [promise, canceler] = await workspaceService.createFolder(payload);
       expect(promise).toBe(mockPromise);
       expect(canceler).toBe(mockCanceler);
     });
 
-    it('should retrieve workspace folders', () => {
+    it('should retrieve workspace folders', async () => {
       const mockPromise = Promise.resolve({ result: [] });
       const mockCanceler = vi.fn();
       mockWorkspacesClient.getFolders.mockReturnValue([mockPromise, mockCanceler]);
-      const [promise] = workspaceService.getWorkspaceFolders(mockIds.workspaceId, 'folder-id', 0, 50);
+      const [promise] = await workspaceService.getWorkspaceFolders(mockIds.workspaceId, 'folder-id', 0, 50);
       expect(promise).toBe(mockPromise);
       expect(mockWorkspacesClient.getFolders).toHaveBeenCalledWith(
         mockIds.workspaceId,
@@ -367,7 +367,7 @@ describe('workspace service', () => {
       const mockCanceler = vi.fn();
       mockWorkspacesClient.getFiles.mockReturnValue([mockPromise, mockCanceler]);
 
-      const [promise, canceler] = workspaceService.getWorkspaceFiles(mockIds.workspaceId, 'folder-id', 0, 50);
+      const [promise, canceler] = await workspaceService.getWorkspaceFiles(mockIds.workspaceId, 'folder-id', 0, 50);
       const result = await promise;
 
       expect(canceler).toBe(mockCanceler);
@@ -426,11 +426,11 @@ describe('workspace service', () => {
     it.each([
       { type: 'folders', fn: 'getAllWorkspaceTeamSharedFolders', clientFn: 'getWorkspaceTeamSharedFoldersV2' },
       { type: 'files', fn: 'getAllWorkspaceTeamSharedFiles', clientFn: 'getWorkspaceTeamSharedFilesV2' },
-    ])('should retrieve all shared $type', ({ fn, clientFn }) => {
+    ])('should retrieve all shared $type', async ({ fn, clientFn }) => {
       const mockPromise = Promise.resolve({ items: [] });
       const mockCanceler = vi.fn();
       mockWorkspacesClient[clientFn].mockReturnValue([mockPromise, mockCanceler]);
-      const [promise] = workspaceService[fn](mockIds.workspaceId);
+      const [promise] = await workspaceService[fn](mockIds.workspaceId);
       expect(promise).toBe(mockPromise);
     });
 
@@ -441,19 +441,19 @@ describe('workspace service', () => {
         clientFn: 'getWorkspaceTeamSharedFolderFoldersV2',
       },
       { type: 'files', fn: 'getAllWorkspaceTeamSharedFolderFiles', clientFn: 'getWorkspaceTeamSharedFolderFilesV2' },
-    ])('should retrieve $type within shared folder', ({ fn, clientFn }) => {
+    ])('should retrieve $type within shared folder', async ({ fn, clientFn }) => {
       const mockPromise = Promise.resolve({ items: [] });
       const mockCanceler = vi.fn();
       mockWorkspacesClient[clientFn].mockReturnValue([mockPromise, mockCanceler]);
-      const [promise] = workspaceService[fn](mockIds.workspaceId, 'shared-uuid', 1, 50);
+      const [promise] = await workspaceService[fn](mockIds.workspaceId, 'shared-uuid', 1, 50);
       expect(promise).toBe(mockPromise);
     });
 
-    it('should retrieve users and teams an item is shared with', () => {
+    it('should retrieve users and teams an item is shared with', async () => {
       const mockPromise = Promise.resolve({ users: [], teams: [] });
       const mockCanceler = vi.fn();
       mockWorkspacesClient.getUsersAndTeamsAnItemIsShareWidth.mockReturnValue([mockPromise, mockCanceler]);
-      const [promise] = workspaceService.getUsersAndTeamsAnItemIsShareWidth({
+      const [promise] = await workspaceService.getUsersAndTeamsAnItemIsShareWidth({
         workspaceId: mockIds.workspaceId,
         itemType: 'folder',
         itemId: 'item-123',

--- a/src/services/workspace.service.ts
+++ b/src/services/workspace.service.ts
@@ -35,43 +35,43 @@ import { SdkFactory } from 'app/core/factory/sdk';
 import errorService from 'services/error.service';
 import transformItemService from 'app/drive/services/item-transform.service';
 
-export function getWorkspaces(): Promise<WorkspacesResponse> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function getWorkspaces(): Promise<WorkspacesResponse> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.getWorkspaces().catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getWorkspacesMembers(workspaceId: string): Promise<WorkspaceMembers> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function getWorkspacesMembers(workspaceId: string): Promise<WorkspaceMembers> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.getWorkspacesMembers(workspaceId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getWorkspaceTeams(workspaceId: string): Promise<WorkspaceTeamResponse> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function getWorkspaceTeams(workspaceId: string): Promise<WorkspaceTeamResponse> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.getWorkspacesTeams(workspaceId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getTeamMembers(teamId: string): Promise<TeamMembers> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function getTeamMembers(teamId: string): Promise<TeamMembers> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.getWorkspacesTeamMembers(teamId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getMemberDetails(workspaceId: string, memberId: string): Promise<GetMemberDetailsResponse> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function getMemberDetails(workspaceId: string, memberId: string): Promise<GetMemberDetailsResponse> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.getMemberDetails(workspaceId, memberId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function inviteUserToTeam(inviteUserBody: InviteMemberBody): Promise<void> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function inviteUserToTeam(inviteUserBody: InviteMemberBody): Promise<void> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.inviteMemberToWorkspace(inviteUserBody).catch((error) => {
     throw errorService.castError(error);
   });
@@ -94,28 +94,34 @@ export const processInvitation = async (
   return response;
 };
 
-export function acceptWorkspaceInvite({ invitationId, token }: { invitationId: string; token: string }): Promise<void> {
-  const shareClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
-  return shareClient.acceptInvitation(invitationId, token).catch((error) => {
-    throw errorService.castError(error);
-  });
-}
-
-export function declineWorkspaceInvite({
+export async function acceptWorkspaceInvite({
   invitationId,
   token,
 }: {
   invitationId: string;
   token: string;
 }): Promise<void> {
-  const shareClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+  const shareClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
+  return shareClient.acceptInvitation(invitationId, token).catch((error) => {
+    throw errorService.castError(error);
+  });
+}
+
+export async function declineWorkspaceInvite({
+  invitationId,
+  token,
+}: {
+  invitationId: string;
+  token: string;
+}): Promise<void> {
+  const shareClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return shareClient.declineInvitation(invitationId, token).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function setupWorkspace(workspaceSetupInfo: WorkspaceSetupInfo): Promise<void> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function setupWorkspace(workspaceSetupInfo: WorkspaceSetupInfo): Promise<void> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.setupWorkspace(workspaceSetupInfo).catch((error) => {
     throw errorService.castError(error);
   });
@@ -125,164 +131,166 @@ export async function editWorkspace(
   workspaceId: string,
   details: { name?: string; description?: string; address?: string },
 ): Promise<void> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.editWorkspace(workspaceId, details).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
 export async function updateWorkspaceAvatar(workspaceId: string, avatar: Blob): Promise<{ avatar: string }> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.updateAvatar(workspaceId, { avatar }).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
 export async function deleteWorkspaceAvatar(workspaceId: string): Promise<void> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.deleteAvatar(workspaceId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function createTeam(createTeamData: CreateTeamData): Promise<void> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function createTeam(createTeamData: CreateTeamData): Promise<void> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.createTeam(createTeamData).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function editTeam(teamId: string, name: string): Promise<void> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function editTeam(teamId: string, name: string): Promise<void> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.editTeam({ teamId, name }).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function deleteTeam(workspaceId: string, teamId: string): Promise<void> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function deleteTeam(workspaceId: string, teamId: string): Promise<void> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.deleteTeam({ workspaceId, teamId }).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function addTeamUser(teamId: string, userUuid: string): Promise<void> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function addTeamUser(teamId: string, userUuid: string): Promise<void> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.addTeamUser(teamId, userUuid).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function removeTeamUser(teamId: string, userUuid: string): Promise<void> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function removeTeamUser(teamId: string, userUuid: string): Promise<void> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.removeTeamUser(teamId, userUuid).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function changeTeamManager(workspaceId: string, teamId: string, userId: string): Promise<void> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function changeTeamManager(workspaceId: string, teamId: string, userId: string): Promise<void> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.changeTeamManager(workspaceId, teamId, userId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function createFileEntry(
+export async function createFileEntry(
   fileEntry: FileEntry,
   workspaceId: string,
   resourcesToken?: string,
 ): Promise<DriveFileData> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.createFileEntry(fileEntry, workspaceId, resourcesToken).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function createFolder(payload: CreateFolderPayload): [Promise<CreateFolderResponse>, RequestCanceler] {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function createFolder(
+  payload: CreateFolderPayload,
+): Promise<[Promise<CreateFolderResponse>, RequestCanceler]> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.createFolder(payload);
 }
 
-export function getWorkspaceCredentials(workspaceId: string): Promise<WorkspaceCredentialsDetails> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function getWorkspaceCredentials(workspaceId: string): Promise<WorkspaceCredentialsDetails> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.getWorkspaceCredentials(workspaceId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getWorkspacePendingInvitations(
+export async function getWorkspacePendingInvitations(
   workspaceId: string,
   limit: number,
   offset: number,
 ): Promise<WorkspacePendingInvitations[]> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.getWorkspacePendingInvitations(workspaceId, limit, offset).catch((error) => {
     throw errorService.castError(error);
   });
 }
-export function getTrashItems(
+export async function getTrashItems(
   workspaceId: string,
   type: 'file' | 'folder',
   offset,
 ): Promise<FetchTrashContentResponse> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.getPersonalTrash(workspaceId, type, offset).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function validateWorkspaceInvitation(inviteId: string): Promise<{ uuid: string }> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function validateWorkspaceInvitation(inviteId: string): Promise<{ uuid: string }> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.validateWorkspaceInvitation(inviteId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getPendingInvites(): Promise<PendingInvitesResponse> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function getPendingInvites(): Promise<PendingInvitesResponse> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.getPendingInvites().catch((error) => {
     throw errorService.castError(error);
   });
 }
-export function emptyTrash(workspaceId: string): Promise<void> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function emptyTrash(workspaceId: string): Promise<void> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.emptyPersonalTrash(workspaceId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function shareItemWithTeam(shareItemWithTeamPayload: CreateWorkspaceSharingPayload): Promise<SharingMeta> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function shareItemWithTeam(shareItemWithTeamPayload: CreateWorkspaceSharingPayload): Promise<SharingMeta> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.shareItem(shareItemWithTeamPayload).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getAllWorkspaceTeamSharedFolders(
+export async function getAllWorkspaceTeamSharedFolders(
   workspaceId: string,
   orderBy?: OrderByOptions,
-): [Promise<ListAllSharedFoldersResponse>, RequestCanceler] {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+): Promise<[Promise<ListAllSharedFoldersResponse>, RequestCanceler]> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.getWorkspaceTeamSharedFoldersV2(workspaceId, orderBy);
 }
 
-export function getAllWorkspaceTeamSharedFiles(
+export async function getAllWorkspaceTeamSharedFiles(
   workspaceId: string,
   orderBy?: OrderByOptions,
-): [Promise<ListAllSharedFoldersResponse>, RequestCanceler] {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+): Promise<[Promise<ListAllSharedFoldersResponse>, RequestCanceler]> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.getWorkspaceTeamSharedFilesV2(workspaceId, orderBy);
 }
 
-export function getAllWorkspaceTeamSharedFolderFolders(
+export async function getAllWorkspaceTeamSharedFolderFolders(
   workspaceId: string,
   sharedFolderUUID: string,
   page: number,
   perPage: number,
   token?: string,
   orderBy?: OrderByOptions,
-): [Promise<ListWorkspaceSharedItemsResponse>, RequestCanceler] {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+): Promise<[Promise<ListWorkspaceSharedItemsResponse>, RequestCanceler]> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.getWorkspaceTeamSharedFolderFoldersV2(
     workspaceId,
     sharedFolderUUID,
@@ -293,15 +301,15 @@ export function getAllWorkspaceTeamSharedFolderFolders(
   );
 }
 
-export function getAllWorkspaceTeamSharedFolderFiles(
+export async function getAllWorkspaceTeamSharedFolderFiles(
   workspaceId: string,
   sharedFolderUUID: string,
   page: number,
   perPage: number,
   token?: string,
   orderBy?: OrderByOptions,
-): [Promise<ListWorkspaceSharedItemsResponse>, RequestCanceler] {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+): Promise<[Promise<ListWorkspaceSharedItemsResponse>, RequestCanceler]> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.getWorkspaceTeamSharedFolderFilesV2(
     workspaceId,
     sharedFolderUUID,
@@ -312,7 +320,7 @@ export function getAllWorkspaceTeamSharedFolderFiles(
   );
 }
 
-export function getUsersAndTeamsAnItemIsShareWidth({
+export async function getUsersAndTeamsAnItemIsShareWidth({
   workspaceId,
   itemType,
   itemId,
@@ -320,29 +328,29 @@ export function getUsersAndTeamsAnItemIsShareWidth({
   workspaceId: string;
   itemId: string;
   itemType: 'folder' | 'file';
-}): [Promise<UsersAndTeamsAnItemIsShareWidthResponse>, RequestCanceler] {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+}): Promise<[Promise<UsersAndTeamsAnItemIsShareWidthResponse>, RequestCanceler]> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.getUsersAndTeamsAnItemIsShareWidth({ workspaceId, itemType, itemId });
 }
 
-export function getWorkspaceFolders(
+export async function getWorkspaceFolders(
   workspaceId: string,
   folderId: string,
   offset: number,
   limit: number,
-): [Promise<FetchPaginatedFolderContentResponse>, RequestCanceler] {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+): Promise<[Promise<FetchPaginatedFolderContentResponse>, RequestCanceler]> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   const folders = workspaceClient.getFolders(workspaceId, folderId, offset, limit, 'plainName', 'ASC');
 
   return folders;
 }
-export function getWorkspaceFiles(
+export async function getWorkspaceFiles(
   workspaceId: string,
   folderId: string,
   offset: number,
   limit: number,
-): [Promise<FetchPaginatedFolderContentResponse>, RequestCanceler] {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+): Promise<[Promise<FetchPaginatedFolderContentResponse>, RequestCanceler]> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   const [responsePromise, requestCanceller] = workspaceClient.getFiles(
     workspaceId,
     folderId,
@@ -363,57 +371,57 @@ export function getWorkspaceFiles(
   return [transformedPromise, requestCanceller];
 }
 
-export function deactivateMember(workspaceId: string, memberId: string): Promise<void> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function deactivateMember(workspaceId: string, memberId: string): Promise<void> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.deactivateMember(workspaceId, memberId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function reactivateMember(workspaceId: string, memberId: string): Promise<void> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function reactivateMember(workspaceId: string, memberId: string): Promise<void> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.activateMember(workspaceId, memberId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function removeMember(workspaceId: string, memberId: string): Promise<void> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function removeMember(workspaceId: string, memberId: string): Promise<void> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.removeMember(workspaceId, memberId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function getUsage(workspaceId: string): Promise<GetMemberUsageResponse> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function getUsage(workspaceId: string): Promise<GetMemberUsageResponse> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.getMemberUsage(workspaceId).catch((error) => {
     throw errorService.castError(error);
   });
 }
-export function modifyMemberUsage(
+export async function modifyMemberUsage(
   workspaceId: string,
   memberId: string,
   spaceLimitBytes: number,
 ): Promise<WorkspaceUser> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.modifyMemberUsage(workspaceId, memberId, spaceLimitBytes);
 }
 
-export function getWorkspace(workspaceId: string): Promise<Workspace> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function getWorkspace(workspaceId: string): Promise<Workspace> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.getWorkspace(workspaceId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export function leaveWorkspace(workspaceId: string): Promise<void> {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+export async function leaveWorkspace(workspaceId: string): Promise<void> {
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient.leaveWorkspace(workspaceId).catch((error) => {
     throw errorService.castError(error);
   });
 }
 
-export const getWorkspaceLogs = ({
+export const getWorkspaceLogs = async ({
   workspaceId,
   limit = 50,
   offset = 0,
@@ -432,7 +440,7 @@ export const getWorkspaceLogs = ({
   summary?: boolean;
   orderBy?: WorkspaceLogOrderBy;
 }): Promise<WorkspaceLogResponse[]> => {
-  const workspaceClient = SdkFactory.getNewApiInstance().createWorkspacesClient();
+  const workspaceClient = await SdkFactory.getNewApiInstance().createWorkspacesClient();
   return workspaceClient
     .getWorkspaceLogs(workspaceId, limit, offset, member, activity, lastDays, summary, orderBy)
     .catch((error) => {

--- a/src/views/Backups/hooks/useBackupsPagination.ts
+++ b/src/views/Backups/hooks/useBackupsPagination.ts
@@ -43,7 +43,7 @@ export const useBackupsPagination = (folderUuid: string | undefined, clearSelect
       const currentOffset = isFirstLoad ? 0 : offset;
 
       try {
-        const [folderContentPromise] = newStorageService.getFolderContentByUuid({
+        const [folderContentPromise] = await newStorageService.getFolderContentByUuid({
           folderUuid,
           limit: DEFAULT_LIMIT,
           offset: currentOffset,

--- a/src/views/Backups/services/backups.service.ts
+++ b/src/views/Backups/services/backups.service.ts
@@ -5,35 +5,35 @@ import { DriveFolderData } from 'app/drive/types';
 
 const backupsService = {
   async getAllDevices(): Promise<Device[]> {
-    const backupsClient = SdkFactory.getNewApiInstance().createBackupsClient();
+    const backupsClient = await SdkFactory.getNewApiInstance().createBackupsClient();
     const devices = await backupsClient.getBackupDevices();
     return devices.filter((device) => device.id);
   },
 
   async getAllDevicesAsFolders(): Promise<DriveFolderData[]> {
-    const backupsClient = SdkFactory.getNewApiInstance().createBackupsClient();
+    const backupsClient = await SdkFactory.getNewApiInstance().createBackupsClient();
     const encryptedFolders = await backupsClient.getAllDevicesAsFolder();
     return encryptedFolders.filter((folder) => !folder.deleted).map(mapBackupFolder);
   },
 
   async getAllBackups(mac: string): Promise<DeviceBackup[]> {
-    const backupsClient = SdkFactory.getNewApiInstance().createBackupsClient();
+    const backupsClient = await SdkFactory.getNewApiInstance().createBackupsClient();
     const backups = await backupsClient.getAllBackups(mac);
     return backups;
   },
 
-  deleteBackup(backup: DeviceBackup): Promise<void> {
-    const backupsClient = SdkFactory.getNewApiInstance().createBackupsClient();
+  async deleteBackup(backup: DeviceBackup): Promise<void> {
+    const backupsClient = await SdkFactory.getNewApiInstance().createBackupsClient();
     return backupsClient.deleteBackup(backup.id);
   },
 
-  deleteDevice(device: Device): Promise<void> {
-    const backupsClient = SdkFactory.getNewApiInstance().createBackupsClient();
+  async deleteDevice(device: Device): Promise<void> {
+    const backupsClient = await SdkFactory.getNewApiInstance().createBackupsClient();
     return backupsClient.deleteBackupDevice(device.id);
   },
 
-  deleteBackupDeviceAsFolder(folderId: string) {
-    const backupsClient = SdkFactory.getNewApiInstance().createBackupsClient();
+  async deleteBackupDeviceAsFolder(folderId: string) {
+    const backupsClient = await SdkFactory.getNewApiInstance().createBackupsClient();
     return backupsClient.deleteBackupDeviceAsFolder(folderId);
   },
 };

--- a/src/views/Checkout/services/checkout.service.ts
+++ b/src/views/Checkout/services/checkout.service.ts
@@ -113,7 +113,7 @@ export const createPaymentIntent = async ({
 
 const checkoutSetupIntent = async (customerId: string) => {
   try {
-    const newToken = localStorageService.getToken();
+    const newToken = await localStorageService.getToken();
 
     if (!newToken) {
       throw new Error('No authentication token available');

--- a/src/views/Drive/services/fileVersion.service.ts
+++ b/src/views/Drive/services/fileVersion.service.ts
@@ -4,22 +4,22 @@ import { DriveItemData } from 'app/drive/types';
 import { WorkspaceCredentialsDetails, WorkspaceData } from '@internxt/sdk/dist/workspaces';
 import { FileLimitsResponse, FileVersion, RestoreFileVersionResponse } from '@internxt/sdk/dist/drive/storage/types';
 
-const getStorageClient = () => SdkFactory.getNewApiInstance().createNewStorageClient();
+const getStorageClient = async () => SdkFactory.getNewApiInstance().createNewStorageClient();
 
 export async function getFileVersions(fileUuid: string): Promise<FileVersion[]> {
-  return getStorageClient().getFileVersions(fileUuid);
+  return (await getStorageClient()).getFileVersions(fileUuid);
 }
 
 export async function deleteVersion(fileUuid: string, versionId: string): Promise<void> {
-  await getStorageClient().deleteFileVersion(fileUuid, versionId);
+  await (await getStorageClient()).deleteFileVersion(fileUuid, versionId);
 }
 
 export async function restoreVersion(fileUuid: string, versionId: string): Promise<RestoreFileVersionResponse> {
-  return getStorageClient().restoreFileVersion(fileUuid, versionId);
+  return (await getStorageClient()).restoreFileVersion(fileUuid, versionId);
 }
 
 export async function getLimits(): Promise<FileLimitsResponse> {
-  return getStorageClient().getFileVersionLimits();
+  return (await getStorageClient()).getFileVersionLimits();
 }
 
 export async function downloadVersion(

--- a/src/views/Drive/services/replaceFile.service.ts
+++ b/src/views/Drive/services/replaceFile.service.ts
@@ -7,7 +7,7 @@ export interface ReplaceFilePayload {
 }
 
 export async function replaceFile(fileUuid: string, payload: ReplaceFilePayload): Promise<DriveFileData> {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
   return storageClient.replaceFile(fileUuid, payload);
 }
 

--- a/src/views/Home/components/NavbarGlobalSearch.tsx
+++ b/src/views/Home/components/NavbarGlobalSearch.tsx
@@ -206,7 +206,7 @@ const Navbar = (props: NavbarProps) => {
     const query = searchInput.current?.value ?? '';
     const workspaceId = selectedWorkspace?.workspaceUser.workspaceId;
     if (query.length > 0) {
-      const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+      const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
       const [itemsPromise] = storageClient.getGlobalSearchItems(query, workspaceId);
       const items = await itemsPromise;
       const resultItems: SearchResult[] = Array.isArray(items) ? items : items.data;

--- a/src/views/Home/components/PendingInvitationsDialog.tsx
+++ b/src/views/Home/components/PendingInvitationsDialog.tsx
@@ -28,7 +28,6 @@ const PendingInvitationsDialog = ({
 }) => {
   const dispatch = useAppDispatch();
   const { translate } = useTranslationContext();
-  const token = localStorageService.getToken();
 
   function formatDate(dateString) {
     const date = dayjs(dateString);
@@ -42,6 +41,7 @@ const PendingInvitationsDialog = ({
   }
 
   async function onAcceptInvitation(invitationId: string) {
+    const token = await localStorageService.getToken();
     setIsLoading(true);
     try {
       token && (await workspacesService.acceptWorkspaceInvite({ invitationId, token }));
@@ -69,6 +69,7 @@ const PendingInvitationsDialog = ({
   }
 
   async function onDeclineInvitation(invitationId: string) {
+    const token = await localStorageService.getToken();
     setIsLoading(true);
     try {
       token && (await workspacesService.declineWorkspaceInvite({ invitationId, token }));

--- a/src/views/Login/OAuthLinkView.tsx
+++ b/src/views/Login/OAuthLinkView.tsx
@@ -30,8 +30,8 @@ const OAuthLinkView = (): JSX.Element => {
     authService.logOut(params);
   };
 
-  const handleContinueWithCurrentUser = () => {
-    const newToken = localStorageService.getToken();
+  const handleContinueWithCurrentUser = async () => {
+    const newToken = await localStorageService.getToken();
     if (!newToken) {
       navigationService.history.replace(AppView.Login);
       return;

--- a/src/views/Login/UniversalLinkSuccessView.tsx
+++ b/src/views/Login/UniversalLinkSuccessView.tsx
@@ -26,8 +26,8 @@ export default function UniversalLinkView(): JSX.Element {
     }
   }, [user]);
 
-  const getUniversalLinkAuthUrl = (user: UserSettings) => {
-    const newToken = localStorageService.getToken();
+  const getUniversalLinkAuthUrl = async (user: UserSettings) => {
+    const newToken = await localStorageService.getToken();
     if (!newToken) return AppView.Login;
 
     let baseURL = DEEPLINK_SUCCESS_REDIRECT_BASE;
@@ -45,8 +45,8 @@ export default function UniversalLinkView(): JSX.Element {
     authService.logOut();
   };
 
-  const handleGoToUniversalLinkUrl = () => {
-    globalThis.location.href = getUniversalLinkAuthUrl(user);
+  const handleGoToUniversalLinkUrl = async () => {
+    globalThis.location.href = await getUniversalLinkAuthUrl(user);
   };
 
   return (

--- a/src/views/Login/components/LogIn.tsx
+++ b/src/views/Login/components/LogIn.tsx
@@ -148,8 +148,8 @@ export default function LogIn(): JSX.Element {
     }
   };
 
-  const handleSuccessfulAuth = (user: UserSettings, mnemonic: string): void => {
-    const newToken = localStorageService.getToken();
+  const handleSuccessfulAuth = async (user: UserSettings, mnemonic: string): Promise<void> => {
+    const newToken = await localStorageService.getToken();
 
     if (!newToken) {
       throw new Error('No authentication token available');

--- a/src/views/Login/hooks/useOAuthFlow.test.tsx
+++ b/src/views/Login/hooks/useOAuthFlow.test.tsx
@@ -1,5 +1,5 @@
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { localStorageService, navigationService } from 'services';
 import { AppView } from 'app/core/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -77,19 +77,21 @@ describe('OAuth custom hook', () => {
   });
 
   describe('On component mount', () => {
-    it('when OAuth is active and user credentials exist, then user is redirected to OAuthLink view', () => {
+    it('when OAuth is active and user credentials exist, then user is redirected to OAuthLink view', async () => {
       const mockNewToken = 'test-new-token';
       const mockPush = vi.fn();
 
       vi.spyOn(localStorageService, 'getUser').mockReturnValue(mockUserSettings);
-      vi.spyOn(localStorageService, 'getToken').mockReturnValue(mockNewToken);
+      vi.spyOn(localStorageService, 'getToken').mockResolvedValue(mockNewToken);
       vi.mocked(navigationService.push).mockImplementation(mockPush);
 
       renderHook(() => useOAuthFlow({ authOrigin: 'https://meet.internxt.com' }));
 
       expect(localStorageService.getUser).toHaveBeenCalled();
       expect(localStorageService.getToken).toHaveBeenCalled();
-      expect(mockPush).toHaveBeenCalledWith(AppView.OAuthLink, expect.any(Object));
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith(AppView.OAuthLink, expect.any(Object));
+      });
       expect(mockSendAuthSuccess).not.toHaveBeenCalled();
     });
 
@@ -97,7 +99,7 @@ describe('OAuth custom hook', () => {
       const mockNewToken = 'test-new-token';
 
       vi.spyOn(localStorageService, 'getUser').mockReturnValue(mockUserSettings);
-      vi.spyOn(localStorageService, 'getToken').mockReturnValue(mockNewToken);
+      vi.spyOn(localStorageService, 'getToken').mockResolvedValue(mockNewToken);
 
       renderHook(() => useOAuthFlow({ authOrigin: null }));
 

--- a/src/views/Login/hooks/useOAuthFlow.ts
+++ b/src/views/Login/hooks/useOAuthFlow.ts
@@ -16,15 +16,19 @@ export const useOAuthFlow = ({ authOrigin }: UseOAuthFlowParams): UseOAuthFlowRe
   const isOAuthFlow = !!authOrigin;
 
   useEffect(() => {
-    if (isOAuthFlow) {
+    if (!isOAuthFlow) return;
+
+    const handleOAuthFlow = async () => {
       const user = localStorageService.getUser();
-      const newToken = localStorageService.getToken();
+      const newToken = await localStorageService.getToken();
 
       if (user && newToken) {
         const params = new URLSearchParams(globalThis.location.search);
         navigationService.push(AppView.OAuthLink, Object.fromEntries(params.entries()));
       }
-    }
+    };
+
+    void handleOAuthFlow();
   }, [isOAuthFlow]);
 
   const handleOAuthSuccess = (user: UserSettings, newToken: string): boolean => {

--- a/src/views/Recents/services/fetchRecents.ts
+++ b/src/views/Recents/services/fetchRecents.ts
@@ -2,8 +2,8 @@ import { StorageTypes } from '@internxt/sdk/dist/drive';
 
 import { SdkFactory } from 'app/core/factory/sdk';
 
-export const fetchRecents = (limit: number): Promise<StorageTypes.DriveFileData[]> => {
-  const storageClient = SdkFactory.getNewApiInstance().createNewStorageClient();
+export const fetchRecents = async (limit: number): Promise<StorageTypes.DriveFileData[]> => {
+  const storageClient = await SdkFactory.getNewApiInstance().createNewStorageClient();
 
   return storageClient.getRecentFilesV2(limit);
 };

--- a/src/views/Shared/components/SharedItemListContainer.tsx
+++ b/src/views/Shared/components/SharedItemListContainer.tsx
@@ -115,7 +115,7 @@ const SharedItemListContainer = ({
         const pageItemsNumber = 5;
         let sharedToken;
         if (workspaceCredentials && workspaceId) {
-          const [responsePromise] = workspacesService.getAllWorkspaceTeamSharedFolderFolders(
+          const [responsePromise] = await workspacesService.getAllWorkspaceTeamSharedFolderFolders(
             workspaceId,
             currentFolderId,
             page,

--- a/src/views/Shared/hooks/useFetchSharedData.tsx
+++ b/src/views/Shared/hooks/useFetchSharedData.tsx
@@ -126,7 +126,7 @@ const useFetchSharedData = () => {
       let response;
 
       if (workspaceId) {
-        const [promise] = workspacesService.getAllWorkspaceTeamSharedFolders(workspaceId);
+        const [promise] = await workspacesService.getAllWorkspaceTeamSharedFolders(workspaceId);
         response = await promise;
       } else {
         response = await shareService.getAllSharedFolders(page, ITEMS_PER_PAGE);
@@ -163,7 +163,7 @@ const useFetchSharedData = () => {
       let response;
 
       if (workspaceId) {
-        const [promise] = workspacesService.getAllWorkspaceTeamSharedFiles(workspaceId);
+        const [promise] = await workspacesService.getAllWorkspaceTeamSharedFiles(workspaceId);
         response = await promise;
       } else {
         response = await shareService.getAllSharedFiles(page, ITEMS_PER_PAGE);
@@ -198,7 +198,7 @@ const useFetchSharedData = () => {
       try {
         let response;
         if (workspaceId) {
-          const [promise] = workspacesService.getAllWorkspaceTeamSharedFolderFolders(
+          const [promise] = await workspacesService.getAllWorkspaceTeamSharedFolderFolders(
             workspaceId,
             currentFolderId,
             page,
@@ -251,7 +251,7 @@ const useFetchSharedData = () => {
       try {
         let response;
         if (workspaceId) {
-          const [promise] = workspacesService.getAllWorkspaceTeamSharedFolderFiles(
+          const [promise] = await workspacesService.getAllWorkspaceTeamSharedFolderFiles(
             workspaceId,
             currentFolderId,
             page,

--- a/src/views/Signup/hooks/useSignup.ts
+++ b/src/views/Signup/hooks/useSignup.ts
@@ -72,7 +72,7 @@ export function useSignUp(referrer?: string): {
     const mnemonic = bip39.generateMnemonic(256);
     const encMnemonic = encryptTextWithKey(mnemonic, password);
 
-    const authClient = SdkFactory.getNewApiInstance().createAuthClient();
+    const authClient = await SdkFactory.getNewApiInstance().createAuthClient();
 
     const keys = await getKeys(password);
 
@@ -102,7 +102,7 @@ export function useSignUp(referrer?: string): {
 
   const doRegisterPreCreatedUser = async (email: string, password: string, invitationId: string, captcha: string) => {
     const captchaToken = await generateCaptchaToken();
-    const authClient = SdkFactory.getNewApiInstance().createAuthClient({
+    const authClient = await SdkFactory.getNewApiInstance().createAuthClient({
       captchaToken,
     });
 

--- a/src/views/Trash/services/clearTrash.service.ts
+++ b/src/views/Trash/services/clearTrash.service.ts
@@ -20,7 +20,7 @@ const clearTrash = async (workspaceId?: string): Promise<void> => {
     if (workspaceId) {
       await workspacesService.emptyTrash(workspaceId);
     } else {
-      const trashClient = SdkFactory.getNewApiInstance().createTrashClient();
+      const trashClient = await SdkFactory.getNewApiInstance().createTrashClient();
       await trashClient.clearTrash();
     }
     store.dispatch(storageActions.resetTrash());

--- a/src/views/Trash/services/deleteItems.service.ts
+++ b/src/views/Trash/services/deleteItems.service.ts
@@ -21,7 +21,7 @@ const deleteItems = async (itemsToDelete: DriveItemData[]): Promise<void> => {
   });
 
   try {
-    const trashClient = SdkFactory.getNewApiInstance().createTrashClient();
+    const trashClient = await SdkFactory.getNewApiInstance().createTrashClient();
     await processBatchConcurrently({
       items,
       batchSize: MAX_ITEMS_TO_DELETE,

--- a/src/views/Trash/services/getTrash.service.ts
+++ b/src/views/Trash/services/getTrash.service.ts
@@ -9,7 +9,7 @@ import { store } from 'app/store';
 import { storageActions } from 'app/store/slices/storage';
 
 const getTrash = async (): Promise<void> => {
-  const trashClient = SdkFactory.getNewApiInstance().createTrashClient();
+  const trashClient = await SdkFactory.getNewApiInstance().createTrashClient();
   const itemsInTrash = await trashClient.getTrash();
   for (const folder of itemsInTrash.children) {
     Object.assign(folder, { isFolder: true });
@@ -67,7 +67,7 @@ const getTrashPaginated = async (
   folderId?: number | undefined,
 ): Promise<{ finished: boolean; itemsRetrieved: number }> => {
   try {
-    const trashClient = SdkFactory.getNewApiInstance().createTrashClient();
+    const trashClient = await SdkFactory.getNewApiInstance().createTrashClient();
     const itemsInTrash = await trashClient.getTrashedItemsSorted(limit, offset, type, root, sort, order, folderId);
 
     const { finished, itemsRetrieved } = processTrashItems(itemsInTrash.result, type, limit);

--- a/src/views/Trash/services/moveItemsToTrash.service.ts
+++ b/src/views/Trash/services/moveItemsToTrash.service.ts
@@ -24,7 +24,7 @@ const moveItemsToTrash = async (itemsToTrash: DriveItemData[], onSuccess?: () =>
   let movingItemsToastId;
 
   try {
-    const trashClient = SdkFactory.getNewApiInstance().createTrashClient();
+    const trashClient = await SdkFactory.getNewApiInstance().createTrashClient();
 
     movingItemsToastId = notificationsService.show({
       type: ToastType.Loading,


### PR DESCRIPTION
## Description

This PR includes all changes related to making getToken and only getToken async. No encryption added, just the function is turned into async to match what the getToken with decryption will do.


## Related Issues

Relates to [PB-6505](https://inxt.atlassian.net/browse/PB-6505)

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

Check all main functionalities of the drive web as the token was everywhere.

## Additional Notes

I'm not sure this is the best way. Maybe we can compromise and store the token in the cache, sessionStorage, etc. Because there are lots of changes.


[PB-6505]: https://inxt.atlassian.net/browse/PB-6505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ