### PR TITLE
[PB-6680]: fix/clear-workspace-credentials-user-leak

### DIFF
--- a/src/services/encrypted-storage.service.ts
+++ b/src/services/encrypted-storage.service.ts
@@ -133,8 +133,6 @@ const setWorkspaceCredentials = async (credentials: WorkspaceCredentialsDetails)
 const clearWorkspaceCredentials = (): void => {
   workspaceCredentialsCache = null;
   localStorage.removeItem(LocalStorageProtectedItem.EncryptedWorkspaceCredentials);
-  localStorage.removeItem(LocalStorageProtectedItem.User);
-  localStorage.removeItem(LocalStorageItem.UserUUID);
 };
 
 const getUser = (): UserSettings | null => {


### PR DESCRIPTION
## What
`clearWorkspaceCredentials()` no longer removes the account's `User` and `UserUUID` entries from `localStorage`; it only clears the workspace credentials it owns.

## Why
`clearWorkspaceCredentials()` is called on every app mount for any user without a `workspaceid` URL param (via `App.tsx`'s `resetB2BWorkspaceCredentials` effect), as well as on personal folder/file navigation and when unselecting a workspace. It was wiping the account `User` object from `localStorage` as a side effect, even though that data isn't workspace-scoped.

`getEnvironmentConfig()` reads the user straight from `localStorage` (not from Redux) to build upload/download credentials. Redux's in-memory user survived the wipe, so the UI looked fine, but any upload/download triggered before the user got re-persisted (via the async `refreshUserThunk`) hit a `null` user and crashed with `Cannot read properties of null (reading 'bridgeUser')`. This was intermittent and depended on timing, not the browser — reproducible in both Firefox and Chrome.