### PR TITLE
[_] bugfix/fix broken imports in scrypt and up db version

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
         color-scheme: dark;
       }
     </style>
-    <script>
+    <script type="module">
       import localStorageService from 'services/local-storage.service';
       import { LocalStorageItem } from 'app/core/types';
       (function () {

--- a/src/app/core/config/app.json
+++ b/src/app/core/config/app.json
@@ -16,7 +16,7 @@
   },
   "database": {
     "name": "app-database",
-    "version": 6,
+    "version": 7,
     "provider": "indexed-db"
   }
 }


### PR DESCRIPTION
## Description

Up db version to 7

Fix this error (imports are permitted only in module scripts, not plain js scripts):

<img width="926" height="166" alt="Screenshot 2026-08-04 at 10 57 00" src="https://github.com/user-attachments/assets/44c27dcf-1a2e-4d09-a900-6de8575f81b6" />


## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

Log in to an account with a business workspace, go to that workspace, and open the shared folder

## Additional Notes

Content is still not shown, but it's cello loading error now