### PR TITLE
feat: update Stripe elements amount dynamically based on price changes

### DIFF
--- a/src/views/Checkout/constants.ts
+++ b/src/views/Checkout/constants.ts
@@ -5,6 +5,13 @@ export const IS_CRYPTO_PAYMENT_ENABLED = true;
 
 export const POSTAL_CODE_REQUIRED_COUNTRIES = ['US', 'CA', 'IN'];
 
+/**
+ * Smallest amount, in minor units, that Stripe accepts for the `amount` option of an Elements
+ * instance (0.50 EUR / 0.50 USD). Amounts below it are rejected, so they must never be sent.
+ * See https://docs.stripe.com/currencies#minimum-and-maximum-charge-amounts
+ */
+export const STRIPE_MINIMUM_CHARGE_AMOUNT = 50;
+
 export const THEME_STYLES = {
   dark: {
     backgroundColor: 'rgb(17 17 17)',

--- a/src/views/Checkout/hooks/useInitializeCheckout.test.ts
+++ b/src/views/Checkout/hooks/useInitializeCheckout.test.ts
@@ -209,6 +209,63 @@ describe('Initialize checkout custom hook', () => {
       });
       expect(checkoutService.loadStripeElements).toHaveBeenCalledTimes(1);
     });
+
+    test.each([
+      ['zero, because a 100% OFF coupon was applied', 0],
+      ['below the Stripe minimum charge', 49],
+    ])('When the price amount with tax is %s, then the Stripe elements amount is not updated', async (_, amount) => {
+      const { result, rerender } = renderHook((props) => useInitializeCheckout(props), {
+        initialProps: {
+          checkoutTheme: 'light',
+          price: mockPriceWithTax,
+          translate: mockTranslate,
+        },
+      });
+
+      await waitFor(() => {
+        expect(result.current.stripeElementsOptions?.amount).toBe(1210);
+      });
+
+      rerender({
+        checkoutTheme: 'light',
+        price: {
+          ...mockPriceWithTax,
+          taxes: { ...mockPriceWithTax.taxes, amountWithTax: amount },
+        },
+        translate: mockTranslate,
+      });
+
+      await waitFor(() => {
+        expect(result.current.stripeElementsOptions?.amount).toBe(1210);
+      });
+    });
+
+    test('When the price amount with tax is exactly the Stripe minimum charge, then the Stripe elements amount is updated', async () => {
+      const { result, rerender } = renderHook((props) => useInitializeCheckout(props), {
+        initialProps: {
+          checkoutTheme: 'light',
+          price: mockPriceWithTax,
+          translate: mockTranslate,
+        },
+      });
+
+      await waitFor(() => {
+        expect(result.current.stripeElementsOptions?.amount).toBe(1210);
+      });
+
+      rerender({
+        checkoutTheme: 'light',
+        price: {
+          ...mockPriceWithTax,
+          taxes: { ...mockPriceWithTax.taxes, amountWithTax: 50 },
+        },
+        translate: mockTranslate,
+      });
+
+      await waitFor(() => {
+        expect(result.current.stripeElementsOptions?.amount).toBe(50);
+      });
+    });
   });
 
   describe('Loading crypto currencies', () => {

--- a/src/views/Checkout/hooks/useInitializeCheckout.test.ts
+++ b/src/views/Checkout/hooks/useInitializeCheckout.test.ts
@@ -176,6 +176,41 @@ describe('Initialize checkout custom hook', () => {
     });
   });
 
+  describe('Updating the Stripe elements amount', () => {
+    test('When the price amount with tax changes (e.g. a coupon is applied), then the Stripe elements amount is updated without reloading the elements', async () => {
+      const { result, rerender } = renderHook((props) => useInitializeCheckout(props), {
+        initialProps: {
+          checkoutTheme: 'light',
+          price: mockPriceWithTax,
+          translate: mockTranslate,
+        },
+      });
+
+      await waitFor(() => {
+        expect(result.current.stripeElementsOptions?.amount).toBe(1210);
+      });
+
+      const discountedPrice: PriceWithTax = {
+        ...mockPriceWithTax,
+        taxes: {
+          ...mockPriceWithTax.taxes,
+          amountWithTax: 605,
+        },
+      };
+
+      rerender({
+        checkoutTheme: 'light',
+        price: discountedPrice,
+        translate: mockTranslate,
+      });
+
+      await waitFor(() => {
+        expect(result.current.stripeElementsOptions?.amount).toBe(605);
+      });
+      expect(checkoutService.loadStripeElements).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('Loading crypto currencies', () => {
     test('When the plan is lifetime, then crypto currencies are fetched', async () => {
       const props = {

--- a/src/views/Checkout/hooks/useInitializeCheckout.ts
+++ b/src/views/Checkout/hooks/useInitializeCheckout.ts
@@ -1,4 +1,4 @@
-import { Stripe, StripeElementsOptions } from '@stripe/stripe-js';
+import { Stripe, StripeElementsOptionsMode } from '@stripe/stripe-js';
 import { checkoutService, currencyService, paymentService } from '../services';
 import { useEffect, useState } from 'react';
 import { errorService, navigationService } from 'services';
@@ -20,7 +20,7 @@ interface UseInitializeCheckoutProps {
 
 export const useInitializeCheckout = ({ user, price, checkoutTheme, translate }: UseInitializeCheckoutProps) => {
   const [stripeSdk, setStripeSdk] = useState<Stripe | null>(null);
-  const [stripeElementsOptions, setStripeElementsOptions] = useState<StripeElementsOptions>();
+  const [stripeElementsOptions, setStripeElementsOptions] = useState<StripeElementsOptionsMode>();
   const [isCheckoutReady, setIsCheckoutReady] = useState(false);
   const [availableCryptoCurrencies, setAvailableCryptoCurrencies] = useState<CryptoCurrency[] | undefined>(undefined);
 
@@ -41,6 +41,20 @@ export const useInitializeCheckout = ({ user, price, checkoutTheme, translate }:
       loadStripeAndCrypto();
     }
   }, [stripeSdk, price?.price?.id]);
+
+  useEffect(() => {
+    const amount = price?.taxes?.amountWithTax;
+
+    if (amount === undefined) return;
+
+    setStripeElementsOptions((prevOptions) => {
+      if (!prevOptions || prevOptions.amount === amount) {
+        return prevOptions;
+      }
+
+      return { ...prevOptions, amount };
+    });
+  }, [price?.taxes?.amountWithTax]);
 
   const initCheckout = async () => {
     try {
@@ -93,7 +107,7 @@ export const useInitializeCheckout = ({ user, price, checkoutTheme, translate }:
 
     try {
       const stripeElements = await checkoutService.loadStripeElements(THEME_STYLES[checkoutTheme], price);
-      setStripeElementsOptions(stripeElements as StripeElementsOptions);
+      setStripeElementsOptions(stripeElements as StripeElementsOptionsMode);
     } catch (error) {
       const castedError = errorService.castError(error);
       throw new Error(castedError.message);

--- a/src/views/Checkout/hooks/useInitializeCheckout.ts
+++ b/src/views/Checkout/hooks/useInitializeCheckout.ts
@@ -5,7 +5,7 @@ import { errorService, navigationService } from 'services';
 import { AppView } from 'app/core/types';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import { CryptoCurrency, PriceWithTax } from '@internxt/sdk/dist/payments/types';
-import { IS_CRYPTO_PAYMENT_ENABLED, THEME_STYLES } from '../constants';
+import { IS_CRYPTO_PAYMENT_ENABLED, STRIPE_MINIMUM_CHARGE_AMOUNT, THEME_STYLES } from '../constants';
 import { PlanInterval } from '../types';
 import notificationsService, { ToastType } from 'app/notifications/services/notifications.service';
 import { UserType } from '@internxt/sdk/dist/drive/payments/types/types';
@@ -45,7 +45,9 @@ export const useInitializeCheckout = ({ user, price, checkoutTheme, translate }:
   useEffect(() => {
     const amount = price?.taxes?.amountWithTax;
 
-    if (amount === undefined) return;
+    // Stripe rejects amounts under its minimum charge, so a heavily discounted total (a 100% OFF
+    // coupon, for instance) is skipped instead of being pushed to the already mounted elements.
+    if (amount === undefined || amount < STRIPE_MINIMUM_CHARGE_AMOUNT) return;
 
     setStripeElementsOptions((prevOptions) => {
       if (!prevOptions || prevOptions.amount === amount) {


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise summary of the changes. Include the reason and context, if applicable. -->
Update stripe elements' after a discount code is applied. If total value is below than stripe's allowed min of 0.50 ignore, in practice this won't happen but would crash in the case we apply a 100% test discount code. Those cases are handled differently elsewhere in the code base.

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->
When checking out and entering a discount select apple pay as a checkout method, then apple pay should correctly reflect 
the newly discounted price rather than the original unsicounted total

