### PR TITLE
[_]: refactor/extract-checkout-price-refetch-hook

### DIFF
--- a/src/views/Checkout/hooks/usePriceRefetchOnAddressChange.test.ts
+++ b/src/views/Checkout/hooks/usePriceRefetchOnAddressChange.test.ts
@@ -1,0 +1,150 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { usePriceRefetchOnAddressChange } from './usePriceRefetchOnAddressChange';
+import { PriceWithTax } from '@internxt/sdk/dist/payments/types';
+import { UserType } from '@internxt/sdk/dist/drive/payments/types/types';
+
+describe('usePriceRefetchOnAddressChange', () => {
+  const mockPriceWithTax: PriceWithTax = {
+    price: {
+      id: 'price_123',
+      bytes: 1099511627776,
+      decimalAmount: 10,
+      product: 'prod_1234',
+      currency: 'eur',
+      amount: 10,
+      interval: 'year',
+      type: UserType.Individual,
+    },
+    taxes: {
+      amountWithTax: 1210,
+      decimalTax: 12.1,
+      tax: 210,
+      decimalAmountWithTax: 12.1,
+    },
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  test('does not refetch when the billing country is missing', () => {
+    const fetchSelectedPlan = vi.fn();
+
+    renderHook(() =>
+      usePriceRefetchOnAddressChange({
+        selectedPlan: mockPriceWithTax,
+        billingCountry: undefined,
+        billingPostalCode: '28001',
+        fetchSelectedPlan,
+      }),
+    );
+
+    vi.advanceTimersByTime(1000);
+
+    expect(fetchSelectedPlan).not.toHaveBeenCalled();
+  });
+
+  test('does not refetch when the billing postal code is missing, even if the country is already known from geolocation', () => {
+    const fetchSelectedPlan = vi.fn();
+
+    renderHook(() =>
+      usePriceRefetchOnAddressChange({
+        selectedPlan: mockPriceWithTax,
+        billingCountry: 'ES',
+        billingPostalCode: undefined,
+        fetchSelectedPlan,
+      }),
+    );
+
+    vi.advanceTimersByTime(1000);
+
+    expect(fetchSelectedPlan).not.toHaveBeenCalled();
+  });
+
+  test('does not refetch when there is no selected plan yet', () => {
+    const fetchSelectedPlan = vi.fn();
+
+    renderHook(() =>
+      usePriceRefetchOnAddressChange({
+        selectedPlan: undefined,
+        billingCountry: 'ES',
+        billingPostalCode: '28001',
+        fetchSelectedPlan,
+      }),
+    );
+
+    vi.advanceTimersByTime(1000);
+
+    expect(fetchSelectedPlan).not.toHaveBeenCalled();
+  });
+
+  test('refetches with both country and postal code once both are known, after debouncing', () => {
+    const fetchSelectedPlan = vi.fn();
+
+    renderHook(() =>
+      usePriceRefetchOnAddressChange({
+        selectedPlan: mockPriceWithTax,
+        billingCountry: 'ES',
+        billingPostalCode: '28001',
+        promotionCode: 'SUMMER20',
+        fetchSelectedPlan,
+      }),
+    );
+
+    expect(fetchSelectedPlan).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(500);
+
+    expect(fetchSelectedPlan).toHaveBeenCalledWith({
+      priceId: 'price_123',
+      currency: 'eur',
+      promotionCode: 'SUMMER20',
+      postalCode: '28001',
+      country: 'ES',
+    });
+  });
+
+  test('debounces rapid postal code changes into a single request', () => {
+    const fetchSelectedPlan = vi.fn();
+
+    const { rerender } = renderHook(
+      (props) => usePriceRefetchOnAddressChange(props),
+      {
+        initialProps: {
+          selectedPlan: mockPriceWithTax,
+          billingCountry: 'ES',
+          billingPostalCode: '2800',
+          fetchSelectedPlan,
+        },
+      },
+    );
+
+    vi.advanceTimersByTime(300);
+    rerender({
+      selectedPlan: mockPriceWithTax,
+      billingCountry: 'ES',
+      billingPostalCode: '28001',
+      fetchSelectedPlan,
+    });
+    vi.advanceTimersByTime(300);
+    rerender({
+      selectedPlan: mockPriceWithTax,
+      billingCountry: 'ES',
+      billingPostalCode: '28002',
+      fetchSelectedPlan,
+    });
+
+    expect(fetchSelectedPlan).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(500);
+
+    expect(fetchSelectedPlan).toHaveBeenCalledTimes(1);
+    expect(fetchSelectedPlan).toHaveBeenCalledWith(expect.objectContaining({ postalCode: '28002' }));
+  });
+});

--- a/src/views/Checkout/hooks/usePriceRefetchOnAddressChange.test.ts
+++ b/src/views/Checkout/hooks/usePriceRefetchOnAddressChange.test.ts
@@ -33,7 +33,7 @@ describe('usePriceRefetchOnAddressChange', () => {
     vi.clearAllMocks();
   });
 
-  test('does not refetch when the billing country is missing', () => {
+  test('Given a selected plan and a known postal code, when the billing country is missing, then the price is not refetched', () => {
     const fetchSelectedPlan = vi.fn();
 
     renderHook(() =>
@@ -50,7 +50,7 @@ describe('usePriceRefetchOnAddressChange', () => {
     expect(fetchSelectedPlan).not.toHaveBeenCalled();
   });
 
-  test('does not refetch when the billing postal code is missing, even if the country is already known from geolocation', () => {
+  test('Given a selected plan and a country resolved from geolocation, when the billing postal code is missing, then the price is not refetched', () => {
     const fetchSelectedPlan = vi.fn();
 
     renderHook(() =>
@@ -67,7 +67,7 @@ describe('usePriceRefetchOnAddressChange', () => {
     expect(fetchSelectedPlan).not.toHaveBeenCalled();
   });
 
-  test('does not refetch when there is no selected plan yet', () => {
+  test('Given a known country and postal code, when there is no selected plan yet, then the price is not refetched', () => {
     const fetchSelectedPlan = vi.fn();
 
     renderHook(() =>
@@ -84,7 +84,7 @@ describe('usePriceRefetchOnAddressChange', () => {
     expect(fetchSelectedPlan).not.toHaveBeenCalled();
   });
 
-  test('refetches with both country and postal code once both are known, after debouncing', () => {
+  test('Given a selected plan, when both country and postal code become known, then the price is refetched with both after debouncing', () => {
     const fetchSelectedPlan = vi.fn();
 
     renderHook(() =>
@@ -110,7 +110,7 @@ describe('usePriceRefetchOnAddressChange', () => {
     });
   });
 
-  test('debounces rapid postal code changes into a single request', () => {
+  test('Given a selected plan, when the postal code changes rapidly, then only a single debounced request is sent with the latest value', () => {
     const fetchSelectedPlan = vi.fn();
 
     const { rerender } = renderHook(

--- a/src/views/Checkout/hooks/usePriceRefetchOnAddressChange.ts
+++ b/src/views/Checkout/hooks/usePriceRefetchOnAddressChange.ts
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import { PriceWithTax } from '@internxt/sdk/dist/payments/types';
+
+interface FetchSelectedPlanPayload {
+  priceId: string;
+  promotionCode?: string;
+  postalCode?: string;
+  country?: string;
+  userAddress?: string;
+  currency?: string;
+  mobileToken?: string;
+}
+
+interface UsePriceRefetchOnAddressChangeProps {
+  selectedPlan?: PriceWithTax;
+  billingCountry?: string;
+  billingPostalCode?: string;
+  promotionCode?: string;
+  fetchSelectedPlan: (payload: FetchSelectedPlanPayload) => Promise<PriceWithTax>;
+  debounceMs?: number;
+}
+
+/**
+ * Refetches the selected plan (and its tax breakdown) once the user's billing
+ * country and postal code are both known, so the price shown always matches
+ * the tax jurisdiction used at payment time.
+ */
+export const usePriceRefetchOnAddressChange = ({
+  selectedPlan,
+  billingCountry,
+  billingPostalCode,
+  promotionCode,
+  fetchSelectedPlan,
+  debounceMs = 500,
+}: UsePriceRefetchOnAddressChangeProps) => {
+  useEffect(() => {
+    if (!selectedPlan?.price?.id || !selectedPlan?.price?.currency) {
+      return;
+    }
+
+    if (!billingCountry || !billingPostalCode) {
+      return;
+    }
+
+    const debounceTimer = setTimeout(() => {
+      fetchSelectedPlan({
+        priceId: selectedPlan.price.id,
+        currency: selectedPlan.price.currency,
+        promotionCode: promotionCode ?? undefined,
+        postalCode: billingPostalCode,
+        country: billingCountry,
+      });
+    }, debounceMs);
+
+    return () => clearTimeout(debounceTimer);
+  }, [billingCountry, billingPostalCode, selectedPlan?.price?.id, selectedPlan?.price?.currency]);
+};

--- a/src/views/Checkout/views/CheckoutViewWrapper.tsx
+++ b/src/views/Checkout/views/CheckoutViewWrapper.tsx
@@ -34,6 +34,7 @@ import metaService from 'app/analytics/meta.service';
 import { useCheckoutQueryParams } from '../hooks/useCheckoutQueryParams';
 import { useInitializeCheckout } from '../hooks/useInitializeCheckout';
 import { useProducts } from '../hooks/useProducts';
+import { usePriceRefetchOnAddressChange } from '../hooks/usePriceRefetchOnAddressChange';
 import { useUserLocation } from 'hooks/useUserLocation';
 import {
   GCLID_COOKIE_LIFESPAN_DAYS,
@@ -140,27 +141,13 @@ const CheckoutViewWrapper = () => {
     }
   }, [isAuthenticated, user]);
 
-  useEffect(() => {
-    if (!selectedPlan?.price?.id || !selectedPlan?.price?.currency) {
-      return;
-    }
-
-    if (!billingCountry || !billingPostalCode) {
-      return;
-    }
-
-    const debounceTimer = setTimeout(() => {
-      fetchSelectedPlan({
-        priceId: selectedPlan.price.id,
-        currency: selectedPlan.price.currency,
-        promotionCode: promotionCode ?? undefined,
-        postalCode: billingPostalCode,
-        country: billingCountry,
-      });
-    }, 500);
-
-    return () => clearTimeout(debounceTimer);
-  }, [billingCountry, billingPostalCode, selectedPlan?.price?.id, selectedPlan?.price?.currency]);
+  usePriceRefetchOnAddressChange({
+    selectedPlan,
+    billingCountry,
+    billingPostalCode,
+    promotionCode: promotionCode ?? undefined,
+    fetchSelectedPlan,
+  });
 
   useEffect(() => {
     if (isCheckoutReady && selectedPlan?.price) {


### PR DESCRIPTION
## What
Extracts the price/tax refetch effect triggered by billing address changes into `usePriceRefetchOnAddressChange` (fix applied in #2103), with unit tests covering the cases that caused the tax flash.

## Why
The bug in #2103 wasn't caught by any test because that logic lived inline in `CheckoutViewWrapper` with no coverage. Extracting it into a hook makes it testable and prevents a future regression.