### PR TITLE
chore:(PB-6297) bump version to v1.0.816

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drive-web",
-  "version": "v1.0.810",
+  "version": "v1.0.816",
   "private": true,
   "packageManager": "yarn@1.22.22",
   "dependencies": {


### PR DESCRIPTION
### Description
Bumps the app version from `v1.0.810` to `v1.0.816` after merging the public shared folder preview work (PB-6297, PR #2052).

### Changes
- `package.json`: `version` `v1.0.810` → `v1.0.816`