### PR TITLE
[PB-6707]: surface failed uploads in the retry modal and task logger

### DIFF
--- a/src/app/i18n/locales/de.json
+++ b/src/app/i18n/locales/de.json
@@ -1090,7 +1090,8 @@
       "allProcessesHaveFinished": "Alle Prozesse sind abgeschlossen",
       "processing": "Wird bearbeitet {{pending}} von {{finished}}",
       "failedToUpload": "Fehler beim Hochladen",
-      "failedToDownload": "Fehler beim Herunterladen"
+      "failedToDownload": "Fehler beim Herunterladen",
+      "notAllowed": "Nicht erlaubt"
     },
     "waiting": "Warten",
     "paused": "Pausiert",
@@ -1729,17 +1730,11 @@
               "Cleaner (Bereinigungstool)",
               "Meet (Videokonferenz)"
             ],
-            "comingSoonFeatures": [
-              "Mail",
-              "Fotos"
-            ]
+            "comingSoonFeatures": ["Mail", "Fotos"]
           },
           "default": {
             "bytesTitle": "{{bytes}}",
-            "features": [
-              "{{bytes}} verschlüsselter Cloud-Speicher",
-              "Verschlüsseltes VPN"
-            ]
+            "features": ["{{bytes}} verschlüsselter Cloud-Speicher", "Verschlüsseltes VPN"]
           }
         },
         "businessPlanFeaturesList": {

--- a/src/app/i18n/locales/en.json
+++ b/src/app/i18n/locales/en.json
@@ -1117,7 +1117,8 @@
       "allProcessesHaveFinished": "All processes have finished",
       "processing": "Processing {{pending}} of {{finished}}",
       "failedToUpload": "Failed to upload",
-      "failedToDownload": "Failed to download"
+      "failedToDownload": "Failed to download",
+      "notAllowed": "Not allowed"
     },
     "waiting": "Waiting",
     "paused": "Paused",
@@ -1753,17 +1754,11 @@
               "Cleaner",
               "Meet"
             ],
-            "comingSoonFeatures": [
-              "Mail",
-              "Photos"
-            ]
+            "comingSoonFeatures": ["Mail", "Photos"]
           },
           "default": {
             "bytesTitle": "{{bytes}}",
-            "features": [
-              "{{bytes}} of encrypted storage",
-              "Encrypted VPN"
-            ]
+            "features": ["{{bytes}} of encrypted storage", "Encrypted VPN"]
           }
         },
         "businessPlanFeaturesList": {

--- a/src/app/i18n/locales/es.json
+++ b/src/app/i18n/locales/es.json
@@ -1096,7 +1096,8 @@
       "allProcessesHaveFinished": "Todos los procesos han finalizado",
       "processing": "Procesando {{pending}} de {{finished}}",
       "failedToUpload": "Error al subir",
-      "failedToDownload": "Error al descargar"
+      "failedToDownload": "Error al descargar",
+      "notAllowed": "No permitido"
     },
     "waiting": "Esperando",
     "paused": "Pausado",
@@ -1733,17 +1734,11 @@
               "Cleaner",
               "Meet"
             ],
-            "comingSoonFeatures": [
-              "Mail",
-              "Fotos"
-            ]
+            "comingSoonFeatures": ["Mail", "Fotos"]
           },
           "default": {
             "bytesTitle": "{{bytes}}",
-            "features": [
-              "{{bytes}} de almacenamiento en la nube cifrado",
-              "VPN cifrada"
-            ]
+            "features": ["{{bytes}} de almacenamiento en la nube cifrado", "VPN cifrada"]
           }
         },
         "businessPlanFeaturesList": {

--- a/src/app/i18n/locales/fr.json
+++ b/src/app/i18n/locales/fr.json
@@ -1096,7 +1096,8 @@
       "allProcessesHaveFinished": "Tous les processus ont été complétés",
       "processing": "Traitement {{pending}} de {{finished}}",
       "failedToUpload": "Échec du téléchargement",
-      "failedToDownload": "Échec du téléchargement"
+      "failedToDownload": "Échec du téléchargement",
+      "notAllowed": "Non autorisé"
     },
     "waiting": "En attente",
     "paused": "En pause",
@@ -1732,17 +1733,11 @@
               "Nettoyeur",
               "Meet (Réunion)"
             ],
-            "comingSoonFeatures": [
-              "Mail",
-              "Photos"
-            ]
+            "comingSoonFeatures": ["Mail", "Photos"]
           },
           "default": {
             "bytesTitle": "{{bytes}}",
-            "features": [
-              "{{bytes}} de stockage cloud chiffré",
-              "VPN Chiffré"
-            ]
+            "features": ["{{bytes}} de stockage cloud chiffré", "VPN Chiffré"]
           }
         },
         "businessPlanFeaturesList": {

--- a/src/app/i18n/locales/it.json
+++ b/src/app/i18n/locales/it.json
@@ -1117,7 +1117,8 @@
       "allProcessesHaveFinished": "Tutti i processi sono stati completati",
       "processing": "Elaborazione {{pending}} di {{finished}}",
       "failedToUpload": "Caricamento fallito",
-      "failedToDownload": "Download fallito"
+      "failedToDownload": "Download fallito",
+      "notAllowed": "Non consentito"
     },
     "waiting": "In attesa",
     "paused": "In pausa",
@@ -1753,17 +1754,11 @@
               "Cleaner (Pulitore)",
               "Meet (Videoconferenza)"
             ],
-            "comingSoonFeatures": [
-              "Mail",
-              "Foto"
-            ]
+            "comingSoonFeatures": ["Mail", "Foto"]
           },
           "default": {
             "bytesTitle": "{{bytes}}",
-            "features": [
-              "{{bytes}} di spazio di archiviazione cloud crittografato",
-              "VPN Crittografata"
-            ]
+            "features": ["{{bytes}} di spazio di archiviazione cloud crittografato", "VPN Crittografata"]
           }
         },
         "businessPlanFeaturesList": {

--- a/src/app/i18n/locales/ru.json
+++ b/src/app/i18n/locales/ru.json
@@ -1096,7 +1096,8 @@
       "allProcessesHaveFinished": "Все процессы завершены",
       "processing": "Обработка {{pending}} из {{finished}}",
       "failedToUpload": "Не удалось загрузить",
-      "failedToDownload": "Не удалось загрузить"
+      "failedToDownload": "Не удалось загрузить",
+      "notAllowed": "Не разрешено"
     },
     "waiting": "Ожидание",
     "paused": "Приостановлено",
@@ -1732,17 +1733,11 @@
               "Cleaner (Очиститель)",
               "Meet (Видеоконференции)"
             ],
-            "comingSoonFeatures": [
-              "Mail (Почта)",
-              "Фотографии"
-            ]
+            "comingSoonFeatures": ["Mail (Почта)", "Фотографии"]
           },
           "default": {
             "bytesTitle": "{{bytes}}",
-            "features": [
-              "{{bytes}} зашифрованного облачного хранилища",
-              "Зашифрованный VPN"
-            ]
+            "features": ["{{bytes}} зашифрованного облачного хранилища", "Зашифрованный VPN"]
           }
         },
         "businessPlanFeaturesList": {

--- a/src/app/i18n/locales/tw.json
+++ b/src/app/i18n/locales/tw.json
@@ -1117,7 +1117,8 @@
       "allProcessesHaveFinished": "所有進程已完成",
       "processing": "處理中 {{pending}} 個，共 {{finished}} 個",
       "failedToUpload": "上傳失敗",
-      "failedToDownload": "下載失敗"
+      "failedToDownload": "下載失敗",
+      "notAllowed": "不允許"
     },
     "waiting": "等待中",
     "paused": "已暫停",
@@ -1753,17 +1754,11 @@
               "清理工具 (Cleaner)",
               "會議 (Meet)"
             ],
-            "comingSoonFeatures": [
-              "郵件 (Mail)",
-              "照片(Photos)"
-            ]
+            "comingSoonFeatures": ["郵件 (Mail)", "照片(Photos)"]
           },
           "default": {
             "bytesTitle": "{{bytes}}",
-            "features": [
-              "{{bytes}} 加密雲端儲存空間",
-              "加密 VPN"
-            ]
+            "features": ["{{bytes}} 加密雲端儲存空間", "加密 VPN"]
           }
         },
         "businessPlanFeaturesList": {

--- a/src/app/i18n/locales/zh.json
+++ b/src/app/i18n/locales/zh.json
@@ -1117,7 +1117,8 @@
       "allProcessesHaveFinished": "所有处理都已完成",
       "processing": "正在处理 {{pending}}/{{finished}}",
       "failedToUpload": "上傳失敗",
-      "failedToDownload": "下載失敗"
+      "failedToDownload": "下載失敗",
+      "notAllowed": "不允許"
     },
     "waiting": "等待中",
     "paused": "暂停",
@@ -1753,17 +1754,11 @@
               "清理工具 (Cleaner)",
               "会议 (Meet)"
             ],
-            "comingSoonFeatures": [
-              "邮件 (Mail)",
-              "照片 (Photos)"
-            ]
+            "comingSoonFeatures": ["邮件 (Mail)", "照片 (Photos)"]
           },
           "default": {
             "bytesTitle": "{{bytes}}",
-            "features": [
-              "{{bytes}} 加密云存储空间",
-              "加密 VPN"
-            ]
+            "features": ["{{bytes}} 加密云存储空间", "加密 VPN"]
           }
         },
         "businessPlanFeaturesList": {

--- a/src/app/network/DownloadManager.ts
+++ b/src/app/network/DownloadManager.ts
@@ -13,7 +13,7 @@ import {
   isLostConnectionError,
   areItemArraysEqual,
 } from 'app/drive/services/downloadManager.service';
-import RetryManager, { RetryableTask } from './RetryManager';
+import RetryManager, { RetryableTask, RetryableTaskType } from './RetryManager';
 import { ErrorMessages } from 'app/core/constants';
 
 /**
@@ -175,7 +175,7 @@ export class DownloadManager {
             ({
               taskId: downloadTask.taskId,
               params: item,
-              type: 'download',
+              type: RetryableTaskType.Download,
             }) as RetryableTask,
         );
         RetryManager.addTasks(failedTasks);

--- a/src/app/network/RetryManager.test.ts
+++ b/src/app/network/RetryManager.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import RetryManager, { RetryableTask } from './RetryManager';
+import RetryManager, { RetryableTask, RetryableTaskStatus, RetryableTaskType } from './RetryManager';
 
 describe('RetryManager', () => {
-  const sampleTask: RetryableTask = { taskId: 'task1', type: 'upload', params: {} };
-  const anotherTask: RetryableTask = { taskId: 'task2', type: 'download', params: {} };
+  const sampleTask: RetryableTask = { taskId: 'task1', type: RetryableTaskType.Upload, params: {} };
+  const anotherTask: RetryableTask = { taskId: 'task2', type: RetryableTaskType.Download, params: {} };
 
   beforeEach(() => {
     RetryManager.clearTasks();
@@ -13,15 +13,15 @@ describe('RetryManager', () => {
     RetryManager.addTask(sampleTask);
     const tasks = RetryManager.getTasks();
     expect(tasks).toHaveLength(1);
-    expect(tasks[0]).toEqual({ ...sampleTask, status: 'failed' });
+    expect(tasks[0]).toEqual({ ...sampleTask, status: RetryableTaskStatus.Failed });
   });
 
   it('should add multiple tasks with failed status', () => {
     RetryManager.addTasks([sampleTask, anotherTask]);
     const tasks = RetryManager.getTasks();
     expect(tasks).toHaveLength(2);
-    expect(tasks).toContainEqual({ ...sampleTask, status: 'failed' });
-    expect(tasks).toContainEqual({ ...anotherTask, status: 'failed' });
+    expect(tasks).toContainEqual({ ...sampleTask, status: RetryableTaskStatus.Failed });
+    expect(tasks).toContainEqual({ ...anotherTask, status: RetryableTaskStatus.Failed });
   });
 
   it('should replace an existing task instead of duplicating it when re-added', () => {
@@ -30,22 +30,22 @@ describe('RetryManager', () => {
     const tasks = RetryManager.getTasks();
     expect(tasks).toHaveLength(2);
     expect(tasks.filter((task) => task.taskId === 'task1')).toEqual([
-      { ...sampleTask, retryable: false, status: 'failed' },
+      { ...sampleTask, retryable: false, status: RetryableTaskStatus.Failed },
     ]);
   });
 
   it('should change the status of a task', () => {
     RetryManager.addTask(sampleTask);
-    RetryManager.changeStatus('task1', 'retrying');
+    RetryManager.changeStatus('task1', RetryableTaskStatus.Retrying);
     const tasks = RetryManager.getTasks();
-    expect(tasks[0].status).toBe('retrying');
+    expect(tasks[0].status).toBe(RetryableTaskStatus.Retrying);
   });
 
   it('should not change status if taskId does not exist', () => {
     RetryManager.addTask(sampleTask);
-    RetryManager.changeStatus('invalidTask', 'retrying');
+    RetryManager.changeStatus('invalidTask', RetryableTaskStatus.Retrying);
     const tasks = RetryManager.getTasks();
-    expect(tasks[0].status).toBe('failed');
+    expect(tasks[0].status).toBe(RetryableTaskStatus.Failed);
   });
 
   it('should remove a task by taskId', () => {
@@ -79,7 +79,7 @@ describe('RetryManager', () => {
     RetryManager.addTask(sampleTask);
     expect(listener).toHaveBeenCalledTimes(1);
 
-    RetryManager.changeStatus('task1', 'retrying');
+    RetryManager.changeStatus('task1', RetryableTaskStatus.Retrying);
     expect(listener).toHaveBeenCalledTimes(2);
 
     RetryManager.removeTask('task1');
@@ -112,46 +112,46 @@ describe('RetryManager', () => {
 
   it('should return all tasks if no type is specified', () => {
     RetryManager.addTasks([
-      { taskId: 'task1', type: 'upload', params: {} },
-      { taskId: 'task2', type: 'download', params: {} },
+      { taskId: 'task1', type: RetryableTaskType.Upload, params: {} },
+      { taskId: 'task2', type: RetryableTaskType.Download, params: {} },
     ]);
 
     const tasks = RetryManager.getTasks();
     expect(tasks).toHaveLength(2);
     expect(tasks).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ taskId: 'task1', type: 'upload' }),
-        expect.objectContaining({ taskId: 'task2', type: 'download' }),
+        expect.objectContaining({ taskId: 'task1', type: RetryableTaskType.Upload }),
+        expect.objectContaining({ taskId: 'task2', type: RetryableTaskType.Download }),
       ]),
     );
   });
 
   it('should return only upload tasks when type is upload', () => {
     RetryManager.addTasks([
-      { taskId: 'task1', type: 'upload', params: {} },
-      { taskId: 'task2', type: 'download', params: {} },
+      { taskId: 'task1', type: RetryableTaskType.Upload, params: {} },
+      { taskId: 'task2', type: RetryableTaskType.Download, params: {} },
     ]);
 
-    const tasks = RetryManager.getTasks('upload');
+    const tasks = RetryManager.getTasks(RetryableTaskType.Upload);
     expect(tasks).toHaveLength(1);
-    expect(tasks[0]).toEqual(expect.objectContaining({ taskId: 'task1', type: 'upload' }));
+    expect(tasks[0]).toEqual(expect.objectContaining({ taskId: 'task1', type: RetryableTaskType.Upload }));
   });
 
   it('should return only download tasks when type is download', () => {
     RetryManager.addTasks([
-      { taskId: 'task1', type: 'upload', params: {} },
-      { taskId: 'task2', type: 'download', params: {} },
+      { taskId: 'task1', type: RetryableTaskType.Upload, params: {} },
+      { taskId: 'task2', type: RetryableTaskType.Download, params: {} },
     ]);
 
-    const tasks = RetryManager.getTasks('download');
+    const tasks = RetryManager.getTasks(RetryableTaskType.Download);
     expect(tasks).toHaveLength(1);
-    expect(tasks[0]).toEqual(expect.objectContaining({ taskId: 'task2', type: 'download' }));
+    expect(tasks[0]).toEqual(expect.objectContaining({ taskId: 'task2', type: RetryableTaskType.Download }));
   });
 
   it('should return an empty array if no tasks match the specified type', () => {
-    RetryManager.addTask({ taskId: 'task1', type: 'upload', params: {} });
+    RetryManager.addTask({ taskId: 'task1', type: RetryableTaskType.Upload, params: {} });
 
-    const tasks = RetryManager.getTasks('download');
+    const tasks = RetryManager.getTasks(RetryableTaskType.Download);
     expect(tasks).toHaveLength(0);
   });
 });

--- a/src/app/network/RetryManager.ts
+++ b/src/app/network/RetryManager.ts
@@ -1,8 +1,19 @@
+export enum RetryableTaskType {
+  Upload = 'upload',
+  Download = 'download',
+}
+
+export enum RetryableTaskStatus {
+  Pending = 'pending',
+  Failed = 'failed',
+  Retrying = 'retrying',
+}
+
 export type RetryableTask = {
   taskId: string;
-  type: 'upload' | 'download';
+  type: RetryableTaskType;
   params: any;
-  status?: 'pending' | 'failed' | 'retrying';
+  status?: RetryableTaskStatus;
   retryable?: boolean;
 };
 
@@ -11,7 +22,7 @@ class RetryManager {
   private listeners: (() => void)[] = [];
 
   addTask(task: RetryableTask) {
-    this.tasksToRetry.push({ ...task, status: 'failed' });
+    this.tasksToRetry.push({ ...task, status: RetryableTaskStatus.Failed });
     this.notify();
   }
 
@@ -19,13 +30,13 @@ class RetryManager {
     // A task can only appear once per taskId: re-adding a failed task replaces its entry
     // instead of duplicating it in the retry list.
     const incomingTaskIds = new Set(tasks.map((task) => task.taskId).filter(Boolean));
-    const tasksWithStatus = tasks.map((task) => ({ ...task, status: 'failed' }) as RetryableTask);
+    const tasksWithStatus = tasks.map((task) => ({ ...task, status: RetryableTaskStatus.Failed }));
     this.tasksToRetry = this.tasksToRetry.filter((task) => !incomingTaskIds.has(task.taskId));
     this.tasksToRetry.push(...tasksWithStatus);
     this.notify();
   }
 
-  changeStatus(taskId: string, status: 'pending' | 'failed' | 'retrying') {
+  changeStatus(taskId: string, status: RetryableTaskStatus) {
     this.tasksToRetry = this.tasksToRetry.map((task) => (task.taskId === taskId ? { ...task, status } : task));
     this.notify();
   }
@@ -52,7 +63,7 @@ class RetryManager {
     this.notify();
   }
 
-  getTasks(type?: 'upload' | 'download') {
+  getTasks(type?: RetryableTaskType) {
     return type ? this.tasksToRetry.filter((task) => task.type === type) : this.tasksToRetry;
   }
 

--- a/src/app/network/UploadManager.test.ts
+++ b/src/app/network/UploadManager.test.ts
@@ -5,7 +5,7 @@ import { AppError } from '@internxt/sdk';
 import uploadFile from 'app/drive/services/file.service/uploadFile';
 import DatabaseUploadRepository from 'app/repositories/DatabaseUploadRepository';
 import { DriveFileData } from 'app/drive/types';
-import RetryManager from './RetryManager';
+import RetryManager, { RetryableTaskType } from './RetryManager';
 import { TaskStatus } from 'app/tasks/types';
 import { ErrorMessages } from 'app/core/constants';
 
@@ -707,7 +707,9 @@ describe('uploadFileWithManager', () => {
       userEmail: '',
       parentFolderId: '',
     };
-    RetryManager.addTasks([{ taskId: 'retried-task', type: 'upload', params: fileParams, retryable: true }]);
+    RetryManager.addTasks([
+      { taskId: 'retried-task', type: RetryableTaskType.Upload, params: fileParams, retryable: true },
+    ]);
 
     await expect(
       uploadFileWithManager({

--- a/src/app/network/UploadManager.ts
+++ b/src/app/network/UploadManager.ts
@@ -8,7 +8,7 @@ import { PersistUploadRepository } from '../repositories/DatabaseUploadRepositor
 import { TaskStatus } from '../tasks/types';
 import { ConnectionLostError } from './requests';
 import { FileToUpload } from 'app/drive/services/file.service/types';
-import RetryManager, { RetryableTask } from './RetryManager';
+import RetryManager, { RetryableTask, RetryableTaskStatus, RetryableTaskType } from './RetryManager';
 import { ErrorMessages } from 'app/core/constants';
 import { MAX_UPLOAD_ATTEMPTS, TWENTY_MEGABYTES, USE_MULTIPART_THRESHOLD_BYTES } from './networkConstants';
 import { OwnerUserAuthenticationData, UploadErrorReason } from './types';
@@ -440,7 +440,7 @@ class UploadManager {
           else
             filesToRetry.push({
               taskId: files[i]?.taskId ?? files[i]?.relatedTaskId ?? '',
-              type: 'upload',
+              type: RetryableTaskType.Upload,
               params: files[i],
               retryable: !this.nonRetryableTaskIds.has(files[i]?.taskId ?? ''),
             });
@@ -451,7 +451,7 @@ class UploadManager {
         if (files.length === 1 && fileTaskId) {
           const noFilesToRetry = filesToRetry.length === 0;
           if (noFilesToRetry) RetryManager.removeTask(fileTaskId);
-          else RetryManager.changeStatus(fileTaskId, 'failed');
+          else RetryManager.changeStatus(fileTaskId, RetryableTaskStatus.Failed);
         }
       };
 

--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.test.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.test.ts
@@ -9,7 +9,7 @@ import { RootState } from '../../..';
 import { prepareFilesToUpload } from '../fileUtils/prepareFilesToUpload';
 import { uploadFilesWithTasks } from 'app/tasks/upload/uploadFilesWithTasks';
 import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
-import RetryManager from 'app/network/RetryManager';
+import RetryManager, { RetryableTaskType } from 'app/network/RetryManager';
 import { ActionReducerMapBuilder } from '@reduxjs/toolkit';
 import { StorageState } from '../storage.model';
 import errorService from 'services/error.service';
@@ -350,7 +350,7 @@ describe('uploadItemsThunkExtraReducers', () => {
     const RetryChangeStatusSpy = vi.spyOn(RetryManager, 'changeStatus');
 
     RetryManager.addTask({
-      type: 'upload',
+      type: RetryableTaskType.Upload,
       taskId: sampleFile.taskId ?? 'task1',
       params: sampleFile,
     });

--- a/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/uploadItemsThunk.ts
@@ -21,7 +21,7 @@ import { planSelectors, planThunks } from '../../plan';
 import { uiActions } from '../../ui';
 import workspacesSelectors from '../../workspaces/workspaces.selectors';
 
-import RetryManager from 'app/network/RetryManager';
+import RetryManager, { RetryableTaskStatus } from 'app/network/RetryManager';
 import { FileToUpload } from 'app/drive/services/file.service/types';
 import { prepareFilesToUpload } from '../fileUtils/prepareFilesToUpload';
 import { StorageState } from '../storage.model';
@@ -227,7 +227,7 @@ export const uploadItemsThunk = createAsyncThunk<void, UploadItemsPayload, { sta
         },
       });
     } catch (error) {
-      if (taskId && isRetry) RetryManager.changeStatus(taskId, 'failed');
+      if (taskId && isRetry) RetryManager.changeStatus(taskId, RetryableTaskStatus.Failed);
       errors.push(errorService.castError(error));
     }
 
@@ -540,7 +540,7 @@ export const uploadItemsThunkExtraReducers = (builder: ActionReducerMapBuilder<S
     .addCase(uploadItemsParallelThunk.rejected, (state, action) => {
       const requestOptions = { ...DEFAULT_OPTIONS, ...(action.meta.arg.options ?? {}) };
       const taskId = action.meta.arg.taskId;
-      if (taskId && RetryManager.isRetryingTask(taskId)) RetryManager.changeStatus(taskId, 'failed');
+      if (taskId && RetryManager.isRetryingTask(taskId)) RetryManager.changeStatus(taskId, RetryableTaskStatus.Failed);
       if (requestOptions?.showErrors) {
         notificationsService.show({
           text: t('error.uploadingFile', { reason: action.error.message ?? '' }),

--- a/src/app/tasks/components/TaskLogger/TaskLogger.tsx
+++ b/src/app/tasks/components/TaskLogger/TaskLogger.tsx
@@ -27,7 +27,7 @@ const TaskLogger = (): JSX.Element => {
   const filesToRetryGroupedByTask = useMemo(
     () =>
       filesToRetry.reduce<Record<string, RetryableTask[]>>((acc, file) => {
-        const relatedTaskId = file.taskId;
+        const relatedTaskId = file.params?.relatedTaskId ?? file.taskId;
         if (relatedTaskId) {
           if (!acc[relatedTaskId]) {
             acc[relatedTaskId] = [];

--- a/src/app/tasks/components/TaskLoggerActions/TaskButtonActionBlocks.tsx
+++ b/src/app/tasks/components/TaskLoggerActions/TaskButtonActionBlocks.tsx
@@ -84,14 +84,13 @@ const PendingBlock = (): JSX.Element => {
 
 const SuccessBlock = ({ isHovered, magnifyingAction, infoAction, taskType, haveWarnings }): JSX.Element => {
   if (isHovered && taskType.includes('upload')) {
-    return (
-      <>
-        {haveWarnings && <TaskLoggerButton onClick={infoAction} Icon={InfoIcon} />}
-        <TaskLoggerButton onClick={magnifyingAction} Icon={MagnifyingGlass} />
-      </>
+    return haveWarnings ? (
+      <TaskLoggerButton onClick={infoAction} Icon={InfoIcon} iconSize={20} />
+    ) : (
+      <TaskLoggerButton onClick={magnifyingAction} Icon={MagnifyingGlass} />
     );
   } else if (isHovered && taskType.includes('download')) {
-    return <>{haveWarnings && <TaskLoggerButton onClick={infoAction} Icon={InfoIcon} />}</>;
+    return <>{haveWarnings && <TaskLoggerButton onClick={infoAction} Icon={InfoIcon} iconSize={20} />}</>;
   } else {
     return (
       <div className="flex h-8 w-8 items-center justify-center">

--- a/src/app/tasks/components/TaskLoggerButton/TaskLoggerButton.tsx
+++ b/src/app/tasks/components/TaskLoggerButton/TaskLoggerButton.tsx
@@ -4,17 +4,25 @@ interface TaskLoggerButtonProps {
   onClick: () => void;
   Icon: FunctionComponent<SVGProps<SVGSVGElement>>;
   className?: string;
+  sizeClassName?: string;
+  iconSize?: number;
 }
 
-export const TaskLoggerButton = ({ onClick, Icon, className }: TaskLoggerButtonProps) => {
+export const TaskLoggerButton = ({
+  onClick,
+  Icon,
+  className,
+  sizeClassName = 'h-8 w-8',
+  iconSize = 20,
+}: TaskLoggerButtonProps) => {
   return (
     <button
       data-testid="task-logger-button"
       onClick={onClick}
       onKeyDown={() => {}}
-      className={`flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg border border-gray-10 bg-white shadow-sm dark:border-gray-30 dark:bg-gray-20 ${className}`}
+      className={`flex ${sizeClassName} cursor-pointer items-center justify-center rounded-lg border border-gray-10 bg-white shadow-sm dark:border-gray-30 dark:bg-gray-20 ${className}`}
     >
-      <Icon height={20} width={20} className="text-gray-100" />
+      <Icon height={iconSize} width={iconSize} className="text-gray-100" />
     </button>
   );
 };

--- a/src/app/tasks/components/TaskLoggerItem/TaskLoggerItem.tsx
+++ b/src/app/tasks/components/TaskLoggerItem/TaskLoggerItem.tsx
@@ -11,7 +11,7 @@ import { TaskData, TaskNotification, TaskStatus, TaskType, UploadFileData, Uploa
 import { TaskLoggerActions } from '../TaskLoggerActions/TaskLoggerActions';
 import workspacesSelectors from 'app/store/slices/workspaces/workspaces.selectors';
 import TaskToRetry from '../TaskToRetry/TaskToRetry';
-import { RetryableTask } from 'app/network/RetryManager';
+import { RetryableTask, RetryableTaskType } from 'app/network/RetryManager';
 
 const THREE_HUNDRED_MB_IN_BYTES = 3 * 100 * 1024 * 1024;
 interface TaskLoggerItemProps {
@@ -132,7 +132,7 @@ const TaskLoggerItem = ({ notification, task, filesToRetry }: TaskLoggerItemProp
     [TaskStatus.Error, TaskStatus.Cancelled].includes(notification.status) &&
     (notification.action === TaskType.DownloadFile || notification.action === TaskType.DownloadFolder);
   const someFileIsDownloaded = filesToRetry?.some(
-    (file) => file.taskId === notification.taskId && file.type === 'download',
+    (file) => file.taskId === notification.taskId && file.type === RetryableTaskType.Download,
   );
 
   const isDownloadError = isDownloadAction || someFileIsDownloaded;

--- a/src/app/tasks/components/TaskToRetry/TaskToRetry.test.tsx
+++ b/src/app/tasks/components/TaskToRetry/TaskToRetry.test.tsx
@@ -1,7 +1,7 @@
 import { render, fireEvent } from '@testing-library/react';
 import { describe, it, vi, expect, beforeEach } from 'vitest';
 import TaskToRetry from './TaskToRetry';
-import RetryManager, { RetryableTask } from '../../../network/RetryManager';
+import RetryManager, { RetryableTask, RetryableTaskStatus, RetryableTaskType } from '../../../network/RetryManager';
 
 vi.mock('../../../store/hooks', () => ({
   useAppDispatch: vi.fn(),
@@ -42,7 +42,7 @@ describe('TaskToRetry', () => {
   const files: RetryableTask[] = [
     {
       taskId: 'task-1',
-      type: 'upload',
+      type: RetryableTaskType.Upload,
       params: {
         filecontent: {
           content: 'file-content' as any,
@@ -55,7 +55,7 @@ describe('TaskToRetry', () => {
         taskId: 'task-1',
         userEmail: 'user@example.com',
       },
-      status: 'failed',
+      status: RetryableTaskStatus.Failed,
     },
   ];
 
@@ -98,7 +98,7 @@ describe('TaskToRetry', () => {
 
     if (downloadItem) fireEvent.click(downloadItem);
 
-    expect(mockChangeStatus).toHaveBeenCalledWith('task-1', 'retrying');
+    expect(mockChangeStatus).toHaveBeenCalledWith('task-1', RetryableTaskStatus.Retrying);
     expect(mockUploadRetryItem).toHaveBeenCalledWith({
       uploadFile: 'file-content',
       parentFolderId: 'folder-1',
@@ -118,7 +118,7 @@ describe('TaskToRetry', () => {
 
     if (downloadItem) fireEvent.click(downloadItem);
 
-    expect(mockChangeStatus).toHaveBeenCalledWith('task-1', 'retrying');
-    expect(mockChangeStatus).toHaveBeenCalledWith('task-1', 'failed');
+    expect(mockChangeStatus).toHaveBeenCalledWith('task-1', RetryableTaskStatus.Retrying);
+    expect(mockChangeStatus).toHaveBeenCalledWith('task-1', RetryableTaskStatus.Failed);
   });
 });

--- a/src/app/tasks/components/TaskToRetry/TaskToRetry.tsx
+++ b/src/app/tasks/components/TaskToRetry/TaskToRetry.tsx
@@ -3,7 +3,7 @@ import { useReduxActions } from 'app/store/slices/storage/hooks/useReduxActions'
 import { FixedSizeList as List } from 'react-window';
 import TaskToRetryItem from '../TaskToRetryItem/TaskToRetryItem';
 import { useTranslationContext } from 'app/i18n/provider/TranslationProvider';
-import RetryManager, { RetryableTask } from '../../../network/RetryManager';
+import RetryManager, { RetryableTask, RetryableTaskStatus, RetryableTaskType } from '../../../network/RetryManager';
 import { Modal } from '@internxt/ui';
 import { DownloadManager } from '../../../network/DownloadManager';
 import { useAppSelector } from '../../../store/hooks';
@@ -22,21 +22,21 @@ const TaskToRetry = ({ isOpen, files, onClose }: TaskToRetryProps): JSX.Element 
   const workspaceCredentials = useAppSelector(workspacesSelectors.getWorkspaceCredentials);
 
   const downloadItem = async ({ taskId, params, type }: RetryableTask) => {
-    if (type == 'upload') {
+    if (type === RetryableTaskType.Upload) {
       const data = {
         uploadFile: params?.filecontent?.content,
         parentFolderId: params?.parentFolderId,
         taskId: taskId ?? params?.taskId ?? '',
         fileType: params?.filecontent?.type ?? '',
       };
-      RetryManager.changeStatus(taskId ?? params?.taskId ?? '', 'retrying');
+      RetryManager.changeStatus(taskId ?? params?.taskId ?? '', RetryableTaskStatus.Retrying);
       try {
         uploadRetryItem(data);
       } catch {
-        RetryManager.changeStatus(taskId ?? params?.taskId ?? '', 'failed');
+        RetryManager.changeStatus(taskId ?? params?.taskId ?? '', RetryableTaskStatus.Failed);
       }
     } else {
-      RetryManager.changeStatus(taskId, 'retrying');
+      RetryManager.changeStatus(taskId, RetryableTaskStatus.Retrying);
       try {
         await DownloadManager.downloadItem({
           payload: [params],
@@ -45,7 +45,7 @@ const TaskToRetry = ({ isOpen, files, onClose }: TaskToRetryProps): JSX.Element 
           taskId,
         });
       } finally {
-        RetryManager.changeStatus(taskId ?? params?.taskId ?? '', 'failed');
+        RetryManager.changeStatus(taskId ?? params?.taskId ?? '', RetryableTaskStatus.Failed);
       }
     }
   };
@@ -55,7 +55,7 @@ const TaskToRetry = ({ isOpen, files, onClose }: TaskToRetryProps): JSX.Element 
       <div className="flex pb-5 justify-between items-center">
         <h4 data-testid="title-taskRetry" className="text-xl font-medium text-gray-100 ">
           {translate(
-            files?.length > 0 && files[0].type === 'upload'
+            files?.length > 0 && files[0].type === RetryableTaskType.Upload
               ? 'tasks.messages.failedToUpload'
               : 'tasks.messages.failedToDownload',
           )}

--- a/src/app/tasks/components/TaskToRetry/TaskToRetry.tsx
+++ b/src/app/tasks/components/TaskToRetry/TaskToRetry.tsx
@@ -44,11 +44,10 @@ const TaskToRetry = ({ isOpen, files, onClose }: TaskToRetryProps): JSX.Element 
           workspaceCredentials,
           taskId,
         });
-      } catch {
+      } finally {
         RetryManager.changeStatus(taskId ?? params?.taskId ?? '', 'failed');
       }
     }
-    RetryManager.changeStatus(taskId ?? params?.taskId ?? '', 'failed');
   };
 
   return (
@@ -73,9 +72,11 @@ const TaskToRetry = ({ isOpen, files, onClose }: TaskToRetryProps): JSX.Element 
       <div className="absolute top-[72px] left-0 w-full border-b border-gray-10" />
 
       {files?.length > 0 ? (
-        <List height={400} itemCount={files.length} itemSize={72} width={'100%'} itemData={{ files, downloadItem }}>
-          {TaskToRetryItem}
-        </List>
+        <div className="pt-3">
+          <List height={400} itemCount={files.length} itemSize={72} width={'100%'} itemData={{ files, downloadItem }}>
+            {TaskToRetryItem}
+          </List>
+        </div>
       ) : (
         <span className="flex p-5 justify-between items-center" data-testid="finish-msg-taskRetry">
           {translate('tasks.messages.allProcessesHaveFinished')}.

--- a/src/app/tasks/components/TaskToRetryItem/TaskToRetryItem.test.tsx
+++ b/src/app/tasks/components/TaskToRetryItem/TaskToRetryItem.test.tsx
@@ -8,7 +8,7 @@ vi.mock('app/drive/services/size.service', () => ({
 }));
 
 vi.mock('services/date.service', () => ({
-  formatDefaultDate: vi.fn(() => '2025-02-25'),
+  formatDefaultDate: vi.fn(() => '9 Jan, 2025 at 12:20'),
 }));
 
 vi.mock('i18next', () => ({
@@ -22,7 +22,7 @@ describe('TaskToRetyItem', () => {
       filecontent: {
         name: 'Test File',
         size: 10485760,
-        type: 'application/pdf',
+        type: 'pdf',
         content: {
           lastModified: 1677654000000,
         },
@@ -40,11 +40,11 @@ describe('TaskToRetyItem', () => {
     },
   };
 
-  it('should render file namem size and date correctly', () => {
+  it('should render the file name with its extension, plus size and date', () => {
     const { getByText } = render(<TaskToRetyItem {...defaultProps} />);
 
-    expect(getByText('Test File')).toBeInTheDocument();
-    expect(getByText('10 MB - 2025-02-25')).toBeInTheDocument();
+    expect(getByText('Test File.pdf')).toBeInTheDocument();
+    expect(getByText('10 MB - 9 Jan, 2025 at 12:20')).toBeInTheDocument();
   });
 
   it('should render a retry button when the file status is "failed"', () => {
@@ -64,5 +64,14 @@ describe('TaskToRetyItem', () => {
     const { container } = render(<TaskToRetyItem {...uploadingProps} />);
     const spinner = container.querySelector('.animate-spin');
     expect(spinner).toBeInTheDocument();
+  });
+
+  it('should render a "Not allowed" label instead of a retry button when the file is not retryable', () => {
+    const notAllowedFile = { ...mockFile, retryable: false };
+    const notAllowedProps = { ...defaultProps, data: { files: [notAllowedFile], downloadItem: mockDownloadItem } };
+    const { getByText, queryByRole } = render(<TaskToRetyItem {...notAllowedProps} />);
+
+    expect(getByText('tasks.messages.notAllowed')).toBeInTheDocument();
+    expect(queryByRole('button')).not.toBeInTheDocument();
   });
 });

--- a/src/app/tasks/components/TaskToRetryItem/TaskToRetryItem.test.tsx
+++ b/src/app/tasks/components/TaskToRetryItem/TaskToRetryItem.test.tsx
@@ -2,6 +2,7 @@ import { render, fireEvent } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { ListChildComponentProps } from 'react-window';
 import TaskToRetyItem from './TaskToRetryItem';
+import { RetryableTaskStatus, RetryableTaskType } from 'app/network/RetryManager';
 
 vi.mock('app/drive/services/size.service', () => ({
   bytesToString: vi.fn(() => '10 MB'),
@@ -18,6 +19,8 @@ vi.mock('i18next', () => ({
 describe('TaskToRetyItem', () => {
   const mockDownloadItem = vi.fn();
   const mockFile = {
+    taskId: 'task-1',
+    type: RetryableTaskType.Upload,
     params: {
       filecontent: {
         name: 'Test File',
@@ -28,7 +31,7 @@ describe('TaskToRetyItem', () => {
         },
       },
     },
-    status: 'failed',
+    status: RetryableTaskStatus.Failed,
   };
 
   const defaultProps: ListChildComponentProps = {
@@ -47,6 +50,26 @@ describe('TaskToRetyItem', () => {
     expect(getByText('10 MB - 9 Jan, 2025 at 12:20')).toBeInTheDocument();
   });
 
+  it('should render the decrypted plainName of a failed download item', () => {
+    const downloadFile = {
+      taskId: 'task-2',
+      type: RetryableTaskType.Download,
+      params: {
+        plainName: 'Report',
+        name: 'encrypted-name',
+        type: 'pdf',
+        size: 10485760,
+        updatedAt: '2025-01-09T12:20:00.000Z',
+        isFolder: false,
+      },
+      status: RetryableTaskStatus.Failed,
+    };
+    const downloadProps = { ...defaultProps, data: { files: [downloadFile], downloadItem: mockDownloadItem } };
+    const { getByText } = render(<TaskToRetyItem {...downloadProps} />);
+
+    expect(getByText('Report.pdf')).toBeInTheDocument();
+  });
+
   it('should render a retry button when the file status is "failed"', () => {
     const { getByRole } = render(<TaskToRetyItem {...defaultProps} />);
     expect(getByRole('button')).toBeInTheDocument();
@@ -59,7 +82,7 @@ describe('TaskToRetyItem', () => {
   });
 
   it('should render a spinner when the file status is "retrying"', () => {
-    const uploadingFile = { ...mockFile, status: 'retrying' };
+    const uploadingFile = { ...mockFile, status: RetryableTaskStatus.Retrying };
     const uploadingProps = { ...defaultProps, data: { files: [uploadingFile], downloadItem: mockDownloadItem } };
     const { container } = render(<TaskToRetyItem {...uploadingProps} />);
     const spinner = container.querySelector('.animate-spin');

--- a/src/app/tasks/components/TaskToRetryItem/TaskToRetryItem.tsx
+++ b/src/app/tasks/components/TaskToRetryItem/TaskToRetryItem.tsx
@@ -6,7 +6,9 @@ import { formatDefaultDate } from 'services/date.service';
 import { t } from 'i18next';
 import { TaskLoggerButton } from '../TaskLoggerButton/TaskLoggerButton';
 import { CircleNotch } from '@phosphor-icons/react';
-import { RetryableTask } from 'app/network/RetryManager';
+import { RetryableTask, RetryableTaskStatus, RetryableTaskType } from 'app/network/RetryManager';
+import { UploadManagerFileParams } from 'app/network/UploadManager';
+import { DownloadItemType } from 'app/drive/services/downloadManager.service';
 
 interface DisplayData {
   name: string;
@@ -16,20 +18,31 @@ interface DisplayData {
   isFolder: boolean;
 }
 
-const getDisplayData = (params: RetryableTask['params']): DisplayData => ({
-  name: params?.filecontent?.name ?? params.plainName ?? params.name,
-  type: params?.filecontent?.type ?? params.type,
-  size: params?.filecontent?.size ?? params.size,
-  modifiedAt: params?.filecontent?.content.lastModified ?? params.updatedAt,
-  isFolder: Boolean(params?.isFolder),
+const getUploadDisplayData = (params: UploadManagerFileParams): DisplayData => ({
+  name: params.filecontent.name,
+  type: params.filecontent.type,
+  size: params.filecontent.size,
+  modifiedAt: params.filecontent.content.lastModified,
+  isFolder: false,
 });
+
+const getDownloadDisplayData = (item: DownloadItemType): DisplayData => ({
+  name: item.plainName ?? item.name,
+  type: item.type,
+  size: item.size,
+  modifiedAt: item.updatedAt,
+  isFolder: Boolean(item.isFolder),
+});
+
+const getDisplayData = (task: RetryableTask): DisplayData =>
+  task.type === RetryableTaskType.Upload ? getUploadDisplayData(task.params) : getDownloadDisplayData(task.params);
 
 const withExtension = (name: string, type?: string): string =>
   type && !name?.toLowerCase().endsWith(`.${type.toLowerCase()}`) ? `${name}.${type}` : name;
 
 const TaskToRetyItem = ({ index, style, data }: ListChildComponentProps) => {
   const file: RetryableTask = data.files[index];
-  const { params, status, retryable } = file;
+  const { status, retryable } = file;
   const { downloadItem } = data;
   const isNotAllowed = retryable === false;
   const getFileIcon = (type: string) => {
@@ -39,7 +52,7 @@ const TaskToRetyItem = ({ index, style, data }: ListChildComponentProps) => {
   const FolderIcon = iconService.getItemIcon(true);
   const getFolderIcon = <FolderIcon className="w-12 h-12 drop-shadow-soft" />;
 
-  const { name, type, size, modifiedAt, isFolder } = getDisplayData(params);
+  const { name, type, size, modifiedAt, isFolder } = getDisplayData(file);
   const displayName = withExtension(name, type);
   const displaySize = bytesToString(size, false).replace('kB', 'KB');
 
@@ -60,10 +73,10 @@ const TaskToRetyItem = ({ index, style, data }: ListChildComponentProps) => {
         </div>
       </div>
       {isNotAllowed && <span className="mr-2 text-sm font-medium text-gray-50">{t('tasks.messages.notAllowed')}</span>}
-      {!isNotAllowed && status === 'failed' && (
+      {!isNotAllowed && status === RetryableTaskStatus.Failed && (
         <TaskLoggerButton onClick={() => downloadItem(file)} Icon={RestartIcon} sizeClassName="h-8 w-8" iconSize={16} />
       )}
-      {!isNotAllowed && status === 'retrying' && (
+      {!isNotAllowed && status === RetryableTaskStatus.Retrying && (
         <CircleNotch size={16} className="mr-2 animate-spin text-gray-60" weight="bold" />
       )}
     </div>

--- a/src/app/tasks/components/TaskToRetryItem/TaskToRetryItem.tsx
+++ b/src/app/tasks/components/TaskToRetryItem/TaskToRetryItem.tsx
@@ -8,10 +8,30 @@ import { TaskLoggerButton } from '../TaskLoggerButton/TaskLoggerButton';
 import { CircleNotch } from '@phosphor-icons/react';
 import { RetryableTask } from 'app/network/RetryManager';
 
+interface DisplayData {
+  name: string;
+  type?: string;
+  size: number;
+  modifiedAt: number | string;
+  isFolder: boolean;
+}
+
+const getDisplayData = (params: RetryableTask['params']): DisplayData => ({
+  name: params?.filecontent?.name ?? params.plainName ?? params.name,
+  type: params?.filecontent?.type ?? params.type,
+  size: params?.filecontent?.size ?? params.size,
+  modifiedAt: params?.filecontent?.content.lastModified ?? params.updatedAt,
+  isFolder: Boolean(params?.isFolder),
+});
+
+const withExtension = (name: string, type?: string): string =>
+  type && !name?.toLowerCase().endsWith(`.${type.toLowerCase()}`) ? `${name}.${type}` : name;
+
 const TaskToRetyItem = ({ index, style, data }: ListChildComponentProps) => {
   const file: RetryableTask = data.files[index];
-  const { params, status } = file;
+  const { params, status, retryable } = file;
   const { downloadItem } = data;
+  const isNotAllowed = retryable === false;
   const getFileIcon = (type: string) => {
     const IconComponent = iconService.getItemIcon(false, type);
     return <IconComponent className="w-10 h-10 text-gray-600" />;
@@ -19,22 +39,33 @@ const TaskToRetyItem = ({ index, style, data }: ListChildComponentProps) => {
   const FolderIcon = iconService.getItemIcon(true);
   const getFolderIcon = <FolderIcon className="w-12 h-12 drop-shadow-soft" />;
 
+  const { name, type, size, modifiedAt, isFolder } = getDisplayData(params);
+  const displayName = withExtension(name, type);
+  const displaySize = bytesToString(size, false).replace('kB', 'KB');
+
+  const isLastItem = index === data.files.length - 1;
+
   return (
-    <div style={style} className="flex items-center justify-between px-4 py-3 border-b border-gray-5">
+    <div
+      style={style}
+      className={`flex items-center justify-between px-1 py-3 ${isLastItem ? '' : 'border-b border-gray-5'}`}
+    >
       <div className="flex items-center gap-4">
-        {params?.isFolder ? getFolderIcon : getFileIcon(params?.filecontent?.type ?? params.type)}
+        {isFolder ? getFolderIcon : getFileIcon(type ?? '')}
         <div>
-          <p className="text-base font-medium text-gray-100 truncate max-w-xs">
-            {params?.filecontent?.name ?? params.plainName ?? params.name}
-          </p>
+          <p className="text-base font-medium text-gray-100 truncate max-w-xs">{displayName}</p>
           <p className="text-sm font-regular text-gray-50">
-            {bytesToString(params?.filecontent?.size ?? params.size)} -{' '}
-            {formatDefaultDate(params?.filecontent?.content.lastModified ?? params.updatedAt, t)}
+            {displaySize} - {formatDefaultDate(modifiedAt, t)}
           </p>
         </div>
       </div>
-      {status === 'failed' && <TaskLoggerButton onClick={() => downloadItem(file)} Icon={RestartIcon} />}
-      {status === 'retrying' && <CircleNotch size={24} className="mr-2 animate-spin text-gray-60" weight="bold" />}
+      {isNotAllowed && <span className="mr-2 text-sm font-medium text-gray-50">{t('tasks.messages.notAllowed')}</span>}
+      {!isNotAllowed && status === 'failed' && (
+        <TaskLoggerButton onClick={() => downloadItem(file)} Icon={RestartIcon} sizeClassName="h-8 w-8" iconSize={16} />
+      )}
+      {!isNotAllowed && status === 'retrying' && (
+        <CircleNotch size={16} className="mr-2 animate-spin text-gray-60" weight="bold" />
+      )}
     </div>
   );
 };

--- a/src/app/tasks/components/TaskToRetryItem/TaskToRetryItem.tsx
+++ b/src/app/tasks/components/TaskToRetryItem/TaskToRetryItem.tsx
@@ -5,7 +5,7 @@ import { bytesToString } from 'app/drive/services/size.service';
 import { formatDefaultDate } from 'services/date.service';
 import { t } from 'i18next';
 import { TaskLoggerButton } from '../TaskLoggerButton/TaskLoggerButton';
-import { CircleNotch } from '@phosphor-icons/react';
+import { SpinnerIcon } from '@phosphor-icons/react';
 import { RetryableTask, RetryableTaskStatus, RetryableTaskType } from 'app/network/RetryManager';
 import { UploadManagerFileParams } from 'app/network/UploadManager';
 import { DownloadItemType } from 'app/drive/services/downloadManager.service';
@@ -77,7 +77,7 @@ const TaskToRetyItem = ({ index, style, data }: ListChildComponentProps) => {
         <TaskLoggerButton onClick={() => downloadItem(file)} Icon={RestartIcon} sizeClassName="h-8 w-8" iconSize={16} />
       )}
       {!isNotAllowed && status === RetryableTaskStatus.Retrying && (
-        <CircleNotch size={16} className="mr-2 animate-spin text-gray-60" weight="bold" />
+        <SpinnerIcon size={16} className="mr-2 animate-spin text-gray-60" weight="bold" />
       )}
     </div>
   );


### PR DESCRIPTION
## Description

Retry entries are grouped under their parent folder task via relatedTaskId, and non-retryable files show a "Not allowed" label (added to all locales) instead of a retry button.

Also normalizes the two RetryableTask param shapes in TaskToRetryItem behind a getDisplayData helper (file names now display with their extension), tightens the retry modal row padding, and adds sizeClassName/iconSize props to TaskLoggerButton.

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [ ] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
