### PR TITLE
[_] bigfix/remove new browser only functionality

### DIFF
--- a/src/services/local-storage-crypto.test.ts
+++ b/src/services/local-storage-crypto.test.ts
@@ -120,7 +120,7 @@ describe('decryptEntry', () => {
     await createNewKey();
     const ciphertext = await encryptEntry(mockMnemonic);
 
-    const bytes = Uint8Array.fromBase64(ciphertext);
+    const bytes = Buffer.from(ciphertext, 'base64');
     bytes[bytes.length - 1] ^= 0xff;
     const tampered = Buffer.from(bytes).toString('base64');
 

--- a/src/services/local-storage-crypto.test.ts
+++ b/src/services/local-storage-crypto.test.ts
@@ -8,6 +8,7 @@ import {
   FailedToEncryptEntry,
 } from './local-storage-errors';
 import { KEY_LENGTH, ALGORITHM, IV_LENGTH } from './local-storage-constants';
+import { Buffer } from 'buffer';
 
 beforeEach(async () => {
   await deleteDb();
@@ -121,7 +122,7 @@ describe('decryptEntry', () => {
 
     const bytes = Uint8Array.fromBase64(ciphertext);
     bytes[bytes.length - 1] ^= 0xff;
-    const tampered = bytes.toBase64();
+    const tampered = Buffer.from(bytes).toString('base64');
 
     await expect(decryptEntry(tampered)).rejects.toThrow(FailedToDecryptEntry);
   });

--- a/src/services/local-storage-crypto.test.ts
+++ b/src/services/local-storage-crypto.test.ts
@@ -77,7 +77,7 @@ describe('encryptEntry', () => {
     const result = await encryptEntry(mockMnemonic);
 
     expect(typeof result).toBe('string');
-    const decodedLength = Uint8Array.fromBase64(result).length;
+    const decodedLength = Buffer.from(result, 'base64').length;
     expect(decodedLength).toBeGreaterThan(IV_LENGTH);
   });
 

--- a/src/services/local-storage-crypto.ts
+++ b/src/services/local-storage-crypto.ts
@@ -64,7 +64,7 @@ export async function decryptEntry(ciphertextBase64: string): Promise<string> {
   }
 
   try {
-    const input = Uint8Array.fromBase64(ciphertextBase64);
+    const input = Buffer.from(ciphertextBase64, 'base64');
 
     const iv = input.slice(0, IV_LENGTH);
     const data = input.slice(IV_LENGTH);

--- a/src/services/local-storage-crypto.ts
+++ b/src/services/local-storage-crypto.ts
@@ -66,8 +66,8 @@ export async function decryptEntry(ciphertextBase64: string): Promise<string> {
   try {
     const input = Buffer.from(ciphertextBase64, 'base64');
 
-    const iv = input.slice(0, IV_LENGTH);
-    const data = input.slice(IV_LENGTH);
+    const iv = input.subarray(0, IV_LENGTH);
+    const data = input.subarray(IV_LENGTH);
     const buf = await crypto.subtle.decrypt({ name: ALGORITHM, iv }, key, data);
     return new TextDecoder().decode(buf);
   } catch (error) {

--- a/src/services/local-storage-crypto.ts
+++ b/src/services/local-storage-crypto.ts
@@ -7,6 +7,7 @@ import {
 } from './local-storage-errors';
 import { KEY_ID, KEY_LENGTH, IV_LENGTH, ALGORITHM } from './local-storage-constants';
 import databaseService, { DatabaseCollection } from 'app/database/services/database.service';
+import { Buffer } from 'buffer';
 
 async function ensureKey(): Promise<CryptoKey> {
   const existing = await getKey();
@@ -50,7 +51,7 @@ export async function encryptEntry(plaintext: string): Promise<string> {
     const result = new Uint8Array(iv.length + buf.length);
     result.set(iv, 0);
     result.set(buf, iv.length);
-    return result.toBase64();
+    return Buffer.from(result).toString('base64');
   } catch (error) {
     throw new FailedToEncryptEntry(error instanceof Error ? error.message : String(error));
   }


### PR DESCRIPTION
## Description

Uint8Array.prototype.toBase64() is a function available on Chrome 135+, Firefox 133+, Safari 18.2+ (mid 2025). Some customers run older versions and cannot log in.
<img width="347" height="261" alt="Screenshot 2026-07-31 at 15 17 43" src="https://github.com/user-attachments/assets/591bcfe7-80bf-48d9-9cbf-14ef1d5c0b63" />

## Checklist



- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

Check that login works