### PR TITLE
[PB-6600]: cover the file upload tasks layer with tests

### DIFF
--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.test.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.test.ts
@@ -7,7 +7,7 @@ import {
 } from './uploadItemsThunk';
 import { RootState } from '../../..';
 import { prepareFilesToUpload } from '../fileUtils/prepareFilesToUpload';
-import { uploadFileWithManager } from '../../../../network/UploadManager';
+import { uploadFilesWithTasks } from 'app/tasks/upload/uploadFilesWithTasks';
 import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
 import RetryManager from 'app/network/RetryManager';
 import { ActionReducerMapBuilder } from '@reduxjs/toolkit';
@@ -68,8 +68,8 @@ vi.mock('../fileUtils/prepareFilesToUpload', () => ({
   prepareFilesToUpload: vi.fn(),
 }));
 
-vi.mock('../../../../network/UploadManager', () => ({
-  uploadFileWithManager: vi.fn(),
+vi.mock('app/tasks/upload/uploadFilesWithTasks', () => ({
+  uploadFilesWithTasks: vi.fn(),
 }));
 
 vi.mock('../../workspaces/workspaces.selectors', () => ({
@@ -113,7 +113,7 @@ describe('uploadItemsThunk', () => {
     })(dispatch, getState as () => RootState, {});
 
     expect(prepareFilesToUpload).toHaveBeenCalled();
-    expect(uploadFileWithManager).toHaveBeenCalled();
+    expect(uploadFilesWithTasks).toHaveBeenCalled();
   });
 
   it('should handle upload errors', async () => {
@@ -121,7 +121,7 @@ describe('uploadItemsThunk', () => {
       filesToUpload: [mockFile],
     });
     const notificationsServiceSpy = vi.spyOn(notificationsService, 'show');
-    (uploadFileWithManager as Mock).mockRejectedValue(new Error('Upload failed'));
+    (uploadFilesWithTasks as Mock).mockRejectedValue(new Error('Upload failed'));
 
     await uploadItemsThunk({
       files: [mockFile],
@@ -138,7 +138,7 @@ describe('uploadItemsThunk', () => {
     (prepareFilesToUpload as Mock).mockResolvedValue({
       filesToUpload: [mockFile],
     });
-    (uploadFileWithManager as Mock).mockRejectedValueOnce(new Error('Upload failed'));
+    (uploadFilesWithTasks as Mock).mockRejectedValueOnce(new Error('Upload failed'));
     const RetryChangeStatusSpy = vi.spyOn(RetryManager, 'changeStatus');
 
     await uploadItemsThunk({
@@ -160,7 +160,7 @@ describe('uploadItemsThunk', () => {
     (prepareFilesToUpload as Mock).mockResolvedValue({
       filesToUpload: [mockFile],
     });
-    (uploadFileWithManager as Mock).mockRejectedValue(randomError);
+    (uploadFilesWithTasks as Mock).mockRejectedValue(randomError);
 
     await uploadItemsThunk({
       files: [mockFile],
@@ -179,7 +179,7 @@ describe('uploadItemsThunk', () => {
     (prepareFilesToUpload as Mock).mockResolvedValue({
       filesToUpload: [mockFile],
     });
-    (uploadFileWithManager as Mock).mockResolvedValue(undefined);
+    (uploadFilesWithTasks as Mock).mockResolvedValue(undefined);
     (planSelectors.planLimitToShow as Mock).mockReturnValue(20);
     (planSelectors.planUsageToShow as Mock).mockReturnValue(12.1);
 
@@ -188,7 +188,7 @@ describe('uploadItemsThunk', () => {
       parentFolderId: 'parent1',
     })(dispatch, getState as () => RootState, {});
 
-    const { maxSpaceOccupiedCallback } = (uploadFileWithManager as Mock).mock.calls[0][0];
+    const { maxSpaceOccupiedCallback } = (uploadFilesWithTasks as Mock).mock.calls[0][0];
     maxSpaceOccupiedCallback();
 
     expect(dispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'ui/setOpenReachedPlanLimitDialog' }));
@@ -198,7 +198,7 @@ describe('uploadItemsThunk', () => {
     (prepareFilesToUpload as Mock).mockResolvedValue({
       filesToUpload: [mockFile],
     });
-    (uploadFileWithManager as Mock).mockResolvedValue(undefined);
+    (uploadFilesWithTasks as Mock).mockResolvedValue(undefined);
     (planSelectors.planLimitToShow as Mock).mockReturnValue(20);
     (planSelectors.planUsageToShow as Mock).mockReturnValue(12.1);
 
@@ -208,7 +208,7 @@ describe('uploadItemsThunk', () => {
     })(dispatch, getState as () => RootState, {});
 
     (planSelectors.planUsageToShow as Mock).mockReturnValue(20);
-    const { maxSpaceOccupiedCallback } = (uploadFileWithManager as Mock).mock.calls[0][0];
+    const { maxSpaceOccupiedCallback } = (uploadFilesWithTasks as Mock).mock.calls[0][0];
     maxSpaceOccupiedCallback();
 
     expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'ui/setOpenReachedPlanLimitDialog' }));
@@ -235,7 +235,7 @@ describe('upload shared items thunk', () => {
     const showNotificationSpy = vi.spyOn(notificationsService, 'show');
     (workspacesSelectors.getSelectedWorkspace as Mock).mockReturnValue(null);
     (shareService.getSharedFolderContent as Mock).mockResolvedValue({ items: [] });
-    (uploadFileWithManager as Mock).mockRejectedValue(randomError);
+    (uploadFilesWithTasks as Mock).mockRejectedValue(randomError);
 
     await uploadSharedItemsThunk({
       files: [mockFile],
@@ -272,7 +272,7 @@ describe('Upload items in parallel thunk', () => {
     (prepareFilesToUpload as Mock).mockResolvedValue({
       filesToUpload: [mockFile],
     });
-    (uploadFileWithManager as Mock).mockRejectedValue(randomError);
+    (uploadFilesWithTasks as Mock).mockRejectedValue(randomError);
 
     await uploadItemsParallelThunk({
       files: [mockFile],
@@ -300,7 +300,7 @@ describe('Upload items in parallel thunk', () => {
     })(dispatch, getStateWithLimit as () => RootState, {});
 
     expect(prepareFilesToUpload).not.toHaveBeenCalled();
-    expect(uploadFileWithManager).not.toHaveBeenCalled();
+    expect(uploadFilesWithTasks).not.toHaveBeenCalled();
   });
 
   test('When some files exceed the size limit and some do not, then only the allowed files are uploaded', async () => {

--- a/src/app/tasks/upload/uploadFilesWithTasks.test.ts
+++ b/src/app/tasks/upload/uploadFilesWithTasks.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { beforeEach, describe, expect, Mock, test, vi } from 'vitest';
 import tasksService from 'app/tasks/services/tasks.service';
 import { TaskEvent, TaskStatus } from 'app/tasks/types';
 import referralService from 'services/referral.service';
@@ -68,7 +68,7 @@ describe('uploadFilesWithTasks', () => {
     vi.clearAllMocks();
   });
 
-  it('When a new file upload begins, then a task is created to track it', async () => {
+  test('When a new file upload begins, then a task is created to track it', async () => {
     (tasksService.create as Mock).mockReturnValue('new-task-id');
 
     const { managerProps } = await runUpload([buildFile()]);
@@ -84,7 +84,7 @@ describe('uploadFilesWithTasks', () => {
     expect(managerProps.files).toEqual([expect.objectContaining({ taskId: 'new-task-id' })]);
   });
 
-  it('When an upload is retried, then its existing task resumes instead of creating a new one', async () => {
+  test('When an upload is retried, then its existing task resumes instead of creating a new one', async () => {
     const { managerProps } = await runUpload([buildFile({ taskId: 'existing-task' })]);
 
     expect(tasksService.create).not.toHaveBeenCalled();
@@ -95,7 +95,7 @@ describe('uploadFilesWithTasks', () => {
     expect(managerProps.options.isRetriedUpload).toBe(true);
   });
 
-  it('When files from a folder upload begin, then the folder task shows as in progress', async () => {
+  test('When files from a folder upload begin, then the folder task shows as in progress', async () => {
     (tasksService.create as Mock).mockReturnValue('t1');
     (uploadRepository.getUploadState as Mock).mockResolvedValueOnce(undefined);
 
@@ -107,7 +107,7 @@ describe('uploadFilesWithTasks', () => {
     });
   });
 
-  it('When the folder task is paused, then it does not resume by itself', async () => {
+  test('When the folder task is paused, then it does not resume by itself', async () => {
     (tasksService.create as Mock).mockReturnValue('t1');
     (uploadRepository.getUploadState as Mock).mockResolvedValueOnce(TaskStatus.Paused);
 
@@ -119,7 +119,7 @@ describe('uploadFilesWithTasks', () => {
     });
   });
 
-  it('When a file upload starts, then its task shows it is being prepared and becomes stoppable', async () => {
+  test('When a file upload starts, then its task shows it is being prepared and becomes stoppable', async () => {
     (tasksService.create as Mock).mockReturnValue('t1');
     const { events, managerProps } = await runUpload([buildFile()]);
     const stop = vi.fn();
@@ -132,7 +132,7 @@ describe('uploadFilesWithTasks', () => {
     });
   });
 
-  it('When an upload attempt begins, then only files uploaded outside a folder show as in progress', async () => {
+  test('When an upload attempt begins, then only files uploaded outside a folder show as in progress', async () => {
     (tasksService.create as Mock).mockReturnValue('t1');
     const { events, managerProps } = await runUpload([buildFile()]);
 
@@ -144,7 +144,7 @@ describe('uploadFilesWithTasks', () => {
     expect(tasksService.updateTask).not.toHaveBeenCalled();
   });
 
-  it('When an upload advances, then the task progress updates unless the task is paused or cancelled', async () => {
+  test('When an upload advances, then the task progress updates unless the task is paused or cancelled', async () => {
     (tasksService.create as Mock).mockReturnValue('t1');
     const { events, managerProps } = await runUpload([buildFile()]);
 
@@ -162,7 +162,7 @@ describe('uploadFilesWithTasks', () => {
     expect(tasksService.updateTask).not.toHaveBeenCalled();
   });
 
-  it('When a file finishes uploading, then its task succeeds and the upload is tracked', async () => {
+  test('When a file finishes uploading, then its task succeeds and the upload is tracked', async () => {
     (tasksService.create as Mock).mockReturnValue('t1');
     const { events, managerProps } = await runUpload([buildFile()]);
 
@@ -176,7 +176,7 @@ describe('uploadFilesWithTasks', () => {
     expect(networkInformation.logNetworkInfoForUpload).toHaveBeenCalledWith({ fileName: 'file.txt', fileSize: 1024 });
   });
 
-  it('When a file inside a folder finishes uploading, then the folder progress advances', async () => {
+  test('When a file inside a folder finishes uploading, then the folder progress advances', async () => {
     (tasksService.create as Mock).mockReturnValue('t1');
     const relatedTaskProgress = { filesUploaded: 0, totalFilesToUpload: 4 };
     const { events, managerProps } = await runUpload([buildFile({ relatedTaskId: 'related-task' })], {
@@ -192,7 +192,7 @@ describe('uploadFilesWithTasks', () => {
     });
   });
 
-  it('When an upload fails, then the task shows an error message matching the cause', async () => {
+  test('When an upload fails, then the task shows an error message matching the cause', async () => {
     (tasksService.create as Mock).mockReturnValue('t1');
     const { events, managerProps } = await runUpload([buildFile()]);
 
@@ -212,7 +212,7 @@ describe('uploadFilesWithTasks', () => {
     expect(tasksService.updateTask).toHaveBeenCalledWith({ taskId: 't1', merge: { status: TaskStatus.Error } });
   });
 
-  it('When an upload is aborted, then its task shows as cancelled', async () => {
+  test('When an upload is aborted, then its task shows as cancelled', async () => {
     (tasksService.create as Mock).mockReturnValue('t1');
     const { events, managerProps } = await runUpload([buildFile()]);
 
@@ -221,7 +221,7 @@ describe('uploadFilesWithTasks', () => {
     expect(tasksService.updateTask).toHaveBeenCalledWith({ taskId: 't1', merge: { status: TaskStatus.Cancelled } });
   });
 
-  it('When a task is cancelled by the user, then only that upload is stopped', async () => {
+  test('When a task is cancelled by the user, then only that upload is stopped', async () => {
     (tasksService.create as Mock).mockReturnValue('t1');
     let registeredListener: ((task: { id: string }) => void) | undefined;
     (tasksService.addListener as Mock).mockImplementation(({ listener }) => {

--- a/src/app/tasks/upload/uploadFilesWithTasks.test.ts
+++ b/src/app/tasks/upload/uploadFilesWithTasks.test.ts
@@ -1,0 +1,247 @@
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import tasksService from 'app/tasks/services/tasks.service';
+import { TaskEvent, TaskStatus } from 'app/tasks/types';
+import referralService from 'services/referral.service';
+import * as networkInformation from 'app/network/networkInformation';
+import { uploadFileWithManager, UploadManagerEvents } from 'app/network/UploadManager';
+import { PersistUploadRepository } from 'app/repositories/DatabaseUploadRepository';
+import { uploadFilesWithTasks } from './uploadFilesWithTasks';
+
+vi.mock('app/network/UploadManager', () => ({
+  uploadFileWithManager: vi.fn(() => Promise.resolve({ uploadedFiles: [] })),
+}));
+
+vi.mock('app/tasks/services/tasks.service', () => ({
+  default: {
+    create: vi.fn(),
+    updateTask: vi.fn(),
+    findTask: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  },
+}));
+
+vi.mock('i18next', () => ({ t: (key: string) => key }));
+
+vi.mock('services/referral.service', () => ({
+  default: {
+    trackFileUpload: vi.fn(),
+  },
+}));
+
+vi.mock('app/network/networkInformation', () => ({
+  logNetworkInfoForUpload: vi.fn(),
+}));
+
+const buildFile = (overrides: Record<string, unknown> = {}) => ({
+  filecontent: {
+    content: 'content' as unknown as File,
+    type: 'text/plain',
+    name: 'file.txt',
+    size: 1024,
+    parentFolderId: 'folder',
+  },
+  userEmail: '',
+  parentFolderId: 'folder',
+  ...overrides,
+});
+
+const uploadRepository = {
+  getUploadState: vi.fn(),
+  setUploadState: vi.fn(),
+  removeUploadState: vi.fn(),
+} as unknown as PersistUploadRepository;
+
+const runUpload = async (files: ReturnType<typeof buildFile>[], props: Record<string, unknown> = {}) => {
+  await uploadFilesWithTasks({
+    files,
+    maxSpaceOccupiedCallback: vi.fn(),
+    uploadRepository,
+    ...props,
+  });
+  const managerProps = (uploadFileWithManager as Mock).mock.calls[0][0];
+  return { managerProps, events: managerProps.events as UploadManagerEvents };
+};
+
+describe('uploadFilesWithTasks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('When a new file upload begins, then a task is created to track it', async () => {
+    (tasksService.create as Mock).mockReturnValue('new-task-id');
+
+    const { managerProps } = await runUpload([buildFile()]);
+
+    expect(tasksService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileName: 'file.txt',
+        fileType: 'text/plain',
+        showNotification: true,
+        cancellable: true,
+      }),
+    );
+    expect(managerProps.files).toEqual([expect.objectContaining({ taskId: 'new-task-id' })]);
+  });
+
+  it('When an upload is retried, then its existing task resumes instead of creating a new one', async () => {
+    const { managerProps } = await runUpload([buildFile({ taskId: 'existing-task' })]);
+
+    expect(tasksService.create).not.toHaveBeenCalled();
+    expect(tasksService.updateTask).toHaveBeenCalledWith({
+      taskId: 'existing-task',
+      merge: { status: TaskStatus.Encrypting },
+    });
+    expect(managerProps.options.isRetriedUpload).toBe(true);
+  });
+
+  it('When files from a folder upload begin, then the folder task shows as in progress', async () => {
+    (tasksService.create as Mock).mockReturnValue('t1');
+    (uploadRepository.getUploadState as Mock).mockResolvedValueOnce(undefined);
+
+    await runUpload([buildFile({ relatedTaskId: 'related-task' })]);
+
+    expect(tasksService.updateTask).toHaveBeenCalledWith({
+      taskId: 'related-task',
+      merge: { status: TaskStatus.InProcess },
+    });
+  });
+
+  it('When the folder task is paused, then it does not resume by itself', async () => {
+    (tasksService.create as Mock).mockReturnValue('t1');
+    (uploadRepository.getUploadState as Mock).mockResolvedValueOnce(TaskStatus.Paused);
+
+    await runUpload([buildFile({ relatedTaskId: 'related-task' })]);
+
+    expect(tasksService.updateTask).not.toHaveBeenCalledWith({
+      taskId: 'related-task',
+      merge: { status: TaskStatus.InProcess },
+    });
+  });
+
+  it('When a file upload starts, then its task shows it is being prepared and becomes stoppable', async () => {
+    (tasksService.create as Mock).mockReturnValue('t1');
+    const { events, managerProps } = await runUpload([buildFile()]);
+    const stop = vi.fn();
+
+    events.onUploadStart?.(managerProps.files[0], stop);
+
+    expect(tasksService.updateTask).toHaveBeenCalledWith({
+      taskId: 't1',
+      merge: { status: TaskStatus.Encrypting, stop },
+    });
+  });
+
+  it('When an upload attempt begins, then only files uploaded outside a folder show as in progress', async () => {
+    (tasksService.create as Mock).mockReturnValue('t1');
+    const { events, managerProps } = await runUpload([buildFile()]);
+
+    events.onUploadAttempt?.(managerProps.files[0]);
+    expect(tasksService.updateTask).toHaveBeenCalledWith({ taskId: 't1', merge: { status: TaskStatus.InProcess } });
+
+    (tasksService.updateTask as Mock).mockClear();
+    events.onUploadAttempt?.({ ...managerProps.files[0], relatedTaskId: 'related' });
+    expect(tasksService.updateTask).not.toHaveBeenCalled();
+  });
+
+  it('When an upload advances, then the task progress updates unless the task is paused or cancelled', async () => {
+    (tasksService.create as Mock).mockReturnValue('t1');
+    const { events, managerProps } = await runUpload([buildFile()]);
+
+    (tasksService.findTask as Mock).mockReturnValue({ status: TaskStatus.InProcess });
+    events.onUploadProgress?.(managerProps.files[0], 0.5);
+    expect(tasksService.updateTask).toHaveBeenCalledWith({ taskId: 't1', merge: { progress: 0.5 } });
+
+    (tasksService.updateTask as Mock).mockClear();
+    (tasksService.findTask as Mock).mockReturnValue({ status: TaskStatus.Paused });
+    events.onUploadProgress?.(managerProps.files[0], 0.6);
+    expect(tasksService.updateTask).not.toHaveBeenCalled();
+
+    (tasksService.findTask as Mock).mockReturnValue({ status: TaskStatus.Cancelled });
+    events.onUploadProgress?.(managerProps.files[0], 0.7);
+    expect(tasksService.updateTask).not.toHaveBeenCalled();
+  });
+
+  it('When a file finishes uploading, then its task succeeds and the upload is tracked', async () => {
+    (tasksService.create as Mock).mockReturnValue('t1');
+    const { events, managerProps } = await runUpload([buildFile()]);
+
+    await events.onUploadSuccess?.(managerProps.files[0], { uuid: 'file-uuid' } as never);
+
+    expect(tasksService.updateTask).toHaveBeenCalledWith({
+      taskId: 't1',
+      merge: { status: TaskStatus.Success, itemUUID: { fileUUID: 'file-uuid' } },
+    });
+    expect(referralService.trackFileUpload).toHaveBeenCalledOnce();
+    expect(networkInformation.logNetworkInfoForUpload).toHaveBeenCalledWith({ fileName: 'file.txt', fileSize: 1024 });
+  });
+
+  it('When a file inside a folder finishes uploading, then the folder progress advances', async () => {
+    (tasksService.create as Mock).mockReturnValue('t1');
+    const relatedTaskProgress = { filesUploaded: 0, totalFilesToUpload: 4 };
+    const { events, managerProps } = await runUpload([buildFile({ relatedTaskId: 'related-task' })], {
+      relatedTaskProgress,
+    });
+
+    await events.onUploadSuccess?.(managerProps.files[0], { uuid: 'file-uuid' } as never);
+
+    expect(relatedTaskProgress.filesUploaded).toBe(1);
+    expect(tasksService.updateTask).toHaveBeenCalledWith({
+      taskId: 'related-task',
+      merge: { progress: 0.25 },
+    });
+  });
+
+  it('When an upload fails, then the task shows an error message matching the cause', async () => {
+    (tasksService.create as Mock).mockReturnValue('t1');
+    const { events, managerProps } = await runUpload([buildFile()]);
+
+    events.onUploadError?.(managerProps.files[0], 'connection-lost');
+    expect(tasksService.updateTask).toHaveBeenCalledWith({
+      taskId: 't1',
+      merge: { status: TaskStatus.Error, subtitle: 'error.connectionLostError' },
+    });
+
+    events.onUploadError?.(managerProps.files[0], 'upload-failed');
+    expect(tasksService.updateTask).toHaveBeenCalledWith({
+      taskId: 't1',
+      merge: { status: TaskStatus.Error, subtitle: 'tasks.subtitles.upload-failed' },
+    });
+
+    events.onUploadError?.(managerProps.files[0]);
+    expect(tasksService.updateTask).toHaveBeenCalledWith({ taskId: 't1', merge: { status: TaskStatus.Error } });
+  });
+
+  it('When an upload is aborted, then its task shows as cancelled', async () => {
+    (tasksService.create as Mock).mockReturnValue('t1');
+    const { events, managerProps } = await runUpload([buildFile()]);
+
+    events.onUploadAborted?.(managerProps.files[0]);
+
+    expect(tasksService.updateTask).toHaveBeenCalledWith({ taskId: 't1', merge: { status: TaskStatus.Cancelled } });
+  });
+
+  it('When a task is cancelled by the user, then only that upload is stopped', async () => {
+    (tasksService.create as Mock).mockReturnValue('t1');
+    let registeredListener: ((task: { id: string }) => void) | undefined;
+    (tasksService.addListener as Mock).mockImplementation(({ listener }) => {
+      registeredListener = listener;
+    });
+
+    const { events, managerProps } = await runUpload([buildFile()]);
+    const abort = vi.fn();
+    const unsubscribe = events.registerUploadAbort?.(managerProps.files[0], abort);
+
+    registeredListener?.({ id: 'other-task' });
+    expect(abort).not.toHaveBeenCalled();
+
+    registeredListener?.({ id: 't1' });
+    expect(abort).toHaveBeenCalledOnce();
+
+    unsubscribe?.();
+    expect(tasksService.removeListener).toHaveBeenCalledWith({
+      event: TaskEvent.TaskCancelled,
+      listener: registeredListener,
+    });
+  });
+});


### PR DESCRIPTION
## Description

- Adds the test suite for `uploadFilesWithTasks` (task creation and resume,
  status transitions, progress gating while paused/cancelled, folder progress,
  error subtitles, cancellation wiring).
- Points `uploadItemsThunk` tests at `uploadFilesWithTasks` instead of the
  upload manager, fixing the suite broken by the previous PR.
## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
