### PR TITLE
[PB-6734] Bugfix: fix signup redirect to login

### DIFF
--- a/src/app/store/slices/user/index.ts
+++ b/src/app/store/slices/user/index.ts
@@ -254,7 +254,7 @@ export const userSlice = createSlice({
       },
       prepare: (user: UserSettings) => {
         const createdAt =
-          user.createdAt && !isNaN(new Date(user.createdAt).getTime())
+          user.createdAt && !Number.isNaN(new Date(user.createdAt).getTime())
             ? new Date(user.createdAt).toISOString()
             : new Date().toISOString();
         return { payload: { ...user, createdAt } as unknown as UserSettings };

--- a/src/app/store/slices/user/index.ts
+++ b/src/app/store/slices/user/index.ts
@@ -252,9 +252,13 @@ export const userSlice = createSlice({
         state.isAuthenticated = !!action.payload;
         state.user = action.payload;
       },
-      prepare: (user: UserSettings) => ({
-        payload: { ...user, createdAt: new Date(user.createdAt).toISOString() } as unknown as UserSettings,
-      }),
+      prepare: (user: UserSettings) => {
+        const createdAt =
+          user.createdAt && !isNaN(new Date(user.createdAt).getTime())
+            ? new Date(user.createdAt).toISOString()
+            : new Date().toISOString();
+        return { payload: { ...user, createdAt } as unknown as UserSettings };
+      },
     },
     resetState: (state: UserState) => {
       Object.assign(state, initialState);


### PR DESCRIPTION
## Description

Seems toISOString in new Date(user.createdAt).toISOString() was throwing an RangeError: invalid date when the user wasn't set yet

## Related Issues

Fixes [PB-6734](https://inxt.atlassian.net/browse/PB-6734)

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [x] QA Passed

## Testing Process

Sign up and check that redirected to the drive instead of the login page

[PB-6734]: https://inxt.atlassian.net/browse/PB-6734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ