### PR TITLE
[PB-6600]: decouple folder upload manager from task tracking

### DIFF
--- a/src/app/drive/components/NameCollisionDialog/NameCollisionContainer.tsx
+++ b/src/app/drive/components/NameCollisionDialog/NameCollisionContainer.tsx
@@ -10,7 +10,7 @@ import { uiActions } from 'app/store/slices/ui';
 import { DriveItemData } from 'app/drive/types';
 import { IRoot } from 'app/store/slices/storage/types';
 import workspacesSelectors from 'app/store/slices/workspaces/workspaces.selectors';
-import { uploadFoldersWithManager } from 'app/network/UploadFolderManager';
+import { uploadFoldersWithTracking } from 'app/drive/services/folder.service/uploadFoldersWithTracking';
 import replaceFileService from 'views/Drive/services/replaceFile.service';
 import { Network, getEnvironmentConfig } from 'app/drive/services/network.service';
 import { fileVersionsActions, fileVersionsSelectors } from 'app/store/slices/fileVersions';
@@ -106,7 +106,7 @@ const NameCollisionContainer: FC = () => {
 
       if ((itemToUpload as IRoot).fullPathEdited) {
         await moveItemsToTrash([itemToReplace]);
-        await uploadFoldersWithManager({
+        await uploadFoldersWithTracking({
           payload: [{ root: { ...(itemToUpload as IRoot) }, currentFolderId: group.destinationUuid }],
           selectedWorkspace,
           dispatch,
@@ -136,7 +136,7 @@ const NameCollisionContainer: FC = () => {
   const keepAndUploadItem = async (group: CollisionGroup) => {
     for (const itemToUpload of group.duplicatedItems as (IRoot | File)[]) {
       if ((itemToUpload as IRoot).fullPathEdited) {
-        await uploadFoldersWithManager({
+        await uploadFoldersWithTracking({
           payload: [{ root: { ...(itemToUpload as IRoot) }, currentFolderId: group.destinationUuid }],
           selectedWorkspace,
           dispatch,

--- a/src/app/drive/services/folder.service/uploadFoldersWithTracking.ts
+++ b/src/app/drive/services/folder.service/uploadFoldersWithTracking.ts
@@ -1,0 +1,26 @@
+import { uiActions } from 'app/store/slices/ui';
+import { planThunks } from 'app/store/slices/plan';
+import { uploadFoldersWithTasks } from 'app/tasks/upload/uploadFoldersWithTasks';
+
+type UploadFoldersWithTasksProps = Parameters<typeof uploadFoldersWithTasks>[0];
+type UploadFoldersWithTrackingProps = Omit<
+  UploadFoldersWithTasksProps,
+  'fileSizeExceededCallback' | 'onFolderUploadSucceeded'
+>;
+
+export const uploadFoldersWithTracking = (props: UploadFoldersWithTrackingProps): Promise<void> => {
+  const { dispatch, selectedWorkspace } = props;
+  const memberId = selectedWorkspace?.workspaceUser?.memberId;
+
+  return uploadFoldersWithTasks({
+    ...props,
+    fileSizeExceededCallback: (exceededFiles) =>
+      dispatch(uiActions.setOpenFileSizeLimitReachedDialog({ open: true, info: { exceededFiles } })),
+    onFolderUploadSucceeded: () => {
+      setTimeout(() => {
+        dispatch(planThunks.fetchUsageThunk());
+        if (memberId) dispatch(planThunks.fetchBusinessLimitUsageThunk());
+      }, 1000);
+    },
+  });
+};

--- a/src/app/network/UploadFolderManager.test.ts
+++ b/src/app/network/UploadFolderManager.test.ts
@@ -394,8 +394,13 @@ describe('checkUploadFolders', () => {
     };
 
     const buildManager = (maxUploadFileSize?: number) => {
-      const manager = new UploadFoldersManager([], null, mockDispatch, maxUploadFileSize ?? 100);
-      manager['tasksInfo'][taskId] = { progress: { itemsUploaded: 0, totalItems: 1 } };
+      const manager = new UploadFoldersManager({
+        payload: [],
+        selectedWorkspace: null,
+        dispatch: mockDispatch,
+        maxUploadFileSize: maxUploadFileSize ?? 100,
+      });
+      manager['tasksInfo'][taskId] = { cancelled: false, progress: { itemsUploaded: 0, totalItems: 1 } };
       return manager;
     };
 
@@ -415,8 +420,13 @@ describe('checkUploadFolders', () => {
       const bigFile = new File([new ArrayBuffer(200)], 'big.mp4');
       const dispatchWithUnwrap = vi.fn().mockReturnValue({ unwrap: () => Promise.resolve() });
       vi.spyOn(tasksService, 'updateTask').mockReturnValue();
-      const manager = new UploadFoldersManager([], null, dispatchWithUnwrap, 100);
-      manager['tasksInfo'][taskId] = { progress: { itemsUploaded: 0, totalItems: 1 } };
+      const manager = new UploadFoldersManager({
+        payload: [],
+        selectedWorkspace: null,
+        dispatch: dispatchWithUnwrap,
+        maxUploadFileSize: 100,
+      });
+      manager['tasksInfo'][taskId] = { cancelled: false, progress: { itemsUploaded: 0, totalItems: 1 } };
       const level = {
         childrenFiles: [bigFile],
         childrenFolders: [{ folderId: 'c', childrenFiles: [], childrenFolders: [], name: 'Child', fullPathEdited: '' }],
@@ -476,11 +486,14 @@ describe('checkUploadFolders', () => {
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     };
-    const payload = [];
-    const selectedWorkspace = null;
     const taskId = 'task-id';
 
-    const manager = new UploadFoldersManager(payload, selectedWorkspace, mockDispatch, 100);
+    const manager = new UploadFoldersManager({
+      payload: [],
+      selectedWorkspace: null,
+      dispatch: mockDispatch,
+      maxUploadFileSize: 100,
+    });
     const abortController = new AbortController();
 
     const taskFolder: TaskFolder = {
@@ -517,6 +530,7 @@ describe('checkUploadFolders', () => {
     const renameFolderSpy = (getUniqueFolderName as Mock).mockResolvedValueOnce('');
 
     manager['tasksInfo'][taskId] = {
+      cancelled: false,
       progress: {
         itemsUploaded: 0,
         totalItems: 2,

--- a/src/app/network/UploadFolderManager.ts
+++ b/src/app/network/UploadFolderManager.ts
@@ -1,44 +1,56 @@
 import { WorkspaceData } from '@internxt/sdk/dist/workspaces';
 import { AnyAction, ThunkDispatch } from '@reduxjs/toolkit';
 import { queue, QueueObject } from 'async';
-import { t } from 'i18next';
 import errorService from 'services/error.service';
 import newStorageService from 'app/drive/services/new-storage.service';
 import { DriveFolderData, DriveItemData } from 'app/drive/types';
 import { RootState } from '../store';
-import { planThunks } from '../store/slices/plan';
 import { checkFolderDuplicated } from '../store/slices/storage/folderUtils/checkFolderDuplicated';
 import { createFolder } from '../store/slices/storage/folderUtils/createFolder';
 import { getUniqueFolderName } from '../store/slices/storage/folderUtils/getUniqueFolderName';
 import { deleteItemsThunk } from '../store/slices/storage/storage.thunks/deleteItemsThunk';
 import { uploadItemsParallelThunk } from '../store/slices/storage/storage.thunks/uploadItemsThunk';
 import { IRoot } from '../store/slices/storage/types';
-import tasksService from '../tasks/services/tasks.service';
-import { TaskData, TaskEvent, TaskStatus, TaskType, UploadFolderTask } from '../tasks/types';
 import { QueueUtilsService } from 'utils/queueUtils';
 import { wait } from 'utils/timeUtils';
 import { ConnectionLostError } from './requests';
-import referralService from 'services/referral.service';
-import { logNetworkInfoForUpload } from './networkInformation';
-import { uiActions } from 'app/store/slices/ui';
 import { FilesExceedsSizeLimitError } from 'app/drive/services/file.service/upload.errors';
 import { filterFilesByMaxSize } from 'app/store/slices/storage/fileUtils/filterFilesByMaxSize';
+import { UploadErrorReason } from './types';
 
-interface UploadFolderPayload {
+export interface UploadFolderPayload {
   root: IRoot;
   currentFolderId: string;
-  options?: {
-    taskId?: string;
-    withNotification?: boolean;
+  options: {
+    taskId: string;
     onSuccess?: () => void;
   };
+}
+
+export interface FolderUploadControls {
+  cancelUpload: () => void;
+  pauseUpload: () => void;
+  resumeUpload: () => void;
+}
+
+/**
+ * Upload progress notifications emitted by the manager. The manager knows nothing
+ * about how uploads are presented to the user; observers subscribe to these events.
+ * `onFolderUploadStarted` may return a cleanup function, invoked when that folder's
+ * upload finishes (successfully or not).
+ */
+export interface UploadFolderManagerEvents {
+  onFolderUploadStarted?: (taskId: string, root: IRoot, controls: FolderUploadControls) => (() => void) | void;
+  onFolderUploadProgress?: (taskId: string, progress: number, stopUpload: () => Promise<void>) => void;
+  onFolderUploadSuccess?: (taskId: string, info: { folderName: string; rootFolderUUID?: string }) => void;
+  onFolderUploadError?: (taskId: string, reason?: UploadErrorReason) => void;
+  stopRelatedUploads?: (taskId: string) => Promise<void>[];
 }
 
 export interface TaskFolder {
   root: IRoot;
   currentFolderId: string;
   options?: {
-    withNotification?: boolean;
     onSuccess?: () => void;
   };
   taskId: string;
@@ -47,50 +59,35 @@ export interface TaskFolder {
 
 interface TaskInfo {
   rootFolderItem?: DriveFolderData;
+  cancelled: boolean;
   progress: {
     itemsUploaded: number;
     totalItems: number;
   };
 }
 
-const generateTaskIdForFolders = async (foldersPayload: UploadFolderPayload[]): Promise<TaskFolder[]> => {
+interface UploadFoldersWithManagerProps {
+  payload: UploadFolderPayload[];
+  selectedWorkspace: WorkspaceData | null;
+  dispatch: ThunkDispatch<RootState, unknown, AnyAction>;
+  maxUploadFileSize: number;
+  fileSizeExceededCallback?: (exceededFiles: File[]) => void;
+  events?: UploadFolderManagerEvents;
+}
+
+const prepareTaskFolders = async (foldersPayload: UploadFolderPayload[]): Promise<TaskFolder[]> => {
   const taskFolders: TaskFolder[] = [];
 
   for (const folder of foldersPayload) {
-    const { root: originalRoot, currentFolderId, options: payloadOptions } = folder;
-    const options = { withNotification: true, ...payloadOptions };
+    const { root: originalRoot, currentFolderId, options } = folder;
     const root = await handleFoldersRename(originalRoot, currentFolderId);
-
-    const uploadFolderAbortController = new AbortController();
-
-    let taskId = options?.taskId;
-
-    if (taskId) {
-      tasksService.updateTask({
-        taskId,
-        merge: {
-          folderName: root.name,
-          status: TaskStatus.InProcess,
-          progress: 0,
-        },
-      });
-    } else {
-      taskId = tasksService.create<UploadFolderTask>({
-        action: TaskType.UploadFolder,
-        folderName: root.name,
-        item: root,
-        parentFolderId: currentFolderId,
-        showNotification: !!options.withNotification,
-        cancellable: true,
-      });
-    }
 
     taskFolders.push({
       root,
       currentFolderId,
-      options: payloadOptions,
-      taskId,
-      abortController: uploadFolderAbortController,
+      options,
+      taskId: options.taskId,
+      abortController: new AbortController(),
     });
   }
   return taskFolders;
@@ -130,20 +127,8 @@ const handleFoldersRename = async (root: IRoot, currentFolderId: string) => {
   return folder;
 };
 
-export const uploadFoldersWithManager = ({
-  payload,
-  selectedWorkspace,
-  dispatch,
-  maxUploadFileSize,
-}: {
-  payload: UploadFolderPayload[];
-  selectedWorkspace: WorkspaceData | null;
-  dispatch: ThunkDispatch<RootState, unknown, AnyAction>;
-  maxUploadFileSize: number;
-}): Promise<void> => {
-  const uploadFoldersManager = new UploadFoldersManager(payload, selectedWorkspace, dispatch, maxUploadFileSize);
-  return uploadFoldersManager.run();
-};
+export const uploadFoldersWithManager = (props: UploadFoldersWithManagerProps): Promise<void> =>
+  new UploadFoldersManager(props).run();
 
 export class UploadFoldersManager {
   private static readonly MAX_CONCURRENT_UPLOADS = 6;
@@ -154,19 +139,18 @@ export class UploadFoldersManager {
   private readonly dispatch: ThunkDispatch<RootState, unknown, AnyAction>;
   private readonly abortController?: AbortController;
   private readonly maxUploadFileSize: number;
+  private readonly fileSizeExceededCallback?: (exceededFiles: File[]) => void;
+  private readonly events?: UploadFolderManagerEvents;
 
-  private tasksInfo: Record<string, TaskInfo> = {};
+  private readonly tasksInfo: Record<string, TaskInfo> = {};
 
-  constructor(
-    payload: UploadFolderPayload[],
-    selectedWorkspace: WorkspaceData | null,
-    dispatch: ThunkDispatch<RootState, unknown, AnyAction>,
-    maxUploadFileSize: number,
-  ) {
-    this.payload = payload;
-    this.selectedWorkspace = selectedWorkspace;
-    this.dispatch = dispatch;
-    this.maxUploadFileSize = maxUploadFileSize;
+  constructor(props: UploadFoldersWithManagerProps) {
+    this.payload = props.payload;
+    this.selectedWorkspace = props.selectedWorkspace;
+    this.dispatch = props.dispatch;
+    this.maxUploadFileSize = props.maxUploadFileSize;
+    this.fileSizeExceededCallback = props.fileSizeExceededCallback;
+    this.events = props.events;
   }
 
   private readonly uploadFoldersQueue: QueueObject<TaskFolder> = queue<TaskFolder>(
@@ -228,13 +212,11 @@ export class UploadFoldersManager {
 
   private readonly updateTaskProgress = (taskId: string, abortController: AbortController): void => {
     this.tasksInfo[taskId].progress.itemsUploaded += 1;
-    tasksService.updateTask({
+    this.events?.onFolderUploadProgress?.(
       taskId,
-      merge: {
-        progress: this.tasksInfo[taskId].progress.itemsUploaded / this.tasksInfo[taskId].progress.totalItems,
-        stop: () => this.stopUploadTask(taskId, abortController),
-      },
-    });
+      this.tasksInfo[taskId].progress.itemsUploaded / this.tasksInfo[taskId].progress.totalItems,
+      () => this.stopUploadTask(taskId, abortController),
+    );
   };
 
   private readonly handleFileUploads = async (
@@ -258,9 +240,7 @@ export class UploadFoldersManager {
       await this.stopUploadTask(taskId, abortController);
       this.killQueueAndNotifyError(taskId);
 
-      this.dispatch(
-        uiActions.setOpenFileSizeLimitReachedDialog({ open: true, info: { exceededFiles: level.childrenFiles } }),
-      );
+      this.fileSizeExceededCallback?.(level.childrenFiles);
       throw new FilesExceedsSizeLimitError();
     }
 
@@ -330,13 +310,10 @@ export class UploadFoldersManager {
 
   private readonly stopUploadTask = async (taskId: string, uploadFolderAbortController: AbortController) => {
     uploadFolderAbortController.abort();
-    const relatedTasks = tasksService.getTasks({ relatedTaskId: taskId });
     const promises: Promise<void>[] = [];
 
-    // Cancels related tasks
-    promises.push(
-      ...(relatedTasks.map((task) => task.stop?.()).filter((promise) => promise !== undefined) as Promise<void>[]),
-    );
+    // Cancels uploads spawned by this folder upload (e.g. its file uploads)
+    promises.push(...(this.events?.stopRelatedUploads?.(taskId) ?? []));
     // Deletes the root folder
     const rootFolderItem = this.tasksInfo[taskId].rootFolderItem;
     if (rootFolderItem) {
@@ -350,19 +327,11 @@ export class UploadFoldersManager {
 
   private readonly killQueueAndNotifyError = (taskId: string) => {
     this.uploadFoldersQueue.kill();
-    tasksService.updateTask({
-      taskId: taskId,
-      merge: {
-        status: TaskStatus.Error,
-        subtitle: t('tasks.subtitles.upload-failed') as string,
-      },
-    });
+    this.events?.onFolderUploadError?.(taskId, 'upload-failed');
   };
 
   public readonly run = async (): Promise<void> => {
-    const payloadWithTaskId = await generateTaskIdForFolders(this.payload);
-
-    const memberId = this.selectedWorkspace?.workspaceUser?.memberId;
+    const taskFolders = await prepareTaskFolders(this.payload);
 
     const context = typeof window === 'undefined' ? self : window;
 
@@ -374,43 +343,25 @@ export class UploadFoldersManager {
     }
     context.addEventListener('offline', connectionLostListener);
 
-    for (const taskFolder of payloadWithTaskId) {
-      const { root, currentFolderId, options: payloadOptions, taskId } = taskFolder;
-      const options = { withNotification: true, ...payloadOptions };
+    for (const taskFolder of taskFolders) {
+      const { root, currentFolderId, options, taskId } = taskFolder;
 
       this.tasksInfo[taskId] = {
+        cancelled: false,
         progress: {
           itemsUploaded: 0,
           totalItems: countItemsUnderRoot(root),
         },
       };
 
-      tasksService.updateTask({
-        taskId,
-        merge: {
-          status: TaskStatus.InProcess,
-          progress: 0,
-        },
-      });
-
-      const cancelQueueListener = (task?: TaskData) => {
-        const isCurrentTask = task && task.id === taskId;
-        if (isCurrentTask && task.status === TaskStatus.Cancelled) {
+      const cleanupStartedEvent = this.events?.onFolderUploadStarted?.(taskId, root, {
+        cancelUpload: () => {
+          this.tasksInfo[taskId].cancelled = true;
           this.uploadFoldersQueue.kill();
-        }
-      };
-
-      const updateQueueListener = (task?: TaskData) => {
-        const isCurrentTask = task && task.id === taskId;
-        if (isCurrentTask && task.status === TaskStatus.InProcess) {
-          this.uploadFoldersQueue.resume();
-        } else if (isCurrentTask && task.status === TaskStatus.Paused) {
-          this.uploadFoldersQueue.pause();
-        }
-      };
-
-      tasksService.addListener({ event: TaskEvent.TaskCancelled, listener: cancelQueueListener });
-      tasksService.addListener({ event: TaskEvent.TaskUpdated, listener: updateQueueListener });
+        },
+        pauseUpload: () => this.uploadFoldersQueue.pause(),
+        resumeUpload: () => this.uploadFoldersQueue.resume(),
+      });
 
       try {
         root.folderId = currentFolderId;
@@ -422,51 +373,27 @@ export class UploadFoldersManager {
 
         if (connectionLost) throw new ConnectionLostError();
 
-        tasksService.updateTask({
-          taskId: taskId,
-          merge: {
-            itemUUID: { rootFolderUUID: this.tasksInfo[taskId].rootFolderItem?.uuid },
-            status: TaskStatus.Success,
-          },
+        this.events?.onFolderUploadSuccess?.(taskId, {
+          folderName: root.name,
+          rootFolderUUID: this.tasksInfo[taskId].rootFolderItem?.uuid,
         });
 
-        options.onSuccess?.();
-        referralService.trackFolderUpload();
-        logNetworkInfoForUpload({ folderName: root.name });
-
-        setTimeout(() => {
-          this.dispatch(planThunks.fetchUsageThunk());
-          if (memberId) this.dispatch(planThunks.fetchBusinessLimitUsageThunk());
-        }, 1000);
+        options?.onSuccess?.();
       } catch (err: unknown) {
         const castedError = errorService.castError(err);
-        const updatedTask = tasksService.findTask(taskId);
 
         if (connectionLost) {
-          tasksService.updateTask({
-            taskId: taskId,
-            merge: {
-              status: TaskStatus.Error,
-              subtitle: t('error.connectionLostError') as string,
-            },
-          });
+          this.events?.onFolderUploadError?.(taskId, 'connection-lost');
           errorService.reportError(castedError);
           break;
-        } else if (updatedTask?.status !== TaskStatus.Cancelled && taskId === updatedTask?.id) {
-          tasksService.updateTask({
-            taskId: taskId,
-            merge: {
-              status: TaskStatus.Error,
-              subtitle: t('tasks.subtitles.upload-failed') as string,
-            },
-          });
+        } else if (!this.tasksInfo[taskId].cancelled) {
+          this.events?.onFolderUploadError?.(taskId, 'upload-failed');
           // Log the error or report it but don't re-throw it to allow the next folder to be processed
           errorService.reportError(castedError);
           continue;
         }
       } finally {
-        tasksService.removeListener({ event: TaskEvent.TaskCancelled, listener: cancelQueueListener });
-        tasksService.removeListener({ event: TaskEvent.TaskUpdated, listener: updateQueueListener });
+        cleanupStartedEvent?.();
       }
     }
   };

--- a/src/app/tasks/upload/uploadFoldersWithTasks.ts
+++ b/src/app/tasks/upload/uploadFoldersWithTasks.ts
@@ -1,0 +1,112 @@
+import tasksService from 'app/tasks/services/tasks.service';
+import { TaskData, TaskEvent, TaskStatus, TaskType, UploadFolderTask } from 'app/tasks/types';
+import referralService from 'services/referral.service';
+import { IRoot } from 'app/store/slices/storage/types';
+import { logNetworkInfoForUpload } from 'app/network/networkInformation';
+import {
+  uploadFoldersWithManager,
+  UploadFolderManagerEvents,
+  UploadFolderPayload,
+} from 'app/network/UploadFolderManager';
+import { errorMerge } from './uploadTaskErrors';
+
+type UploadFoldersWithManagerProps = Parameters<typeof uploadFoldersWithManager>[0];
+
+interface UploadFolderTasksPayload {
+  root: IRoot;
+  currentFolderId: string;
+  options?: {
+    taskId?: string;
+    withNotification?: boolean;
+    onSuccess?: () => void;
+  };
+}
+
+interface UploadFoldersWithTasksProps extends Omit<UploadFoldersWithManagerProps, 'payload' | 'events'> {
+  payload: UploadFolderTasksPayload[];
+  onFolderUploadSucceeded?: (taskId: string) => void;
+}
+
+const createOrResumeTask = (folder: UploadFolderTasksPayload): string => {
+  const options = { withNotification: true, ...folder.options };
+
+  if (options.taskId) {
+    tasksService.updateTask({
+      taskId: options.taskId,
+      merge: { folderName: folder.root.name, status: TaskStatus.InProcess, progress: 0 },
+    });
+    return options.taskId;
+  }
+
+  return tasksService.create<UploadFolderTask>({
+    action: TaskType.UploadFolder,
+    folderName: folder.root.name,
+    item: folder.root,
+    parentFolderId: folder.currentFolderId,
+    showNotification: !!options.withNotification,
+    cancellable: true,
+  });
+};
+
+/**
+ * Uploads folders while tracking each one as a task: creates (or resumes) one task per
+ * root folder, then observes the upload manager's events to keep the tasks in sync.
+ * The manager itself never touches tasks.
+ */
+export const uploadFoldersWithTasks = (props: UploadFoldersWithTasksProps): Promise<void> => {
+  const { payload, onFolderUploadSucceeded, ...managerProps } = props;
+
+  const payloadWithTaskIds: UploadFolderPayload[] = payload.map((folder) => ({
+    root: folder.root,
+    currentFolderId: folder.currentFolderId,
+    options: {
+      taskId: createOrResumeTask(folder),
+      onSuccess: folder.options?.onSuccess,
+    },
+  }));
+
+  const events: UploadFolderManagerEvents = {
+    onFolderUploadStarted: (taskId, root, controls) => {
+      tasksService.updateTask({
+        taskId,
+        merge: { folderName: root.name, status: TaskStatus.InProcess, progress: 0 },
+      });
+
+      const cancelListener = (task: TaskData) => {
+        if (task.id === taskId && task.status === TaskStatus.Cancelled) controls.cancelUpload();
+      };
+      const updateListener = (task: TaskData) => {
+        if (task.id !== taskId) return;
+        if (task.status === TaskStatus.InProcess) controls.resumeUpload();
+        else if (task.status === TaskStatus.Paused) controls.pauseUpload();
+      };
+      tasksService.addListener({ event: TaskEvent.TaskCancelled, listener: cancelListener });
+      tasksService.addListener({ event: TaskEvent.TaskUpdated, listener: updateListener });
+
+      return () => {
+        tasksService.removeListener({ event: TaskEvent.TaskCancelled, listener: cancelListener });
+        tasksService.removeListener({ event: TaskEvent.TaskUpdated, listener: updateListener });
+      };
+    },
+
+    onFolderUploadProgress: (taskId, progress, stopUpload) =>
+      tasksService.updateTask({ taskId, merge: { progress, stop: stopUpload } }),
+
+    onFolderUploadSuccess: (taskId, { folderName, rootFolderUUID }) => {
+      tasksService.updateTask({ taskId, merge: { status: TaskStatus.Success, itemUUID: { rootFolderUUID } } });
+      referralService.trackFolderUpload();
+      logNetworkInfoForUpload({ folderName });
+      onFolderUploadSucceeded?.(taskId);
+    },
+
+    onFolderUploadError: (taskId, reason) => tasksService.updateTask({ taskId, merge: errorMerge(reason) }),
+
+    stopRelatedUploads: (taskId) =>
+      tasksService
+        .getTasks({ relatedTaskId: taskId })
+        .map((task) => task.stop?.())
+        .filter((promise): promise is Promise<void> => promise !== undefined),
+  };
+
+  return uploadFoldersWithManager({ ...managerProps, payload: payloadWithTaskIds, events });
+};

--- a/src/views/Drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/views/Drive/components/DriveExplorer/DriveExplorer.tsx
@@ -27,7 +27,7 @@ import { CreateFolderDialog } from 'views/Drive/components';
 import DeleteItemsDialog from 'views/Trash/components/DeleteItemsDialog';
 import { useTrashPagination } from 'views/Trash/hooks/useTrashPagination';
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
-import { uploadFoldersWithManager } from 'app/network/UploadFolderManager';
+import { uploadFoldersWithTracking } from 'app/drive/services/folder.service/uploadFoldersWithTracking';
 import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
 import { AdvancedSharedItem } from 'app/share/types';
 import { Tutorial } from 'components/Tutorial';
@@ -790,7 +790,7 @@ const uploadItems = async (props: DriveExplorerProps, rootList: IRoot[], files: 
         options: { onSuccess: onDragAndDropEnd },
       }));
 
-      await uploadFoldersWithManager({
+      await uploadFoldersWithTracking({
         payload: folderDataToUpload,
         selectedWorkspace: props.selectedWorkspace,
         dispatch,

--- a/src/views/Drive/hooks/useDriveItemDragAndDrop.tsx
+++ b/src/views/Drive/hooks/useDriveItemDragAndDrop.tsx
@@ -8,7 +8,7 @@ import storageThunks from 'app/store/slices/storage/storage.thunks';
 import { getCollisionGroups } from 'app/store/slices/storage/storage.thunks/renameItemsThunk';
 import { uiActions } from 'app/store/slices/ui';
 import { DriveItemData } from 'app/drive/types';
-import { uploadFoldersWithManager } from 'app/network/UploadFolderManager';
+import { uploadFoldersWithTracking } from 'app/drive/services/folder.service/uploadFoldersWithTracking';
 import workspacesSelectors from 'app/store/slices/workspaces/workspaces.selectors';
 import { fileVersionsSelectors } from 'app/store/slices/fileVersions';
 
@@ -90,7 +90,7 @@ const handleFileDrop = async (
       root,
       currentFolderId: item.uuid,
     }));
-    await uploadFoldersWithManager({
+    await uploadFoldersWithTracking({
       payload: folderDataToUpload,
       selectedWorkspace,
       dispatch,


### PR DESCRIPTION
## Description

Applies the same inversion as #2030 to the folder pipeline:

- `UploadFoldersManager` now only orchestrates folder creation and file transfers. It emits events (`onFolderUploadStarted` with cancel/pause/resume controls, `onFolderUploadProgress`,`onFolderUploadSuccess`, `onFolderUploadError`) and no longer touches `tasksService`, `i18next`,`referralService` or Redux UI actions.
  
- New tasks layer `uploadFoldersWithTasks` creates/resumes folder tasks and reacts to the events, including wiring task cancel/pause/resume to the manager controls.

- New `uploadFoldersWithTracking` wrapper owns the Redux side effects (size-limit dialog, usage refresh) and is what the UI now calls (`DriveExplorer`, drag & drop, name collision dialog).

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
