### PR TITLE
fix: close  upgrade dialog in shared dialog

### DIFF
--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -212,8 +212,8 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
       section: 'account',
       subsection: 'plans',
     });
-    setIsRestrictedPasswordDialogOpen(false);
-    setIsRestrictedSharingDialogOpen(false);
+    actionDispatch(setIsRestrictedPasswordDialogOpen(false));
+    actionDispatch(setIsRestrictedSharingDialogOpen(false));
     onClose();
     dispatch(uiActions.setIsPreferencesDialogOpen(true));
   };
@@ -318,7 +318,7 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
             isLoading={isLoading}
             onCopyLink={onCopyLink}
             changeAccess={changeAccess}
-            setShowStopSharingConfirmation={onOpenStopSharingDialog}
+            onOpenStopSharingDialog={onOpenStopSharingDialog}
           />
 
           <SharePasswordInputDialog

--- a/src/app/drive/components/ShareDialog/ShareDialog.tsx
+++ b/src/app/drive/components/ShareDialog/ShareDialog.tsx
@@ -330,7 +330,7 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
           <UpgradeDialog
             isDialogOpen={isRestrictedSharingDialogOpen}
             onAccept={onUpgradePlan}
-            onCloseDialog={() => setIsRestrictedSharingDialogOpen(false)}
+            onCloseDialog={() => actionDispatch(setIsRestrictedSharingDialogOpen(false))}
             title={translate('modals.restrictedSharingModal.title')}
             subtitle={translate('modals.restrictedSharingModal.subtitle')}
             primaryAction={translate('actions.upgrade')}
@@ -339,7 +339,7 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
           <UpgradeDialog
             isDialogOpen={isRestrictedPasswordDialogOpen}
             onAccept={onUpgradePlan}
-            onCloseDialog={() => setIsRestrictedPasswordDialogOpen(false)}
+            onCloseDialog={() => actionDispatch(setIsRestrictedPasswordDialogOpen(false))}
             title={translate('modals.restrictedPasswordModal.title')}
             subtitle={translate('modals.restrictedPasswordModal.subtitle')}
             primaryAction={translate('actions.upgrade')}
@@ -347,7 +347,7 @@ const ShareDialog = (props: ShareDialogProps): JSX.Element => {
           />
           <SharePasswordDisableDialog
             isOpen={openPasswordDisableDialog}
-            onClose={() => setOpenPasswordDisableDialog(false)}
+            onClose={() => actionDispatch(setOpenPasswordDisableDialog(false))}
             onConfirmHandler={onDisablePassword}
           />
 

--- a/src/app/drive/components/ShareDialog/components/GeneralView/UserRoleSelection.tsx
+++ b/src/app/drive/components/ShareDialog/components/GeneralView/UserRoleSelection.tsx
@@ -21,7 +21,7 @@ interface UserRoleSelectionProps {
   isStopSharingAvailable: boolean;
   onCopyLink: () => void;
   changeAccess: (accessMode: AccessMode) => void;
-  setShowStopSharingConfirmation: (show: boolean) => void;
+  onOpenStopSharingDialog: (show: boolean) => void;
 }
 
 export const UserRoleSelection = ({
@@ -33,7 +33,7 @@ export const UserRoleSelection = ({
   isRestrictedSharingAvailable,
   isStopSharingAvailable,
   onCopyLink,
-  setShowStopSharingConfirmation,
+  onOpenStopSharingDialog,
 }: UserRoleSelectionProps) => {
   const { translate } = useTranslationContext();
 
@@ -125,7 +125,7 @@ export const UserRoleSelection = ({
                       <button
                         className="flex h-11 w-full cursor-pointer items-center justify-start rounded-lg pl-14 pr-3 hover:bg-gray-5"
                         onClick={() => {
-                          setShowStopSharingConfirmation(true);
+                          onOpenStopSharingDialog(true);
                           close();
                         }}
                       >


### PR DESCRIPTION
## Description

Fixed a bug where the Upgrade Dialog did not close after being displayed when a user attempted to create a protected shared link that was unavailable for their current subscription tier.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [ ] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
