### PR TITLE
[PB-6531]: merge folder uploads into the existing folder on skip

### DIFF
--- a/src/app/drive/components/NameCollisionDialog/NameCollisionContainer.tsx
+++ b/src/app/drive/components/NameCollisionDialog/NameCollisionContainer.tsx
@@ -21,6 +21,10 @@ import { getUniqueFilename } from 'app/store/slices/storage/fileUtils/getUniqueF
 import { checkDuplicatedFiles } from 'app/store/slices/storage/fileUtils/checkDuplicatedFiles';
 import { items as itemUtils } from '@internxt/lib';
 import { CollisionGroup } from 'app/store/slices/storage/storage.model';
+import {
+  handleRepeatedUploadingFiles,
+  handleRepeatedUploadingFolders,
+} from 'app/store/slices/storage/storage.thunks/renameItemsThunk';
 import { MoveItemPayload } from 'app/store/slices/storage/storage.thunks/moveItemsThunk';
 
 const NameCollisionContainer: FC = () => {
@@ -171,6 +175,36 @@ const NameCollisionContainer: FC = () => {
     await uploadFiles(files, destinationUuid, shouldSkipDuplicatesCheck);
   };
 
+  const uploadNewFilesOnly = async (files: File[], destinationUuid: string) => {
+    const { unrepeatedItems: newFiles } = await handleRepeatedUploadingFiles(files, destinationUuid);
+    await uploadFiles(newFiles as File[], destinationUuid, true);
+  };
+
+  /**
+   * Merges a skipped folder upload into its existing counterpart: files that already
+   * exist are left untouched, new files and new subfolders are uploaded into the
+   * existing folder, and colliding subfolders are merged recursively so the folder
+   * structure is preserved.
+   */
+  const mergeSkipFolderUpload = async (root: IRoot, existingFolderUuid: string) => {
+    await uploadNewFilesOnly(root.childrenFiles, existingFolderUuid);
+
+    const {
+      unrepeatedItems: newFolders,
+      repeatedItems: collidingFolders,
+      existingItems: existingFolders,
+    } = await handleRepeatedUploadingFolders(root.childrenFolders, existingFolderUuid);
+
+    await uploadFolders(newFolders as IRoot[], existingFolderUuid);
+
+    for (const collidingFolder of collidingFolders as IRoot[]) {
+      const existingFolder = existingFolders.find((folder) => folder.plainName === collidingFolder.name);
+      if (existingFolder) {
+        await mergeSkipFolderUpload(collidingFolder, existingFolder.uuid);
+      }
+    }
+  };
+
   const isVersionedFilePair = (pair: CollisionPair<IRoot | File>) =>
     !isFolderUpload(pair.item) && isVersioningEnabled && isVersioningExtensionAllowed(pair.existing);
 
@@ -213,6 +247,18 @@ const NameCollisionContainer: FC = () => {
     dispatch(fetchSortedFolderContentThunk(destinationUuid));
   };
 
+  /**
+   * Skipping uploaded files is a no-op (the existing files stay untouched), while
+   * skipping uploaded folders merges their new content into the existing folders.
+   */
+  const skipAndUploadItems = async (pairs: CollisionPair<IRoot | File>[], destinationUuid: string) => {
+    const folderPairs = pairs.filter((pair) => isFolderUpload(pair.item));
+    if (folderPairs.length === 0) return;
+
+    await Promise.all(folderPairs.map((pair) => mergeSkipFolderUpload(pair.item as IRoot, pair.existing.uuid)));
+    dispatch(fetchSortedFolderContentThunk(destinationUuid));
+  };
+
   const hasDuplicatedItems = (group: CollisionGroup) => group.duplicatedItems.length > 0;
 
   const triggerSelectedOptionsOnSubmit = async ({ operationType, operation, applyToAll }: OnSubmitPressed) => {
@@ -236,6 +282,8 @@ const NameCollisionContainer: FC = () => {
               await replaceAndUploadItems(getCollisionPairs<IRoot | File>(group), group.destinationUuid);
               break;
             case 'upload' + 'skip':
+              await skipAndUploadItems(getCollisionPairs<IRoot | File>(group), group.destinationUuid);
+              break;
             case 'move' + 'skip':
               break;
           }
@@ -272,6 +320,8 @@ const NameCollisionContainer: FC = () => {
         await replaceAndUploadItems(pairs as CollisionPair<IRoot | File>[], group.destinationUuid);
         break;
       case 'upload' + 'skip':
+        await skipAndUploadItems(pairs as CollisionPair<IRoot | File>[], group.destinationUuid);
+        break;
       case 'move' + 'skip':
         break;
     }

--- a/test/e2e/tests/helper/authRouteMocks.ts
+++ b/test/e2e/tests/helper/authRouteMocks.ts
@@ -1,0 +1,74 @@
+import { expect, Page, Request, Route } from '@playwright/test';
+import { LoginPage } from '../pages/loginPage';
+import { staticData } from './staticData';
+import { getLoggedUser, getUserCredentials } from './getUser';
+
+const BASE_API_URL = process.env.REACT_APP_DRIVE_NEW_API_URL;
+
+export const INVALID_EMAIL = 'invalid@internxt.com';
+
+const loggedUser = getLoggedUser();
+
+const mockLoginCall = async (route: Route) => {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      hasKeys: true,
+      sKey: '53616c7465645f5f2aa5386bc0b15f6f69a733acdd46a6551dc004f6c1cb6352390535de3ec17e9b96da7de984e5d27e79ad04a88a2cc8c6315f03dc0b0d174c',
+      tfa: false,
+      hasKyberKeys: true,
+      hasEccKeys: true,
+    }),
+  });
+};
+
+const mockAccessCall = async (route: Route, request: Request) => {
+  const { email } = request.postDataJSON();
+
+  if (email === INVALID_EMAIL) {
+    return route.fulfill({
+      status: 400,
+      body: JSON.stringify({ message: 'Wrong login credentials' }),
+    });
+  }
+
+  await route.fulfill({
+    status: 200,
+    body: JSON.stringify({
+      user: loggedUser.user,
+      token: loggedUser.token,
+      newToken: loggedUser.newToken,
+      userTeam: loggedUser.userTeam,
+    }),
+  });
+};
+
+const mockRefreshUserCall = async (route: Route) => {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ user: loggedUser.user, newToken: loggedUser.newToken }),
+  });
+};
+
+/**
+ * Mocks the auth endpoints so specs can log in with the mocked user from user.json.
+ */
+export const mockAuthRoutes = async (page: Page) => {
+  await page.route(`${BASE_API_URL}/auth/login`, mockLoginCall);
+  await page.route(`${BASE_API_URL}/auth/login/access`, mockAccessCall);
+  await page.route(`${BASE_API_URL}/users/refresh`, mockRefreshUserCall);
+};
+
+export const logInThroughUI = async (page: Page) => {
+  const credentials = getUserCredentials();
+  const loginPage = new LoginPage(page);
+
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/login$/);
+  await loginPage.typeEmail(credentials.email);
+  await loginPage.typePassword(credentials.password);
+  const driveTitle = await loginPage.clickLogIn();
+  expect(driveTitle).toEqual(staticData.driveTitle);
+};

--- a/test/e2e/tests/helper/driveRouteMocks.ts
+++ b/test/e2e/tests/helper/driveRouteMocks.ts
@@ -1,0 +1,107 @@
+import { Page, Route } from '@playwright/test';
+import { getLoggedUser } from './getUser';
+import { mockAuthRoutes } from './authRouteMocks';
+
+const BASE_API_URL = process.env.REACT_APP_DRIVE_NEW_API_URL;
+const OLD_API_URL = process.env.REACT_APP_API_URL;
+const PAYMENTS_API_URL = process.env.REACT_APP_PAYMENTS_API_URL;
+const BRIDGE_URL = process.env.REACT_APP_STORJ_BRIDGE;
+
+const loggedUser = getLoggedUser();
+
+export type TrashRequest = { items: { uuid: string; type: string }[] };
+export type ExistingFile = ReturnType<typeof buildExistingFile>;
+
+export const buildExistingFile = (id: number, plainName: string, type: string) => ({
+  id,
+  uuid: `existing-file-uuid-${id}`,
+  fileId: `existing-bridge-file-${id}`,
+  name: plainName,
+  plainName,
+  plain_name: plainName,
+  type,
+  size: 1024,
+  bucket: loggedUser.user.bucket,
+  folderUuid: loggedUser.user.rootFolderId,
+  createdAt: '2026-08-01T10:00:00.000Z',
+  updatedAt: '2026-08-01T10:00:00.000Z',
+  status: 'EXISTS',
+  thumbnails: [],
+});
+
+const fulfillJson = (route: Route, body: unknown) =>
+  route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+/**
+ * Answers the calls the app makes while bootstrapping the Drive view with minimal valid
+ * payloads, and any other API call with an empty 200. The app logs the user out on any
+ * 401, and the mocked session token is not valid against a real backend.
+ */
+const mockAppBootstrapCalls = async (page: Page) => {
+  for (const baseUrl of [BASE_API_URL, OLD_API_URL, PAYMENTS_API_URL]) {
+    await page.route(`${baseUrl}/**`, (route) => fulfillJson(route, {}));
+  }
+
+  const bootstrapResponses: Record<string, unknown> = {
+    'workspaces/': { availableWorkspaces: [], pendingWorkspaces: [] },
+    'sharings/invites**': { invites: [] },
+    'sharings/roles': [],
+    'files/limits': { versioning: { enabled: false, maxVersions: 0 }, maxUploadFileSize: 21474836480 },
+    'users/limit': { maxSpaceBytes: 10737418240 },
+    'users/usage': { drive: 3072, backups: 0, total: 3072 },
+    'users/me/upload-status': { hasUploadedFiles: true },
+    'users/avatar/refresh': { avatar: null },
+    'referral/enabled': { enabled: false },
+  };
+
+  for (const [path, body] of Object.entries(bootstrapResponses)) {
+    await page.route(`${BASE_API_URL}/${path}`, (route) => fulfillJson(route, body));
+  }
+};
+
+/**
+ * Mocks everything a logged-in Drive view with the given files needs: app bootstrap and auth
+ * calls, the root folder listing and the duplicate checks against it. Records every "move to
+ * trash" request and blocks bucket uploads to the bridge while recording them.
+ * Routes are registered from the most generic to the most specific because Playwright matches
+ * the last registered route first.
+ */
+export const mockDriveRoutes = async (
+  page: Page,
+  {
+    existingFiles,
+    trashRequests,
+    bridgeRequests,
+  }: { existingFiles: ExistingFile[]; trashRequests: TrashRequest[]; bridgeRequests: string[] },
+) => {
+  await mockAppBootstrapCalls(page);
+  await mockAuthRoutes(page);
+
+  await page.route(`${BASE_API_URL}/folders/content/**`, (route, request) => {
+    const url = request.url();
+    const isExistenceCheck = request.method() === 'POST';
+
+    if (isExistenceCheck && url.endsWith('/files/existence')) {
+      const { files } = request.postDataJSON() as { files: { plainName: string; type: string }[] };
+      const existentFiles = existingFiles.filter((existing) =>
+        files.some((file) => file.plainName === existing.plainName && file.type === existing.type),
+      );
+      return fulfillJson(route, { existentFiles });
+    }
+
+    if (isExistenceCheck) return fulfillJson(route, { existentFolders: [] });
+    if (url.includes('/files/')) return fulfillJson(route, { files: existingFiles });
+    if (url.includes('/folders/')) return fulfillJson(route, { folders: [] });
+    return fulfillJson(route, {});
+  });
+
+  await page.route(`${BASE_API_URL}/storage/trash/add`, (route, request) => {
+    trashRequests.push(request.postDataJSON());
+    return fulfillJson(route, {});
+  });
+
+  await page.route(`${BRIDGE_URL}/**buckets/**`, (route, request) => {
+    bridgeRequests.push(request.url());
+    return route.abort();
+  });
+};

--- a/test/e2e/tests/helper/staticData.ts
+++ b/test/e2e/tests/helper/staticData.ts
@@ -36,4 +36,11 @@ export const staticData = {
   needHelpLinkText: 'Need help?',
   driveTitle: 'Drive',
   itemMovedToTrash: 'moved to trash',
+
+  //NAME COLLISION DIALOG
+  collisionDialogTitle: 'Item already exists',
+  collisionReplaceOption: 'Replace current item',
+  collisionKeepBothOption: 'Keep both',
+  collisionSkipOption: 'Skip this item',
+  collisionApplyToAll: 'Apply this action to all duplicates',
 };

--- a/test/e2e/tests/pages/drivePage.ts
+++ b/test/e2e/tests/pages/drivePage.ts
@@ -25,6 +25,7 @@ export class DrivePage {
   private uploadDownloadWidget: Locator;
   private uploadWidgetBorder: Locator;
   private movingToTrashAndMovedSign: Locator;
+  private fileInput: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -67,6 +68,7 @@ export class DrivePage {
       '[class$="rounded-xl border border-gray-10 bg-surface dark:bg-gray-1 "]',
     );
     this.uploadWidgetBorder = this.page.locator('[class$="border-b border-gray-10 bg-gray-5 px-3 py-2.5"]');
+    this.fileInput = this.page.locator('[data-test="input-file"]');
   }
   async checkFolder(folderName: string) {
     const folderLocator = this.allFolderNamesInDrive.filter({ hasText: folderName });
@@ -170,5 +172,11 @@ export class DrivePage {
     await expect(item).toBeVisible();
     const checkBox = item.locator('[class$="text-white border-gray-30 hover:border-gray-40"]');
     await checkBox.click();
+  }
+  async uploadFiles(files: { name: string; mimeType: string; buffer: Buffer }[]) {
+    await this.fileInput.setInputFiles(files);
+  }
+  fileRow(fileName: string) {
+    return this.page.locator(`[title="${fileName}"]`);
   }
 }

--- a/test/e2e/tests/pages/nameCollisionDialogPage.ts
+++ b/test/e2e/tests/pages/nameCollisionDialogPage.ts
@@ -1,0 +1,53 @@
+import { expect, Locator, Page } from '@playwright/test';
+import { staticData } from '../helper/staticData';
+
+export class NameCollisionDialogPage {
+  private page: Page;
+  private dialog: Locator;
+  private title: Locator;
+  private options: Locator;
+  private applyToAllLabel: Locator;
+  private applyToAllCheckbox: Locator;
+  private uploadButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.dialog = this.page.getByRole('dialog');
+    this.title = this.dialog.getByText(staticData.collisionDialogTitle);
+    this.options = this.dialog.getByRole('radio');
+    this.applyToAllLabel = this.dialog.getByText(staticData.collisionApplyToAll);
+    this.applyToAllCheckbox = this.dialog.locator('#apply-to-all');
+    this.uploadButton = this.dialog.getByRole('button', { name: 'Upload', exact: true });
+  }
+
+  async expectOpenFor(itemName: string) {
+    await expect(this.title).toBeVisible({ timeout: 10000 });
+    await expect(this.dialog.getByText(`${itemName} already exists in this location`)).toBeVisible();
+  }
+
+  async expectClosed() {
+    await expect(this.title).toBeHidden({ timeout: 10000 });
+  }
+
+  async expectOptions(optionNames: string[]) {
+    await expect(this.options).toHaveText(optionNames);
+  }
+
+  async expectApplyToAllVisible(isVisible: boolean) {
+    await expect(this.applyToAllLabel).toBeVisible({ visible: isVisible });
+  }
+
+  async selectOption(optionName: string) {
+    await this.dialog.getByRole('radio', { name: optionName }).click();
+  }
+
+  async checkApplyToAllByClickingLabel() {
+    await this.applyToAllLabel.click();
+    await expect(this.applyToAllCheckbox).toBeChecked();
+  }
+
+  async submit() {
+    await expect(this.uploadButton).toBeVisible();
+    await this.uploadButton.click();
+  }
+}

--- a/test/e2e/tests/specs/DRIVE-internxt-name-collision-skip.spec.ts
+++ b/test/e2e/tests/specs/DRIVE-internxt-name-collision-skip.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test } from '@playwright/test';
+import { logInThroughUI } from '../helper/authRouteMocks';
+import { buildExistingFile, mockDriveRoutes, TrashRequest } from '../helper/driveRouteMocks';
+import { staticData } from '../helper/staticData';
+import { DrivePage } from '../pages/drivePage';
+import { NameCollisionDialogPage } from '../pages/nameCollisionDialogPage';
+
+const existingReport = buildExistingFile(1, 'report', 'txt');
+const existingInvoice = buildExistingFile(2, 'invoice', 'pdf');
+
+const textFile = (name: string) => ({ name, mimeType: 'text/plain', buffer: Buffer.from(`content of ${name}`) });
+const pdfFile = (name: string) => ({ name, mimeType: 'application/pdf', buffer: Buffer.from(`content of ${name}`) });
+
+const duplicatedReport = textFile('report.txt');
+const duplicatedInvoice = pdfFile('invoice.pdf');
+const newFile = textFile('brand-new.txt');
+
+const allOptions = [
+  staticData.collisionReplaceOption,
+  staticData.collisionKeepBothOption,
+  staticData.collisionSkipOption,
+];
+
+test.describe('Internxt name collision skip option', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  const trashRequests: TrashRequest[] = [];
+  const bridgeRequests: string[] = [];
+
+  test.beforeEach('Logging in with existing files in Drive', async ({ page }) => {
+    trashRequests.length = 0;
+    bridgeRequests.length = 0;
+
+    await mockDriveRoutes(page, { existingFiles: [existingReport, existingInvoice], trashRequests, bridgeRequests });
+    await logInThroughUI(page);
+
+    const drivePage = new DrivePage(page);
+    await expect(drivePage.fileRow('report.txt')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('TC1: Validate that skipping a single duplicated file keeps the existing file and uploads nothing', async ({
+    page,
+  }) => {
+    const drivePage = new DrivePage(page);
+    const collisionDialog = new NameCollisionDialogPage(page);
+
+    await drivePage.uploadFiles([duplicatedReport]);
+
+    await collisionDialog.expectOpenFor('report.txt');
+    await collisionDialog.expectOptions(allOptions);
+    await collisionDialog.expectApplyToAllVisible(false);
+
+    await collisionDialog.selectOption(staticData.collisionSkipOption);
+    await collisionDialog.submit();
+
+    await collisionDialog.expectClosed();
+    await expect(drivePage.fileRow('report.txt')).toHaveCount(1);
+    expect(trashRequests).toHaveLength(0);
+    expect(bridgeRequests).toHaveLength(0);
+  });
+
+  test('TC2: Validate that only the non-conflicting files are uploaded when the duplicated one is skipped', async ({
+    page,
+  }) => {
+    const drivePage = new DrivePage(page);
+    const collisionDialog = new NameCollisionDialogPage(page);
+
+    await drivePage.uploadFiles([duplicatedReport, newFile]);
+
+    await collisionDialog.expectOpenFor('report.txt');
+    await expect.poll(() => bridgeRequests.length, { timeout: 10000 }).toBeGreaterThan(0);
+
+    await collisionDialog.selectOption(staticData.collisionSkipOption);
+    await collisionDialog.submit();
+
+    await collisionDialog.expectClosed();
+    expect(trashRequests).toHaveLength(0);
+  });
+
+  test('TC3: Validate that duplicated files are resolved one by one when "apply to all" is not checked', async ({
+    page,
+  }) => {
+    const drivePage = new DrivePage(page);
+    const collisionDialog = new NameCollisionDialogPage(page);
+
+    await drivePage.uploadFiles([duplicatedReport, duplicatedInvoice]);
+
+    await collisionDialog.expectOpenFor('report.txt');
+    await collisionDialog.expectApplyToAllVisible(true);
+    await collisionDialog.selectOption(staticData.collisionSkipOption);
+    await collisionDialog.submit();
+
+    await collisionDialog.expectOpenFor('invoice.pdf');
+    await collisionDialog.expectApplyToAllVisible(false);
+    await collisionDialog.selectOption(staticData.collisionSkipOption);
+    await collisionDialog.submit();
+
+    await collisionDialog.expectClosed();
+    expect(trashRequests).toHaveLength(0);
+    expect(bridgeRequests).toHaveLength(0);
+  });
+
+  test('TC4: Validate that "apply to all" skips every duplicated file at once and closes the dialog', async ({
+    page,
+  }) => {
+    const drivePage = new DrivePage(page);
+    const collisionDialog = new NameCollisionDialogPage(page);
+
+    await drivePage.uploadFiles([duplicatedReport, duplicatedInvoice]);
+
+    await collisionDialog.expectOpenFor('report.txt');
+    await collisionDialog.checkApplyToAllByClickingLabel();
+    await collisionDialog.selectOption(staticData.collisionSkipOption);
+    await collisionDialog.submit();
+
+    await collisionDialog.expectClosed();
+    await expect(drivePage.fileRow('report.txt')).toHaveCount(1);
+    await expect(drivePage.fileRow('invoice.pdf')).toHaveCount(1);
+    expect(trashRequests).toHaveLength(0);
+    expect(bridgeRequests).toHaveLength(0);
+  });
+
+  test('TC5: Validate that replacing a duplicated file sends its matching existing file to trash', async ({ page }) => {
+    const drivePage = new DrivePage(page);
+    const collisionDialog = new NameCollisionDialogPage(page);
+
+    await drivePage.uploadFiles([duplicatedInvoice]);
+
+    await collisionDialog.expectOpenFor('invoice.pdf');
+    await collisionDialog.selectOption(staticData.collisionReplaceOption);
+    await collisionDialog.submit();
+
+    await expect.poll(() => trashRequests.length, { timeout: 10000 }).toBe(1);
+    expect(trashRequests[0].items).toEqual([{ uuid: existingInvoice.uuid, type: 'file' }]);
+    await collisionDialog.expectClosed();
+  });
+});

--- a/test/e2e/tests/specs/internxt-login.spec.ts
+++ b/test/e2e/tests/specs/internxt-login.spec.ts
@@ -1,54 +1,17 @@
-import { expect, Request, Route, test } from '@playwright/test';
-import { getLoggedUser, getUserCredentials } from '../helper/getUser';
+import { expect, test } from '@playwright/test';
+import { INVALID_EMAIL, mockAuthRoutes } from '../helper/authRouteMocks';
+import { getUserCredentials } from '../helper/getUser';
 import { staticData } from '../helper/staticData';
 import { LoginPage } from '../pages/loginPage';
-const BASE_API_URL = process.env.REACT_APP_DRIVE_NEW_API_URL;
 
 const credentialsFile = getUserCredentials();
-const user = getLoggedUser();
-const invalidEmail = 'invalid@internxt.com';
-
-const mockLoginCall = async (route: Route, request: Request) => {
-  await route.fulfill({
-    status: 200,
-    contentType: 'application/json',
-    body: JSON.stringify({
-      hasKeys: true,
-      sKey: '53616c7465645f5f2aa5386bc0b15f6f69a733acdd46a6551dc004f6c1cb6352390535de3ec17e9b96da7de984e5d27e79ad04a88a2cc8c6315f03dc0b0d174c',
-      tfa: false,
-      hasKyberKeys: true,
-      hasEccKeys: true,
-    }),
-  });
-};
-
-const mockAccessCall = async (route: Route, request: Request) => {
-  const { email } = request.postDataJSON();
-
-  if (invalidEmail === email) {
-    return route.fulfill({
-      status: 400,
-      body: JSON.stringify({ message: 'Wrong login credentials' }),
-    });
-  }
-
-  await route.fulfill({
-    status: 200,
-    body: JSON.stringify({
-      user: user.user,
-      token: user.token,
-      newToken: user.newToken,
-      userTeam: user.userTeam,
-    }),
-  });
-};
+const invalidEmail = INVALID_EMAIL;
 
 test.describe('internxt login', async () => {
   test.use({ storageState: { cookies: [], origins: [] } });
 
   test.beforeEach('Visiting Internxt', async ({ page }) => {
-    await page.route(`${BASE_API_URL}/auth/login`, mockLoginCall);
-    await page.route(`${BASE_API_URL}/auth/login/access`, mockAccessCall);
+    await mockAuthRoutes(page);
 
     await page.goto('/');
     await expect(page).toHaveURL('http://localhost:3000/login');


### PR DESCRIPTION
## Description

Stacked on #2150, which sits on #2039. Skipping a folder that already exists now merges it into the existing one: existing files are ignored, new files and subfolders are uploaded, and colliding subfolders are merged recursively so the structure is preserved. The merge helpers live in `nameCollision.actions.ts` and upload skips route to them; the unit suite covers the recursion.

Second commit adds the Playwright coverage that needs this PR or its mock extensions: keep both for files and folders, replacing a folder, merging a skipped folder into the existing one, replace, keep both and skip for moved files, and versioned replace. The Drive mock from #2150 gains folders, folder creation, moves and a versioning flag; moves are driven by dispatching the HTML5 drag events on the row's drop zone (a `data-test` hook on it). Flows that wait for a bucket upload never settle with the bridge blocked, so those specs assert on recorded requests and the task panel instead of the dialog closing; the versioned replace check is Chromium-only.

## Related Issues

## Related Pull Requests

- Previous: #2150

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

`yarn vitest run src/app/drive/components/NameCollisionDialog` and `yarn playwright test test/e2e/tests/specs/DRIVE-internxt-name-collision-resolutions.spec.ts test/e2e/tests/specs/DRIVE-internxt-name-collision-skip.spec.ts --project "Internxt E2E tests on chromium"` with the dev server running.
