### PR TITLE
[MKT_928]:fix/ga services

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,10 @@
       gtag('js', new Date());
       gtag('config', '%REACT_APP_GA_ID%', { debug_mode: '%NODE_ENV%' === 'development' });
       gtag('config', '%REACT_APP_GA_BLOG_ID%', { debug_mode: '%NODE_ENV%' === 'development', groups: 'Blog' });
+      var adsAccountId = '%REACT_APP_GA_CONVERSION_TAG%'.split('/')[0];
+      if (adsAccountId.indexOf('AW-') === 0) {
+        gtag('config', adsAccountId, { allow_enhanced_conversions: true });
+      }
     </script>
 
     <!-- MailerLite Universal -->

--- a/src/app/analytics/ga.service.test.ts
+++ b/src/app/analytics/ga.service.test.ts
@@ -302,7 +302,7 @@ describe('Testing GA Service', () => {
         expect(event.ecommerce.transaction_id).toBe('sub_888');
       });
 
-      it('should fallback to user UUID when neither payment intent nor subscription ID are available', () => {
+      it('should build a unique transaction ID per purchase when payment identifiers are missing, so repeat purchases by the same user are not discarded as duplicates', () => {
         vi.mocked(localStorageService.getUser).mockReturnValue({ uuid: 'user_fallback_uuid' } as any);
         vi.mocked(localStorageService.get).mockImplementation((key) => {
           if (key === 'paymentIntentId') return null;
@@ -322,7 +322,7 @@ describe('Testing GA Service', () => {
         gaService.trackPurchase();
 
         const event = globalThis.window.dataLayer[0] as any;
-        expect(event.ecommerce.transaction_id).toBe('user_fallback_uuid');
+        expect(event.ecommerce.transaction_id).toMatch(/^user_fallback_uuid-\d+$/);
       });
 
       it('should set user email for Enhanced Conversions when available', () => {

--- a/src/app/analytics/ga.service.ts
+++ b/src/app/analytics/ga.service.ts
@@ -125,9 +125,9 @@ function trackBeginCheckout(params: TrackBeginCheckoutParams): void {
       ecommerce: ecommerceData,
     });
 
-    if (globalThis.window.gtag && SEND_TO.length > 0) {
+    if (globalThis.window.gtag && GA_ID) {
       globalThis.window.gtag('event', 'begin_checkout', {
-        send_to: SEND_TO,
+        send_to: [GA_ID],
         value: totalAmount,
         currency: currencyCode,
         items: [item],
@@ -174,7 +174,7 @@ function trackPurchase(): void {
       console.error('[GA Service] Error parsing checkout_item_data:', parseError);
     }
 
-    const transactionId = paymentIntentId || subscriptionId || uuid;
+    const transactionId = paymentIntentId || subscriptionId || `${uuid}-${Date.now()}`;
     const currencyCode = currency ?? 'EUR';
 
     const itemName = checkoutItemData?.item_name || 'Unknown Plan';


### PR DESCRIPTION
## Description
Purchases were not being tracked in Google Ads. This PR fixes the three issues that caused it:

- **`index.html`**: the Google Ads tag (`AW-XXXX`) was never configured with `gtag('config')`, so gtag silently dropped every event sent to the Ads destination, purchase conversions never left the browser. The account id is derived from`REACT_APP_GA_CONVERSION_TAG`.
- **`ga.service.ts`**: `begin_checkout` was sent with the Ads conversion label, so every checkout page view would be counted by Google Ads as a full-price purchase. It now goes to GA4 only.
- **`ga.service.ts`**: the `transaction_id` fallback used the user uuid, which repeats across purchases. Google Ads discards conversions with duplicated transaction ids, silently dropping repeat purchases. The fallback is now unique per purchase.

<!-- Provide a clear and concise summary of the changes. Include the reason and context, if applicable. -->

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process
After carrying out several local tests, I was able to confirm that the data is now being sent correctly and that Google is processing it correctly, as verified by the marketing team.
<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes
I need to update the value of a production env.variable and create it in the preview and i dont have permission to do that, so that I can simulate a final purchase.
<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
