### PR TITLE
[_]: fix/checkout-tax-flash-flash-on-billing-country-refetch

### DIFF
--- a/src/views/Checkout/views/CheckoutViewWrapper.tsx
+++ b/src/views/Checkout/views/CheckoutViewWrapper.tsx
@@ -89,6 +89,7 @@ const CheckoutViewWrapper = () => {
     address,
     isCryptoAddressIncomplete,
     billingCountry,
+    billingPostalCode,
     getCustomerName,
     onUserAddressChanges,
     onUserNameChanges,
@@ -144,17 +145,22 @@ const CheckoutViewWrapper = () => {
       return;
     }
 
+    if (!billingCountry || !billingPostalCode) {
+      return;
+    }
+
     const debounceTimer = setTimeout(() => {
       fetchSelectedPlan({
         priceId: selectedPlan.price.id,
         currency: selectedPlan.price.currency,
         promotionCode: promotionCode ?? undefined,
+        postalCode: billingPostalCode,
         country: billingCountry,
       });
     }, 500);
 
     return () => clearTimeout(debounceTimer);
-  }, [billingCountry, selectedPlan?.price?.id, selectedPlan?.price?.currency]);
+  }, [billingCountry, billingPostalCode, selectedPlan?.price?.id, selectedPlan?.price?.currency]);
 
   useEffect(() => {
     if (isCheckoutReady && selectedPlan?.price) {


### PR DESCRIPTION
## What
Restores `postalCode` in the debounced price refetch triggered by billing address changes in `CheckoutViewWrapper`, and guards the effect so it only fires once both country and postal code are known.

## Why
Since `9cc570d47` ("checkout fixes"), `billingCountry` is populated immediately from IP geolocation on page load (before the user enters anything), which fires a refetch of the price ~500ms later using only `country` (no `postalCode`, no `userAddress`). That refetch returns a different tax amount than the initial fetch, so the tax line item flashes on screen and then disappears. The actual charge is unaffected (postal code is read from the Stripe confirmation token at payment time), so this was a display-only regression.