### PR TITLE
[_] move mocks out of beforeAll

### DIFF
--- a/src/app/share/services/share.service.test.ts
+++ b/src/app/share/services/share.service.test.ts
@@ -70,44 +70,45 @@ vi.mock('services/zip.service', () => ({
   createFolderWithFilesWritable: vi.fn(),
 }));
 
+vi.mock('app/drive/services/folder.service', () => ({
+  default: {},
+  downloadFolderAsZip: vi.fn(),
+  createFilesIterator: vi.fn(),
+  createFoldersIterator: vi.fn(),
+  checkIfCachedSourceIsOlder: vi.fn(),
+}));
+vi.mock('../../core/factory/sdk', () => ({
+  SdkFactory: {
+    getNewApiInstance: vi.fn(() => ({
+      createShareClient: vi.fn(),
+    })),
+  },
+}));
+vi.mock('services/error.service', () => ({
+  default: {
+    castError: vi.fn().mockImplementation((e) => ({
+      message: typeof e === 'string' ? e : e.message || 'Default error message',
+      requestId: 'test-request-id',
+    })),
+    reportError: vi.fn(),
+  },
+}));
+vi.mock('services/encrypted-storage.service', () => ({
+  default: {
+    getUser: vi.fn(),
+  },
+}));
+vi.mock('services/workspace.service', () => ({
+  default: {
+    getAllWorkspaceTeamSharedFolderFolders: vi.fn(),
+    getAllWorkspaceTeamSharedFolderFiles: vi.fn(),
+  },
+}));
+vi.mock('./DomainManager', () => ({ domainManager: { getDomainsList: vi.fn() } }));
+
 describe('Encryption and Decryption', () => {
   beforeAll(() => {
     globalThis.Buffer = Buffer;
-    vi.mock('app/drive/services/folder.service', () => ({
-      default: {},
-      downloadFolderAsZip: vi.fn(),
-      createFilesIterator: vi.fn(),
-      createFoldersIterator: vi.fn(),
-      checkIfCachedSourceIsOlder: vi.fn(),
-    }));
-    vi.mock('../../core/factory/sdk', () => ({
-      SdkFactory: {
-        getNewApiInstance: vi.fn(() => ({
-          createShareClient: vi.fn(),
-        })),
-      },
-    }));
-    vi.mock('services/error.service', () => ({
-      default: {
-        castError: vi.fn().mockImplementation((e) => ({
-          message: typeof e === 'string' ? e : e.message || 'Default error message',
-          requestId: 'test-request-id',
-        })),
-        reportError: vi.fn(),
-      },
-    }));
-    vi.mock('services/encrypted-storage.service', () => ({
-      default: {
-        getUser: vi.fn(),
-      },
-    }));
-    vi.mock('services/workspace.service', () => ({
-      default: {
-        getAllWorkspaceTeamSharedFolderFolders: vi.fn(),
-        getAllWorkspaceTeamSharedFolderFiles: vi.fn(),
-      },
-    }));
-    vi.mock('./DomainManager', () => ({ domainManager: { getDomainsList: vi.fn() } }));
   });
 
   beforeEach(() => {

--- a/src/app/store/slices/sharedLinks/index.test.ts
+++ b/src/app/store/slices/sharedLinks/index.test.ts
@@ -5,7 +5,7 @@ import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import navigationService from 'services/navigation.service';
 import shareService from 'app/share/services/share.service';
 import { Buffer } from 'buffer';
-import { beforeAll, beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { RootState } from '../..';
 import userService from 'services/user.service';
 import {
@@ -24,44 +24,42 @@ import {
 import notificationsService from 'app/notifications/services/notifications.service';
 const { shareItemWithUser } = sharedThunks;
 
+vi.mock('services/navigation.service', () => ({
+  default: { push: vi.fn() },
+}));
+vi.mock('app/share/services/share.service', () => ({
+  default: {
+    inviteUserToSharedFolder: vi.fn(),
+    getSharedFolderInvitationsAsInvitedUser: vi.fn(),
+    getSharingRoles: vi.fn(),
+    stopSharingItem: vi.fn(),
+    removeUserRole: vi.fn(),
+  },
+}));
+vi.mock('services/user.service', () => ({
+  default: {
+    getPublicKeyWithPrecreation: vi.fn(),
+  },
+}));
+vi.mock('utils', () => ({
+  generateCaptchaToken: vi.fn().mockResolvedValue('mock-captcha-token'),
+}));
+
+vi.mock('services/referral.service', () => ({
+  default: {
+    trackShareCreated: vi.fn(),
+  },
+}));
+vi.mock('services/error.service', () => ({
+  default: {
+    castError: vi
+      .fn()
+      .mockImplementation((e) => ({ message: e.message || 'Default error message', requestId: 'test-request-id' })),
+    reportError: vi.fn(),
+  },
+}));
+
 describe('Encryption and Decryption', () => {
-  beforeAll(() => {
-    vi.mock('services/navigation.service', () => ({
-      default: { push: vi.fn() },
-    }));
-    vi.mock('app/share/services/share.service', () => ({
-      default: {
-        inviteUserToSharedFolder: vi.fn(),
-        getSharedFolderInvitationsAsInvitedUser: vi.fn(),
-        getSharingRoles: vi.fn(),
-        stopSharingItem: vi.fn(),
-        removeUserRole: vi.fn(),
-      },
-    }));
-    vi.mock('services/user.service', () => ({
-      default: {
-        getPublicKeyWithPrecreation: vi.fn(),
-      },
-    }));
-    vi.mock('utils', () => ({
-      generateCaptchaToken: vi.fn().mockResolvedValue('mock-captcha-token'),
-    }));
-
-    vi.mock('services/referral.service', () => ({
-      default: {
-        trackShareCreated: vi.fn(),
-      },
-    }));
-    vi.mock('services/error.service', () => ({
-      default: {
-        castError: vi
-          .fn()
-          .mockImplementation((e) => ({ message: e.message || 'Default error message', requestId: 'test-request-id' })),
-        reportError: vi.fn(),
-      },
-    }));
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();

--- a/src/views/Signup/ShareGuestSignUpView.test.tsx
+++ b/src/views/Signup/ShareGuestSignUpView.test.tsx
@@ -16,210 +16,211 @@ const mockHostname = 'hostname';
 const mockPassword = 'mock-password';
 const mockEmal = 'mock@email.com';
 const mockToken = 'mock-token';
+
+vi.spyOn(globalThis, 'decodeURIComponent').mockImplementation((value) => {
+  return value;
+});
+
+vi.mock('services/local-storage.service', () => ({
+  default: {
+    get: vi.fn(),
+    clear: vi.fn(),
+    set: vi.fn(),
+  },
+}));
+vi.mock('services/encrypted-storage.service', () => ({
+  default: {
+    getToken: vi.fn(),
+    setToken: vi.fn(),
+    getUser: vi.fn(),
+  },
+}));
+
+vi.mock('react-helmet-async', () => ({
+  Helmet: vi.fn(),
+}));
+
+vi.mock('@phosphor-icons/react', () => ({
+  Info: () => <div>Mocked Info Icon</div>,
+  WarningCircle: () => <div>Mocked Warning Circle Icon</div>,
+  CheckCircle: () => <div>Mocked Check Circle Icon</div>,
+  Eye: () => <div>Mocked Eye Icon</div>,
+  EyeSlash: () => <div>Mocked Eye Slash Icon</div>,
+  MagnifyingGlass: () => <div>Mocked Magnifyin Glass Icon</div>,
+  Warning: () => <div>Mocked Warning Icon</div>,
+  WarningOctagon: () => <div>Mocked Warning Octagon Icon</div>,
+  X: () => <div>Mocked X Icon</div>,
+}));
+
+vi.mock('components/PasswordInput', () => {
+  return {
+    __esModule: true,
+    default: vi.fn(({ register, ...props }) => (
+      <input
+        data-testid="password-input"
+        type="password"
+        placeholder={props.placeholder}
+        className={props.className}
+        onFocus={props.onFocus}
+        maxLength={props.maxLength}
+        ref={register}
+      />
+    )),
+  };
+});
+
+vi.mock('./components/SignupForm', () => ({
+  Views: vi.fn(),
+}));
+
+vi.mock('./hooks/useSignup', () => ({
+  useSignUp: vi.fn().mockReturnValue({ doRegisterPreCreatedUser: vi.fn() }),
+}));
+
+vi.mock('./hooks/useGuestSignupState', () => ({
+  useGuestSignupState: vi.fn(() => ({
+    isValidPassword: true,
+    setIsValidPassword: vi.fn(),
+    signupError: undefined,
+    setSignupError: vi.fn(),
+    showError: false,
+    setShowError: vi.fn(),
+    isLoading: false,
+    setIsLoading: vi.fn(),
+    passwordState: { tag: 'success', label: 'Password is strong' } as const,
+    setPasswordState: vi.fn(),
+    invitationId: 'test-invitation',
+    setInvitationId: vi.fn(),
+    showPasswordIndicator: true,
+    setShowPasswordIndicator: vi.fn(),
+    user: null,
+    mnemonic: null,
+  })),
+}));
+
+vi.mock('./hooks/useInvitationValidation', () => ({
+  useInvitationValidation: vi.fn().mockReturnValue({
+    invitationValidation: { isLoading: false, isValid: true },
+  }),
+}));
+
+vi.mock('components/PasswordStrengthIndicator', () => ({
+  default: () => <div>Mocked Password Strength Indicator</div>,
+}));
+
+vi.mock('services/error.service', () => ({
+  default: {
+    castError: vi.fn().mockImplementation((e) => ({ message: e.message || 'Default error message' })),
+    reportError: vi.fn(),
+  },
+}));
+
+vi.mock('app/share/services/share.service', () => ({
+  default: {
+    validateSharingInvitation: vi.fn(),
+  },
+  validateSharingInvitation: vi.fn(),
+  decryptMnemonic: vi.fn(),
+}));
+
+vi.mock('services/navigation.service', () => ({
+  default: {
+    push: vi.fn(),
+    history: {
+      location: {
+        search: '?email=mock@email.com&invitation=test-invitation',
+      },
+    },
+  },
+}));
+
+vi.mock('app/i18n/provider/TranslationProvider', () => ({
+  useTranslationContext: vi.fn().mockReturnValue({
+    translate: vi.fn().mockImplementation((value: string) => {
+      return value;
+    }),
+  }),
+}));
+
+vi.mock('components', () => ({
+  ExpiredLinkView: vi.fn(() => <div>Mocked Expired Link View</div>),
+  MAX_PASSWORD_LENGTH: 256,
+}));
+
+vi.mock('query-string', () => ({
+  parse: vi.fn().mockImplementation((input: string) => input),
+}));
+
+vi.mock('react-hook-form', () => {
+  const mockEmail = 'mock@email.com';
+  const mockToken = 'mock-token';
+  const mockPassword = 'mock-password';
+  const mockValues = { email: mockEmail, token: mockToken, password: mockPassword };
+
+  return {
+    SubmitHandler: vi.fn(),
+    useForm() {
+      return {
+        register: vi.fn((name: string) => ({ onChange: vi.fn(), onBlur: vi.fn(), ref: vi.fn(), name })),
+        handleSubmit: vi.fn((fn) => (event: Event) => {
+          event?.preventDefault();
+          return fn(mockValues, event);
+        }),
+        formState: { errors: {}, isValid: true },
+        control: {},
+        watch: vi.fn((name: string) => mockValues[name]),
+      };
+    },
+    useWatch: vi.fn(() => mockPassword),
+  };
+});
+
+vi.mock('react-redux', () => ({
+  useSelector: vi.fn(),
+  useDispatch: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('../../utils', () => ({
+  onChangePasswordHandler: vi.fn(),
+}));
+
+vi.mock('services/workspace.service', () => ({
+  default: {
+    validateWorkspaceInvitation: vi.fn().mockImplementation(() => {
+      return true;
+    }),
+  },
+}));
+
+vi.mock('app/store/hooks', () => ({
+  useAppDispatch: vi.fn().mockReturnValue(vi.fn()),
+}));
+
+vi.mock('app/store/slices/plan', () => ({
+  planThunks: {
+    initializeThunk: vi.fn(),
+  },
+}));
+
+vi.mock('app/store/slices/referrals', () => ({
+  referralsThunks: {
+    initializeThunk: vi.fn(),
+  },
+}));
+
+vi.mock('app/store/slices/user', () => ({
+  initializeUserThunk: vi.fn(),
+  userActions: {
+    setUser: vi.fn(),
+  },
+  userThunks: {
+    initializeUserThunk: vi.fn(),
+  },
+}));
+
 describe('onSubmit', () => {
   beforeAll(() => {
     globalThis.Buffer = Buffer;
-
-    vi.spyOn(globalThis, 'decodeURIComponent').mockImplementation((value) => {
-      return value;
-    });
-
-    vi.mock('services/local-storage.service', () => ({
-      default: {
-        get: vi.fn(),
-        clear: vi.fn(),
-        set: vi.fn(),
-      },
-    }));
-    vi.mock('services/encrypted-storage.service', () => ({
-      default: {
-        getToken: vi.fn(),
-        setToken: vi.fn(),
-        getUser: vi.fn(),
-      },
-    }));
-
-    vi.mock('react-helmet-async', () => ({
-      Helmet: vi.fn(),
-    }));
-
-    vi.mock('@phosphor-icons/react', () => ({
-      Info: () => <div>Mocked Info Icon</div>,
-      WarningCircle: () => <div>Mocked Warning Circle Icon</div>,
-      CheckCircle: () => <div>Mocked Check Circle Icon</div>,
-      Eye: () => <div>Mocked Eye Icon</div>,
-      EyeSlash: () => <div>Mocked Eye Slash Icon</div>,
-      MagnifyingGlass: () => <div>Mocked Magnifyin Glass Icon</div>,
-      Warning: () => <div>Mocked Warning Icon</div>,
-      WarningOctagon: () => <div>Mocked Warning Octagon Icon</div>,
-      X: () => <div>Mocked X Icon</div>,
-    }));
-
-    vi.mock('components/PasswordInput', () => {
-      return {
-        __esModule: true,
-        default: vi.fn(({ register, ...props }) => (
-          <input
-            data-testid="password-input"
-            type="password"
-            placeholder={props.placeholder}
-            className={props.className}
-            onFocus={props.onFocus}
-            maxLength={props.maxLength}
-            ref={register}
-          />
-        )),
-      };
-    });
-
-    vi.mock('./components/SignupForm', () => ({
-      Views: vi.fn(),
-    }));
-
-    vi.mock('./hooks/useSignup', () => ({
-      useSignUp: vi.fn().mockReturnValue({ doRegisterPreCreatedUser: vi.fn() }),
-    }));
-
-    vi.mock('./hooks/useGuestSignupState', () => ({
-      useGuestSignupState: vi.fn(() => ({
-        isValidPassword: true,
-        setIsValidPassword: vi.fn(),
-        signupError: undefined,
-        setSignupError: vi.fn(),
-        showError: false,
-        setShowError: vi.fn(),
-        isLoading: false,
-        setIsLoading: vi.fn(),
-        passwordState: { tag: 'success', label: 'Password is strong' } as const,
-        setPasswordState: vi.fn(),
-        invitationId: 'test-invitation',
-        setInvitationId: vi.fn(),
-        showPasswordIndicator: true,
-        setShowPasswordIndicator: vi.fn(),
-        user: null,
-        mnemonic: null,
-      })),
-    }));
-
-    vi.mock('./hooks/useInvitationValidation', () => ({
-      useInvitationValidation: vi.fn().mockReturnValue({
-        invitationValidation: { isLoading: false, isValid: true },
-      }),
-    }));
-
-    vi.mock('components/PasswordStrengthIndicator', () => ({
-      default: () => <div>Mocked Password Strength Indicator</div>,
-    }));
-
-    vi.mock('services/error.service', () => ({
-      default: {
-        castError: vi.fn().mockImplementation((e) => ({ message: e.message || 'Default error message' })),
-        reportError: vi.fn(),
-      },
-    }));
-
-    vi.mock('app/share/services/share.service', () => ({
-      default: {
-        validateSharingInvitation: vi.fn(),
-      },
-      validateSharingInvitation: vi.fn(),
-      decryptMnemonic: vi.fn(),
-    }));
-
-    vi.mock('services/navigation.service', () => ({
-      default: {
-        push: vi.fn(),
-        history: {
-          location: {
-            search: '?email=mock@email.com&invitation=test-invitation',
-          },
-        },
-      },
-    }));
-
-    vi.mock('app/i18n/provider/TranslationProvider', () => ({
-      useTranslationContext: vi.fn().mockReturnValue({
-        translate: vi.fn().mockImplementation((value: string) => {
-          return value;
-        }),
-      }),
-    }));
-
-    vi.mock('components', () => ({
-      ExpiredLinkView: vi.fn(() => <div>Mocked Expired Link View</div>),
-      MAX_PASSWORD_LENGTH: 256,
-    }));
-
-    vi.mock('query-string', () => ({
-      parse: vi.fn().mockImplementation((input: string) => input),
-    }));
-
-    vi.mock('react-hook-form', () => {
-      const mockEmail = 'mock@email.com';
-      const mockToken = 'mock-token';
-      const mockPassword = 'mock-password';
-      const mockValues = { email: mockEmail, token: mockToken, password: mockPassword };
-
-      return {
-        SubmitHandler: vi.fn(),
-        useForm() {
-          return {
-            register: vi.fn((name: string) => ({ onChange: vi.fn(), onBlur: vi.fn(), ref: vi.fn(), name })),
-            handleSubmit: vi.fn((fn) => (event: Event) => {
-              event?.preventDefault();
-              return fn(mockValues, event);
-            }),
-            formState: { errors: {}, isValid: true },
-            control: {},
-            watch: vi.fn((name: string) => mockValues[name]),
-          };
-        },
-        useWatch: vi.fn(() => mockPassword),
-      };
-    });
-
-    vi.mock('react-redux', () => ({
-      useSelector: vi.fn(),
-      useDispatch: vi.fn(() => vi.fn()),
-    }));
-
-    vi.mock('../../utils', () => ({
-      onChangePasswordHandler: vi.fn(),
-    }));
-
-    vi.mock('services/workspace.service', () => ({
-      default: {
-        validateWorkspaceInvitation: vi.fn().mockImplementation(() => {
-          return true;
-        }),
-      },
-    }));
-
-    vi.mock('app/store/hooks', () => ({
-      useAppDispatch: vi.fn().mockReturnValue(vi.fn()),
-    }));
-
-    vi.mock('app/store/slices/plan', () => ({
-      planThunks: {
-        initializeThunk: vi.fn(),
-      },
-    }));
-
-    vi.mock('app/store/slices/referrals', () => ({
-      referralsThunks: {
-        initializeThunk: vi.fn(),
-      },
-    }));
-
-    vi.mock('app/store/slices/user', () => ({
-      initializeUserThunk: vi.fn(),
-      userActions: {
-        setUser: vi.fn(),
-      },
-      userThunks: {
-        initializeUserThunk: vi.fn(),
-      },
-    }));
   });
 
   beforeEach(() => {


### PR DESCRIPTION
## Description

Move mocks out of beforeAll. Reason: Sonar complains in another PR, and those changes push code line changes over the limit

## Related Pull Requests

- [Change private sharings](https://github.com/internxt/drive-web/pull/2116)

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

unit tests