### PR TITLE
[PB-6600]: convert folder upload manager tests and cover the folder tasks layer

### DIFF
--- a/src/app/network/UploadFolderManager.test.ts
+++ b/src/app/network/UploadFolderManager.test.ts
@@ -1,47 +1,20 @@
-import errorService from 'services/error.service';
-import { AppError } from '@internxt/sdk';
 import { DriveFolderData } from 'app/drive/types';
 import { createFolder } from 'app/store/slices/storage/folderUtils/createFolder';
 import { checkFolderDuplicated } from 'app/store/slices/storage/folderUtils/checkFolderDuplicated';
 import { getUniqueFolderName } from 'app/store/slices/storage/folderUtils/getUniqueFolderName';
-import tasksService from 'app/tasks/services/tasks.service';
 import { beforeEach, describe, expect, it, Mock, test, vi } from 'vitest';
-import { TaskFolder, UploadFoldersManager, uploadFoldersWithManager } from './UploadFolderManager';
-import * as networkInformation from './networkInformation';
+import {
+  TaskFolder,
+  UploadFolderManagerEvents,
+  UploadFoldersManager,
+  uploadFoldersWithManager,
+} from './UploadFolderManager';
 import { FilesExceedsSizeLimitError } from 'app/drive/services/file.service/upload.errors';
 import { uploadItemsParallelThunk } from 'app/store/slices/storage/storage.thunks/uploadItemsThunk';
 
 vi.mock('app/drive/services/new-storage.service', () => ({
   default: {
     deleteFolderByUuid: vi.fn(),
-  },
-}));
-
-vi.mock('app/tasks/services/tasks.service', () => ({
-  default: {
-    create: vi.fn(),
-    updateTask: vi.fn(),
-    getTasks: vi.fn(),
-    findTask: vi.fn(),
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-  },
-}));
-
-vi.mock('app/store/slices/plan', () => ({
-  default: {
-    initializeThunk: vi.fn(),
-    fetchLimitThunk: vi.fn(),
-    fetchUsageThunk: vi.fn(),
-    fetchSubscriptionThunk: vi.fn(),
-    fetchBusinessLimitUsageThunk: vi.fn(),
-  },
-  planThunks: {
-    initializeThunk: vi.fn(),
-    fetchLimitThunk: vi.fn(),
-    fetchUsageThunk: vi.fn(),
-    fetchSubscriptionThunk: vi.fn(),
-    fetchBusinessLimitUsageThunk: vi.fn(),
   },
 }));
 
@@ -65,16 +38,6 @@ vi.mock('app/store/slices/storage/folderUtils/getUniqueFolderName', () => ({
   getUniqueFolderName: vi.fn(),
 }));
 
-vi.mock('services/referral.service', () => ({
-  default: {
-    trackFolderUpload: vi.fn(),
-  },
-}));
-
-vi.mock('./networkInformation', () => ({
-  logNetworkInfoForUpload: vi.fn(),
-}));
-
 vi.mock('services/error.service', () => ({
   default: {
     castError: vi.fn().mockImplementation((e) => e),
@@ -82,50 +45,54 @@ vi.mock('services/error.service', () => ({
   },
 }));
 
-describe('checkUploadFolders', () => {
+describe('uploadFoldersWithManager', () => {
   const mockDispatch = vi.fn();
+
+  const buildFolderData = (overrides: Partial<DriveFolderData> = {}): DriveFolderData =>
+    ({
+      id: 0,
+      uuid: 'uuid',
+      name: 'Folder1',
+      bucket: 'bucket',
+      parentId: 0,
+      parent_id: 0,
+      parentUuid: 'parentUuid',
+      userId: 0,
+      user_id: 0,
+      icon: null,
+      iconId: null,
+      icon_id: null,
+      isFolder: true,
+      color: null,
+      encrypt_version: null,
+      plain_name: 'Folder1',
+      deleted: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      ...overrides,
+    }) as DriveFolderData;
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
   });
 
-  it('should upload folder using an async queue', async () => {
-    const mockFolder: DriveFolderData = {
-      id: 0,
-      uuid: 'uuid',
-      name: 'Folder1',
-      bucket: 'bucket',
-      parentId: 0,
-      parent_id: 0,
-      parentUuid: 'parentUuid',
-      userId: 0,
-      user_id: 0,
-      icon: null,
-      iconId: null,
-      icon_id: null,
-      isFolder: true,
-      color: null,
-      encrypt_version: null,
-      plain_name: 'Folder1',
-      deleted: false,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
+  it('When a folder upload completes, then the folder is created and the upload is notified from start to success', async () => {
+    const mockFolder = buildFolderData({ name: 'MyFolder', plain_name: 'MyFolder' });
     const taskId = 'task-id';
 
     const createFolderSpy = (createFolder as Mock).mockResolvedValueOnce(mockFolder);
-
     (checkFolderDuplicated as Mock).mockResolvedValueOnce({
-      duplicatedFoldersResponse: [] as DriveFolderData[],
-      foldersWithDuplicates: [] as DriveFolderData[],
+      duplicatedFoldersResponse: [],
+      foldersWithDuplicates: [],
       foldersWithoutDuplicates: [mockFolder],
     });
-    vi.spyOn(tasksService, 'create').mockReturnValue(taskId);
-    vi.spyOn(tasksService, 'updateTask').mockReturnValue();
-    vi.spyOn(tasksService, 'addListener').mockReturnValue();
-    vi.spyOn(tasksService, 'removeListener').mockReturnValue();
-    vi.spyOn(errorService, 'castError').mockResolvedValue(new AppError('error'));
+
+    const events: UploadFolderManagerEvents = {
+      onFolderUploadStarted: vi.fn(),
+      onFolderUploadSuccess: vi.fn(),
+      onFolderUploadError: vi.fn(),
+    };
 
     await uploadFoldersWithManager({
       payload: [
@@ -138,58 +105,46 @@ describe('checkUploadFolders', () => {
             name: mockFolder.name,
             fullPathEdited: 'path1',
           },
-          options: {
-            taskId,
-          },
+          options: { taskId },
         },
       ],
       selectedWorkspace: null,
       dispatch: mockDispatch,
       maxUploadFileSize: 100,
+      events,
     });
 
     expect(createFolderSpy).toHaveBeenCalledOnce();
+    expect(events.onFolderUploadStarted).toHaveBeenCalledWith(
+      taskId,
+      expect.objectContaining({ name: 'MyFolder' }),
+      expect.objectContaining({
+        cancelUpload: expect.any(Function),
+        pauseUpload: expect.any(Function),
+        resumeUpload: expect.any(Function),
+      }),
+    );
+    expect(events.onFolderUploadSuccess).toHaveBeenCalledOnce();
+    expect(events.onFolderUploadSuccess).toHaveBeenCalledWith(taskId, {
+      folderName: 'MyFolder',
+      rootFolderUUID: mockFolder.uuid,
+    });
+    expect(events.onFolderUploadError).not.toHaveBeenCalled();
   });
 
-  it('should rename folder before upload using an async queue', async () => {
-    const mockFolder: DriveFolderData = {
-      id: 0,
-      uuid: 'uuid',
-      name: 'Folder1',
-      bucket: 'bucket',
-      parentId: 0,
-      parent_id: 0,
-      parentUuid: 'parentUuid',
-      userId: 0,
-      user_id: 0,
-      icon: null,
-      iconId: null,
-      icon_id: null,
-      isFolder: true,
-      color: null,
-      encrypt_version: null,
-      plain_name: 'Folder1',
-      deleted: false,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
+  it('When a folder name already exists, then the folder is uploaded and announced with a new unique name', async () => {
+    const mockFolder = buildFolderData();
     const taskId = 'task-id';
 
-    const createFolderSpy = (createFolder as Mock).mockResolvedValueOnce(mockFolder);
-
+    (createFolder as Mock).mockResolvedValueOnce(mockFolder);
     (checkFolderDuplicated as Mock).mockResolvedValueOnce({
       duplicatedFoldersResponse: [mockFolder] as DriveFolderData[],
       foldersWithDuplicates: [mockFolder] as DriveFolderData[],
       foldersWithoutDuplicates: [],
     });
-
     const renameFolderSpy = (getUniqueFolderName as Mock).mockResolvedValueOnce('renamed-folder1');
 
-    vi.spyOn(tasksService, 'create').mockReturnValue(taskId);
-    vi.spyOn(tasksService, 'updateTask').mockReturnValue();
-    vi.spyOn(tasksService, 'addListener').mockReturnValue();
-    vi.spyOn(tasksService, 'removeListener').mockReturnValue();
-    vi.spyOn(errorService, 'castError').mockResolvedValue(new AppError('error'));
+    const events: UploadFolderManagerEvents = { onFolderUploadStarted: vi.fn() };
 
     await uploadFoldersWithManager({
       payload: [
@@ -202,63 +157,34 @@ describe('checkUploadFolders', () => {
             name: mockFolder.name,
             fullPathEdited: 'path1',
           },
-          options: {
-            taskId,
-          },
+          options: { taskId },
         },
       ],
       selectedWorkspace: null,
       dispatch: mockDispatch,
       maxUploadFileSize: 100,
+      events,
     });
 
-    expect(createFolderSpy).toHaveBeenCalledOnce();
     expect(renameFolderSpy).toHaveBeenCalledOnce();
+    expect(events.onFolderUploadStarted).toHaveBeenCalledWith(
+      taskId,
+      expect.objectContaining({ name: 'renamed-folder1' }),
+      expect.any(Object),
+    );
   });
 
-  it('should upload multiple folders using an async queue', async () => {
-    const mockParentFolder: DriveFolderData = {
-      id: 1,
-      uuid: 'uuid1',
-      name: 'Folder1',
-      bucket: 'bucket',
-      parentId: 0,
-      parent_id: 0,
-      parentUuid: 'parentUuid',
-      userId: 0,
-      user_id: 0,
-      icon: null,
-      iconId: null,
-      icon_id: null,
-      isFolder: true,
-      color: null,
-      encrypt_version: null,
-      plain_name: 'Folder1',
-      deleted: false,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
-    const mockChildFolder: DriveFolderData = {
+  it('When a folder has subfolders, then every level is uploaded', async () => {
+    const mockParentFolder = buildFolderData({ id: 1, uuid: 'uuid1' });
+    const mockChildFolder = buildFolderData({
       id: 2,
       uuid: 'uuid2',
       name: 'Folder2',
-      bucket: 'bucket',
       parentId: 1,
       parent_id: 1,
       parentUuid: 'uuid1',
-      userId: 0,
-      user_id: 0,
-      icon: null,
-      iconId: null,
-      icon_id: null,
-      isFolder: true,
-      color: null,
-      encrypt_version: null,
       plain_name: 'Folder2',
-      deleted: false,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
+    });
     const taskId = 'task-id';
 
     const createFolderSpy = (createFolder as Mock)
@@ -271,11 +197,7 @@ describe('checkUploadFolders', () => {
       foldersWithoutDuplicates: [mockParentFolder],
     });
 
-    const renameFolderSpy = (getUniqueFolderName as Mock).mockResolvedValueOnce('');
-
-    vi.spyOn(tasksService, 'create').mockReturnValue(taskId);
-    vi.spyOn(tasksService, 'updateTask').mockReturnValue();
-    vi.spyOn(errorService, 'castError').mockResolvedValue(new AppError('error'));
+    (getUniqueFolderName as Mock).mockResolvedValueOnce('');
 
     await uploadFoldersWithManager({
       payload: [
@@ -307,91 +229,11 @@ describe('checkUploadFolders', () => {
     });
 
     expect(createFolderSpy).toHaveBeenCalledTimes(2);
-    expect(renameFolderSpy).not.toHaveBeenCalled();
-  });
-
-  it('should log network information on successful folder upload', async () => {
-    const logNetworkInfoMock = networkInformation.logNetworkInfoForUpload as Mock;
-    const mockFolder: DriveFolderData = {
-      id: 0,
-      uuid: 'uuid',
-      name: 'MyFolder',
-      bucket: 'bucket',
-      parentId: 0,
-      parent_id: 0,
-      parentUuid: 'parentUuid',
-      userId: 0,
-      user_id: 0,
-      icon: null,
-      iconId: null,
-      icon_id: null,
-      isFolder: true,
-      color: null,
-      encrypt_version: null,
-      plain_name: 'MyFolder',
-      deleted: false,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
-    const taskId = 'task-id';
-
-    (createFolder as Mock).mockResolvedValueOnce(mockFolder);
-    (checkFolderDuplicated as Mock).mockResolvedValueOnce({
-      duplicatedFoldersResponse: [],
-      foldersWithDuplicates: [],
-      foldersWithoutDuplicates: [mockFolder],
-    });
-    vi.spyOn(tasksService, 'create').mockReturnValue(taskId);
-    vi.spyOn(tasksService, 'updateTask').mockReturnValue();
-    vi.spyOn(tasksService, 'addListener').mockReturnValue();
-    vi.spyOn(tasksService, 'removeListener').mockReturnValue();
-
-    await uploadFoldersWithManager({
-      payload: [
-        {
-          currentFolderId: 'currentFolderId',
-          root: {
-            folderId: mockFolder.uuid,
-            childrenFiles: [],
-            childrenFolders: [],
-            name: mockFolder.name,
-            fullPathEdited: 'path1',
-          },
-          options: { taskId },
-        },
-      ],
-      selectedWorkspace: null,
-      dispatch: mockDispatch,
-      maxUploadFileSize: 100,
-    });
-
-    expect(logNetworkInfoMock).toHaveBeenCalledOnce();
-    expect(logNetworkInfoMock).toHaveBeenCalledWith({ folderName: 'MyFolder' });
   });
 
   describe('Handle File Uploads', () => {
     const taskId = 'task-id';
-    const mockCreatedFolder: DriveFolderData = {
-      id: 0,
-      uuid: 'folder-uuid',
-      name: 'Folder1',
-      bucket: 'bucket',
-      parentId: 0,
-      parent_id: 0,
-      parentUuid: 'parentUuid',
-      userId: 0,
-      user_id: 0,
-      icon: null,
-      iconId: null,
-      icon_id: null,
-      isFolder: true,
-      color: null,
-      encrypt_version: null,
-      plain_name: 'Folder1',
-      deleted: false,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
+    const mockCreatedFolder = buildFolderData({ uuid: 'folder-uuid' });
 
     const buildManager = (maxUploadFileSize?: number) => {
       const manager = new UploadFoldersManager({
@@ -406,8 +248,6 @@ describe('checkUploadFolders', () => {
 
     test('When all files exceed the size limit and there are no subfolders, then an error indicating so is thrown', async () => {
       const bigFile = new File([new ArrayBuffer(200)], 'big.mp4');
-      vi.spyOn(tasksService, 'updateTask').mockReturnValue();
-      vi.spyOn(tasksService, 'getTasks').mockReturnValue([]);
       const manager = buildManager(100);
       const level = { childrenFiles: [bigFile], childrenFolders: [], folderId: 'f', name: 'F', fullPathEdited: '' };
 
@@ -416,10 +256,9 @@ describe('checkUploadFolders', () => {
       ).rejects.toThrow(FilesExceedsSizeLimitError);
     });
 
-    test('When a folder has files exceeding the size limit but also has subfolders, then it dispatches the upload', async () => {
+    test('When a folder has files exceeding the size limit but also has subfolders, then the upload continues', async () => {
       const bigFile = new File([new ArrayBuffer(200)], 'big.mp4');
       const dispatchWithUnwrap = vi.fn().mockReturnValue({ unwrap: () => Promise.resolve() });
-      vi.spyOn(tasksService, 'updateTask').mockReturnValue();
       const manager = new UploadFoldersManager({
         payload: [],
         selectedWorkspace: null,
@@ -443,49 +282,17 @@ describe('checkUploadFolders', () => {
     });
   });
 
-  it('should abort the upload if abortController is called', async () => {
-    const mockParentFolder: DriveFolderData = {
-      id: 1,
-      uuid: 'uuid1',
-      name: 'Folder1',
-      bucket: 'bucket',
-      parentId: 0,
-      parent_id: 0,
-      parentUuid: 'parentUuid',
-      userId: 0,
-      user_id: 0,
-      icon: null,
-      iconId: null,
-      icon_id: null,
-      isFolder: true,
-      color: null,
-      encrypt_version: null,
-      plain_name: 'Folder1',
-      deleted: false,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
-    const mockChildFolder: DriveFolderData = {
+  it('When the upload was already cancelled, then the folder is not uploaded', async () => {
+    const mockParentFolder = buildFolderData({ id: 1, uuid: 'uuid1' });
+    const mockChildFolder = buildFolderData({
       id: 2,
       uuid: 'uuid2',
       name: 'Folder2',
-      bucket: 'bucket',
       parentId: 1,
       parent_id: 1,
       parentUuid: 'uuid1',
-      userId: 0,
-      user_id: 0,
-      icon: null,
-      iconId: null,
-      icon_id: null,
-      isFolder: true,
-      color: null,
-      encrypt_version: null,
       plain_name: 'Folder2',
-      deleted: false,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
+    });
     const taskId = 'task-id';
 
     const manager = new UploadFoldersManager({
@@ -543,7 +350,6 @@ describe('checkUploadFolders', () => {
     const uploadPromise = manager['uploadFolderAsync'](taskFolder);
 
     await expect(uploadPromise).resolves.toBeUndefined();
-    expect(abortController.signal.aborted).toBe(true);
     expect(createFolderSpy).not.toHaveBeenCalled();
     expect(renameFolderSpy).not.toHaveBeenCalled();
   });

--- a/src/app/network/UploadFolderManager.test.ts
+++ b/src/app/network/UploadFolderManager.test.ts
@@ -2,7 +2,7 @@ import { DriveFolderData } from 'app/drive/types';
 import { createFolder } from 'app/store/slices/storage/folderUtils/createFolder';
 import { checkFolderDuplicated } from 'app/store/slices/storage/folderUtils/checkFolderDuplicated';
 import { getUniqueFolderName } from 'app/store/slices/storage/folderUtils/getUniqueFolderName';
-import { beforeEach, describe, expect, it, Mock, test, vi } from 'vitest';
+import { beforeEach, describe, expect, Mock, test, vi } from 'vitest';
 import {
   TaskFolder,
   UploadFolderManagerEvents,
@@ -77,7 +77,7 @@ describe('uploadFoldersWithManager', () => {
     vi.resetModules();
   });
 
-  it('When a folder upload completes, then the folder is created and the upload is notified from start to success', async () => {
+  test('When a folder upload completes, then the folder is created and the upload is notified from start to success', async () => {
     const mockFolder = buildFolderData({ name: 'MyFolder', plain_name: 'MyFolder' });
     const taskId = 'task-id';
 
@@ -132,7 +132,7 @@ describe('uploadFoldersWithManager', () => {
     expect(events.onFolderUploadError).not.toHaveBeenCalled();
   });
 
-  it('When a folder name already exists, then the folder is uploaded and announced with a new unique name', async () => {
+  test('When a folder name already exists, then the folder is uploaded and announced with a new unique name', async () => {
     const mockFolder = buildFolderData();
     const taskId = 'task-id';
 
@@ -174,7 +174,7 @@ describe('uploadFoldersWithManager', () => {
     );
   });
 
-  it('When a folder has subfolders, then every level is uploaded', async () => {
+  test('When a folder has subfolders, then every level is uploaded', async () => {
     const mockParentFolder = buildFolderData({ id: 1, uuid: 'uuid1' });
     const mockChildFolder = buildFolderData({
       id: 2,
@@ -282,7 +282,7 @@ describe('uploadFoldersWithManager', () => {
     });
   });
 
-  it('When the upload was already cancelled, then the folder is not uploaded', async () => {
+  test('When the upload was already cancelled, then the folder is not uploaded', async () => {
     const mockParentFolder = buildFolderData({ id: 1, uuid: 'uuid1' });
     const mockChildFolder = buildFolderData({
       id: 2,

--- a/src/app/tasks/upload/uploadFoldersWithTasks.test.ts
+++ b/src/app/tasks/upload/uploadFoldersWithTasks.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import tasksService from 'app/tasks/services/tasks.service';
+import { TaskEvent, TaskStatus } from 'app/tasks/types';
+import referralService from 'services/referral.service';
+import * as networkInformation from 'app/network/networkInformation';
+import { uploadFoldersWithManager, UploadFolderManagerEvents } from 'app/network/UploadFolderManager';
+import { IRoot } from 'app/store/slices/storage/types';
+import { uploadFoldersWithTasks } from './uploadFoldersWithTasks';
+
+vi.mock('app/network/UploadFolderManager', () => ({
+  uploadFoldersWithManager: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('app/tasks/services/tasks.service', () => ({
+  default: {
+    create: vi.fn(),
+    updateTask: vi.fn(),
+    getTasks: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  },
+}));
+
+vi.mock('i18next', () => ({ t: (key: string) => key }));
+
+vi.mock('services/referral.service', () => ({
+  default: {
+    trackFolderUpload: vi.fn(),
+  },
+}));
+
+vi.mock('app/network/networkInformation', () => ({
+  logNetworkInfoForUpload: vi.fn(),
+}));
+
+const root: IRoot = { name: 'Folder', childrenFiles: [], childrenFolders: [], folderId: 'parent', fullPathEdited: '' };
+
+const runUpload = async (
+  payload: Parameters<typeof uploadFoldersWithTasks>[0]['payload'],
+  props: Record<string, unknown> = {},
+) => {
+  await uploadFoldersWithTasks({
+    payload,
+    selectedWorkspace: null,
+    dispatch: vi.fn() as never,
+    maxUploadFileSize: 100,
+    ...props,
+  });
+  const managerProps = (uploadFoldersWithManager as Mock).mock.calls[0][0];
+  return { managerProps, events: managerProps.events as UploadFolderManagerEvents };
+};
+
+describe('uploadFoldersWithTasks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('When a folder upload is retried, then its existing task resumes instead of creating a new one', async () => {
+    const { managerProps } = await runUpload([
+      { root, currentFolderId: 'parent', options: { taskId: 'existing-task', withNotification: true } },
+    ]);
+
+    expect(tasksService.updateTask).toHaveBeenCalledWith({
+      taskId: 'existing-task',
+      merge: { folderName: 'Folder', status: TaskStatus.InProcess, progress: 0 },
+    });
+    expect(tasksService.create).not.toHaveBeenCalled();
+    expect(managerProps.payload[0].options.taskId).toBe('existing-task');
+  });
+
+  it('When a new folder upload begins, then a task is created to track it', async () => {
+    (tasksService.create as Mock).mockReturnValue('created-task-id');
+
+    const { managerProps } = await runUpload([
+      { root, currentFolderId: 'parent', options: { withNotification: false } },
+    ]);
+
+    expect(tasksService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ folderName: 'Folder', parentFolderId: 'parent', showNotification: false }),
+    );
+    expect(managerProps.payload[0].options.taskId).toBe('created-task-id');
+  });
+
+  it('When a folder upload starts, then the task shows the final folder name and can cancel, pause and resume it', async () => {
+    (tasksService.create as Mock).mockReturnValue('task-1');
+    const listeners: Record<string, (task: { id: string; status: TaskStatus }) => void> = {};
+    (tasksService.addListener as Mock).mockImplementation(({ event, listener }) => {
+      listeners[event] = listener;
+    });
+
+    const { events } = await runUpload([{ root, currentFolderId: 'parent' }]);
+    const controls = { cancelUpload: vi.fn(), pauseUpload: vi.fn(), resumeUpload: vi.fn() };
+
+    const cleanup = events.onFolderUploadStarted?.('task-1', { ...root, name: 'Folder (1)' }, controls);
+
+    expect(tasksService.updateTask).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      merge: { folderName: 'Folder (1)', status: TaskStatus.InProcess, progress: 0 },
+    });
+
+    listeners[TaskEvent.TaskCancelled]?.({ id: 'other-task', status: TaskStatus.Cancelled });
+    expect(controls.cancelUpload).not.toHaveBeenCalled();
+    listeners[TaskEvent.TaskCancelled]?.({ id: 'task-1', status: TaskStatus.Cancelled });
+    expect(controls.cancelUpload).toHaveBeenCalledOnce();
+
+    listeners[TaskEvent.TaskUpdated]?.({ id: 'task-1', status: TaskStatus.Paused });
+    expect(controls.pauseUpload).toHaveBeenCalledOnce();
+    listeners[TaskEvent.TaskUpdated]?.({ id: 'task-1', status: TaskStatus.InProcess });
+    expect(controls.resumeUpload).toHaveBeenCalledOnce();
+
+    cleanup?.();
+    expect(tasksService.removeListener).toHaveBeenCalledTimes(2);
+  });
+
+  it('When a folder upload advances, then the task progress updates and the upload stays stoppable', async () => {
+    (tasksService.create as Mock).mockReturnValue('task-1');
+    const { events } = await runUpload([{ root, currentFolderId: 'parent' }]);
+    const stop = vi.fn();
+
+    events.onFolderUploadProgress?.('task-1', 0.25, stop);
+
+    expect(tasksService.updateTask).toHaveBeenCalledWith({ taskId: 'task-1', merge: { progress: 0.25, stop } });
+  });
+
+  it('When a folder finishes uploading, then its task succeeds and the upload is tracked', async () => {
+    (tasksService.create as Mock).mockReturnValue('task-1');
+    const onFolderUploadSucceeded = vi.fn();
+    const { events } = await runUpload([{ root, currentFolderId: 'parent' }], { onFolderUploadSucceeded });
+
+    events.onFolderUploadSuccess?.('task-1', { folderName: 'MyFolder', rootFolderUUID: 'root-uuid' });
+
+    expect(tasksService.updateTask).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      merge: { status: TaskStatus.Success, itemUUID: { rootFolderUUID: 'root-uuid' } },
+    });
+    expect(referralService.trackFolderUpload).toHaveBeenCalledOnce();
+    expect(networkInformation.logNetworkInfoForUpload).toHaveBeenCalledWith({ folderName: 'MyFolder' });
+    expect(onFolderUploadSucceeded).toHaveBeenCalledWith('task-1');
+  });
+
+  it('When a folder upload fails, then the task shows an error message matching the cause', async () => {
+    (tasksService.create as Mock).mockReturnValue('task-1');
+    const { events } = await runUpload([{ root, currentFolderId: 'parent' }]);
+
+    events.onFolderUploadError?.('task-1', 'connection-lost');
+
+    expect(tasksService.updateTask).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      merge: { status: TaskStatus.Error, subtitle: 'error.connectionLostError' },
+    });
+  });
+
+  it('When a folder upload stops, then its ongoing file uploads are stopped too', async () => {
+    (tasksService.create as Mock).mockReturnValue('task-1');
+    const resolvedStop = Promise.resolve();
+    (tasksService.getTasks as Mock).mockReturnValue([{ stop: () => resolvedStop }, { stop: undefined }, {}]);
+
+    const { events } = await runUpload([{ root, currentFolderId: 'parent' }]);
+    const promises = events.stopRelatedUploads?.('task-1');
+
+    expect(tasksService.getTasks).toHaveBeenCalledWith({ relatedTaskId: 'task-1' });
+    expect(promises).toEqual([resolvedStop]);
+  });
+});

--- a/src/app/tasks/upload/uploadFoldersWithTasks.test.ts
+++ b/src/app/tasks/upload/uploadFoldersWithTasks.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { beforeEach, describe, expect, Mock, test, vi } from 'vitest';
 import tasksService from 'app/tasks/services/tasks.service';
 import { TaskEvent, TaskStatus } from 'app/tasks/types';
 import referralService from 'services/referral.service';
@@ -55,7 +55,7 @@ describe('uploadFoldersWithTasks', () => {
     vi.clearAllMocks();
   });
 
-  it('When a folder upload is retried, then its existing task resumes instead of creating a new one', async () => {
+  test('When a folder upload is retried, then its existing task resumes instead of creating a new one', async () => {
     const { managerProps } = await runUpload([
       { root, currentFolderId: 'parent', options: { taskId: 'existing-task', withNotification: true } },
     ]);
@@ -68,7 +68,7 @@ describe('uploadFoldersWithTasks', () => {
     expect(managerProps.payload[0].options.taskId).toBe('existing-task');
   });
 
-  it('When a new folder upload begins, then a task is created to track it', async () => {
+  test('When a new folder upload begins, then a task is created to track it', async () => {
     (tasksService.create as Mock).mockReturnValue('created-task-id');
 
     const { managerProps } = await runUpload([
@@ -81,7 +81,7 @@ describe('uploadFoldersWithTasks', () => {
     expect(managerProps.payload[0].options.taskId).toBe('created-task-id');
   });
 
-  it('When a folder upload starts, then the task shows the final folder name and can cancel, pause and resume it', async () => {
+  test('When a folder upload starts, then the task shows the final folder name and can cancel, pause and resume it', async () => {
     (tasksService.create as Mock).mockReturnValue('task-1');
     const listeners: Record<string, (task: { id: string; status: TaskStatus }) => void> = {};
     (tasksService.addListener as Mock).mockImplementation(({ event, listener }) => {
@@ -112,7 +112,7 @@ describe('uploadFoldersWithTasks', () => {
     expect(tasksService.removeListener).toHaveBeenCalledTimes(2);
   });
 
-  it('When a folder upload advances, then the task progress updates and the upload stays stoppable', async () => {
+  test('When a folder upload advances, then the task progress updates and the upload stays stoppable', async () => {
     (tasksService.create as Mock).mockReturnValue('task-1');
     const { events } = await runUpload([{ root, currentFolderId: 'parent' }]);
     const stop = vi.fn();
@@ -122,7 +122,7 @@ describe('uploadFoldersWithTasks', () => {
     expect(tasksService.updateTask).toHaveBeenCalledWith({ taskId: 'task-1', merge: { progress: 0.25, stop } });
   });
 
-  it('When a folder finishes uploading, then its task succeeds and the upload is tracked', async () => {
+  test('When a folder finishes uploading, then its task succeeds and the upload is tracked', async () => {
     (tasksService.create as Mock).mockReturnValue('task-1');
     const onFolderUploadSucceeded = vi.fn();
     const { events } = await runUpload([{ root, currentFolderId: 'parent' }], { onFolderUploadSucceeded });
@@ -138,7 +138,7 @@ describe('uploadFoldersWithTasks', () => {
     expect(onFolderUploadSucceeded).toHaveBeenCalledWith('task-1');
   });
 
-  it('When a folder upload fails, then the task shows an error message matching the cause', async () => {
+  test('When a folder upload fails, then the task shows an error message matching the cause', async () => {
     (tasksService.create as Mock).mockReturnValue('task-1');
     const { events } = await runUpload([{ root, currentFolderId: 'parent' }]);
 
@@ -150,7 +150,7 @@ describe('uploadFoldersWithTasks', () => {
     });
   });
 
-  it('When a folder upload stops, then its ongoing file uploads are stopped too', async () => {
+  test('When a folder upload stops, then its ongoing file uploads are stopped too', async () => {
     (tasksService.create as Mock).mockReturnValue('task-1');
     const resolvedStop = Promise.resolve();
     (tasksService.getTasks as Mock).mockReturnValue([{ stop: () => resolvedStop }, { stop: undefined }, {}]);


### PR DESCRIPTION
## Description

- Adds the test suite for `uploadFoldersWithTasks` (task creation/resume,
  cancel/pause/resume wiring, progress, success tracking, error subtitles,
  stopping related uploads).
- Converts `UploadFolderManager.test.ts` to upload event assertions with
  when/then descriptions, prunes redundant tests, and verifies the renamed
  folder name reaches the task on duplicate uploads.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
