### PR TITLE
[PB-6715]: fix: enhance user storage  with backoff logic

### DIFF
--- a/src/utils/userStoragePolling.utils.test.ts
+++ b/src/utils/userStoragePolling.utils.test.ts
@@ -29,45 +29,94 @@ describe('User Storage Polling', () => {
     vi.clearAllMocks();
   });
 
-  test('When an interval tick occurs, then the limit is fetched', async () => {
+  test('When polling starts, then the limit is fetched immediately and then with a backing-off interval', async () => {
     mockStore.getState.mockReturnValue({ plan: { planLimit: 100 } });
 
     userStoragePolling();
 
-    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(0);
     expect(mockStore.dispatch).toHaveBeenCalledTimes(1);
 
-    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(2000);
     expect(mockStore.dispatch).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(3);
+
+    await vi.advanceTimersByTimeAsync(4500);
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(4);
   });
 
-  test('When limit changes, then stop polling', async () => {
+  test('When polling, then the interval backs off (grows) between checks', async () => {
+    mockStore.getState.mockReturnValue({ plan: { planLimit: 100 } });
+
+    userStoragePolling();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(2999);
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(3);
+  });
+
+  test('When the limit changes from the pre-purchase value, then stop polling', async () => {
     mockStore.getState
       .mockReturnValueOnce({ plan: { planLimit: 100 } })
       .mockReturnValueOnce({ plan: { planLimit: 100 } })
-      .mockReturnValueOnce({ plan: { planLimit: 200 } });
+      .mockReturnValue({ plan: { planLimit: 200 } });
 
     userStoragePolling();
 
-    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(0);
     expect(mockStore.dispatch).toHaveBeenCalledTimes(1);
 
-    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(2000);
     expect(mockStore.dispatch).toHaveBeenCalledTimes(2);
 
-    await vi.advanceTimersByTimeAsync(15000);
+    await vi.advanceTimersByTimeAsync(120000);
     expect(mockStore.dispatch).toHaveBeenCalledTimes(2);
   });
 
-  test('When there is no limit updates, then stops polling after 30 seconds', async () => {
+  test('When the store starts with an unknown limit, then it does not stop on the stale value', async () => {
+    mockStore.getState
+      .mockReturnValueOnce({ plan: { planLimit: 0 } }) // baseline read: unknown
+      .mockReturnValueOnce({ plan: { planLimit: 100 } }) // immediate check: establishes baseline
+      .mockReturnValueOnce({ plan: { planLimit: 100 } }) // next check: still old value
+      .mockReturnValue({ plan: { planLimit: 200 } }); // next check: new limit -> stop
+
+    userStoragePolling();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(1);
+
+    // Still polling: the first real reading only established the baseline, it did not stop.
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(2);
+
+    // New limit detected here -> stop.
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(3);
+
+    await vi.advanceTimersByTimeAsync(120000);
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(3);
+  });
+
+  test('When there is no limit update, then stops polling after the max duration', async () => {
     mockStore.getState.mockReturnValue({ plan: { planLimit: 100 } });
 
     userStoragePolling();
 
-    await vi.advanceTimersByTimeAsync(30000);
-    const callsAt30s = mockStore.dispatch.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(120000);
+    const callsAtMaxDuration = mockStore.dispatch.mock.calls.length;
 
-    await vi.advanceTimersByTimeAsync(10000);
-    expect(mockStore.dispatch).toHaveBeenCalledTimes(callsAt30s);
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(callsAtMaxDuration);
   });
 });

--- a/src/utils/userStoragePolling.utils.ts
+++ b/src/utils/userStoragePolling.utils.ts
@@ -1,31 +1,53 @@
 import { store } from 'app/store';
 import { planThunks } from 'app/store/slices/plan';
 
-const POLLING_INTERVAL_MS = 5 * 1000;
-const MAX_POLLING_DURATION_MS = 30 * 1000;
+const INITIAL_INTERVAL_MS = 2 * 1000;
+const MAX_INTERVAL_MS = 15 * 1000;
+const BACKOFF_FACTOR = 1.5;
+const MAX_POLLING_DURATION_MS = 2 * 60 * 1000;
 
 export const userStoragePolling = () => {
-  const initialLimit = store.getState().plan.planLimit;
+  let baseline = store.getState().plan.planLimit || null;
 
-  let interval: ReturnType<typeof setInterval> | null = null;
+  let nextDelay = INITIAL_INTERVAL_MS;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
 
   const stop = () => {
-    if (interval !== null) {
-      clearInterval(interval);
-      interval = null;
+    stopped = true;
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
     }
-    clearTimeout(timeout);
+    clearTimeout(maxDurationTimeout);
   };
 
-  const timeout = setTimeout(stop, MAX_POLLING_DURATION_MS);
-
-  interval = setInterval(async () => {
-    await store.dispatch(planThunks.fetchLimitThunk());
-    const newLimit = store.getState().plan.planLimit;
-    if (newLimit !== initialLimit) {
-      stop();
+  const scheduleNext = () => {
+    if (stopped) {
+      return;
     }
-  }, POLLING_INTERVAL_MS);
+    timer = setTimeout(runCheck, nextDelay);
+    nextDelay = Math.min(nextDelay * BACKOFF_FACTOR, MAX_INTERVAL_MS);
+  };
+
+  const runCheck = async () => {
+    await store.dispatch(planThunks.fetchLimitThunk());
+    const currentLimit = store.getState().plan.planLimit;
+
+    if (currentLimit) {
+      if (baseline === null) {
+        baseline = currentLimit;
+      } else if (currentLimit !== baseline) {
+        stop();
+        return;
+      }
+    }
+
+    scheduleNext();
+  };
+
+  const maxDurationTimeout = setTimeout(stop, MAX_POLLING_DURATION_MS);
+  void runCheck();
 
   return stop;
 };


### PR DESCRIPTION
## Description
- Removed initial wait to fetch limit
- Updated test descriptions for clarity and accuracy.
- Added tests to verify immediate fetching of limits and backoff intervals during polling.
- Implemented checks for stopping polling when limits change and handling unknown initial limits.
- Adjusted polling duration to reflect maximum limits and ensure proper dispatch counts.

This is to try and get a quicker update on the user's new limit after a succesful checkout, also adjusted logic to retry a little longer in the case the entire stripe webhook -> payments -> drive call chain takes longer than expected

## Related Issues


## Related Pull Requests

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [x] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->
Complete a checkout, observe the limit get updated

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
