### PR TITLE
[MKT_948]feat/Add ApplePay to checkout payment methods

### DIFF
--- a/src/views/Checkout/views/CheckoutViewWrapper.tsx
+++ b/src/views/Checkout/views/CheckoutViewWrapper.tsx
@@ -287,40 +287,16 @@ const CheckoutViewWrapper = () => {
       return;
     }
 
+    if (!stripeSDK || !elements) {
+      console.error('Stripe.js has not loaded yet. Please try again later.');
+      return;
+    }
+
     setIsUserPaying(true);
 
     const { email, password, companyName, companyVatId } = formData;
-    const isStripeNotLoaded = !stripeSDK || !elements;
-
-    const captchaToken = await generateCaptchaToken();
-
-    let authenticatedUser = user;
-
-    if (authMethod !== 'userIsSignedIn') {
-      const result = await onAuthenticateUser({
-        email,
-        password,
-        authMethod,
-        dispatch,
-        authCaptcha: captchaToken,
-        doRegister,
-        onAuthenticationFail: () => {
-          userAuthComponentRef.current?.scrollIntoView();
-          setIsUserPaying(false);
-        },
-      });
-
-      if (result) {
-        authenticatedUser = result;
-      }
-    }
 
     try {
-      if (isStripeNotLoaded) {
-        console.error('Stripe.js has not loaded yet. Please try again later.');
-        return;
-      }
-
       const isCryptoPurchase = currencyType === PaymentType['CRYPTO'];
 
       if (isCryptoPurchase && isCryptoAddressIncomplete) {
@@ -340,6 +316,29 @@ const CheckoutViewWrapper = () => {
 
         if (elementsError) {
           throw new Error(elementsError.message);
+        }
+      }
+
+      const captchaToken = await generateCaptchaToken();
+
+      let authenticatedUser = user;
+
+      if (authMethod !== 'userIsSignedIn') {
+        const result = await onAuthenticateUser({
+          email,
+          password,
+          authMethod,
+          dispatch,
+          authCaptcha: captchaToken,
+          doRegister,
+          onAuthenticationFail: () => {
+            userAuthComponentRef.current?.scrollIntoView();
+            setIsUserPaying(false);
+          },
+        });
+
+        if (result) {
+          authenticatedUser = result;
         }
       }
 

--- a/src/views/Checkout/views/CheckoutViewWrapper.tsx
+++ b/src/views/Checkout/views/CheckoutViewWrapper.tsx
@@ -281,13 +281,15 @@ const CheckoutViewWrapper = () => {
   ) => {
     event?.preventDefault();
 
+    const isStripeNotLoaded = !stripeSDK || !elements;
+
     if (!selectedPlan?.price?.id) {
       console.error('No selected plan available for checkout');
       setIsUserPaying(false);
       return;
     }
 
-    if (!stripeSDK || !elements) {
+    if (isStripeNotLoaded) {
       console.error('Stripe.js has not loaded yet. Please try again later.');
       return;
     }


### PR DESCRIPTION
## Description
Reorders onCheckoutButtonClicked in CheckoutViewWrapper.tsx so that elements.submit() runs as the first async operation of the submit handler, before the captcha and authentication network requests.

Apple Pay requires the payment sheet to be displayed synchronously within the user gesture (the click). The transient user activation is consumed by the first network await, so the previous order:

generateCaptchaToken() (reCAPTCHA request)
onAuthenticateUser() (auth request)
…validations…
elements.submit()
made Stripe throw when opening the Apple Pay sheet:

IntegrationError: Failed to show the Apple Pay payment sheet. Apple Pay requires the payment sheet to be displayed immediately after a user activation event... call elements.submit() at the top of your submission handler, before any async or long-running code.
## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [ ] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
