### PR TITLE
[_]: fix/breadcrumb-ancestors-direct-folder-link

### DIFF
--- a/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
+++ b/src/app/drive/components/MoveItemsDialog/MoveItemsDialog.tsx
@@ -147,7 +147,7 @@ const MoveItemsDialog = (props: MoveItemsDialogProps): JSX.Element => {
     }
 
     if (shouldUpdateBreadcrumb) {
-      await getAncestorsAndSetNamePath(item.isFolder ? itemUuid : itemFolderUuid, dispatch);
+      await getAncestorsAndSetNamePath(item.isFolder ? itemUuid : itemFolderUuid, dispatch, workspaceSelected);
     }
   };
 

--- a/src/app/store/slices/storage/storage.thunks/goToFolderThunk.ts
+++ b/src/app/store/slices/storage/storage.thunks/goToFolderThunk.ts
@@ -1,6 +1,7 @@
 import { ActionReducerMapBuilder, createAsyncThunk } from '@reduxjs/toolkit';
 
 import { FolderAncestor, FolderAncestorWorkspace } from '@internxt/sdk/dist/drive/storage/types';
+import { WorkspaceData } from '@internxt/sdk/dist/workspaces';
 import { storageActions } from '..';
 import { RootState } from '../../..';
 import newStorageService from 'app/drive/services/new-storage.service';
@@ -8,9 +9,9 @@ import { FolderPath } from 'app/drive/types';
 import { uiActions } from '../../ui';
 import { StorageState } from '../storage.model';
 import storageSelectors from '../storage.selectors';
-import { useSelector } from 'react-redux';
 import workspacesSelectors from '../../workspaces/workspaces.selectors';
 import encryptedStorageService from 'services/encrypted-storage.service';
+import errorService from 'services/error.service';
 
 const parsePathNames = (breadcrumbsList: FolderAncestor[] | FolderAncestorWorkspace[]) => {
   // ADDED UNTIL WE UPDATE TYPESCRIPT VERSION
@@ -22,8 +23,7 @@ const parsePathNames = (breadcrumbsList: FolderAncestor[] | FolderAncestorWorksp
   return fullPathParsedNamesList;
 };
 
-export const getAncestorsAndSetNamePath = async (uuid: string, dispatch) => {
-  const workspaceSelected = useSelector(workspacesSelectors.getSelectedWorkspace);
+export const getAncestorsAndSetNamePath = async (uuid: string, dispatch, workspaceSelected: WorkspaceData | null) => {
   const isWorkspaceSelected = !!workspaceSelected;
   const token = await encryptedStorageService.getSharedItemAccessToken(true);
   const breadcrumbsList: FolderAncestor[] | FolderAncestorWorkspace[] = isWorkspaceSelected
@@ -61,7 +61,9 @@ export const goToFolderThunk = createAsyncThunk<void, FolderPath, { state: RootS
     dispatch(storageActions.setCurrentPath(path));
 
     if (path.uuid && !isInNamePath) {
-      getAncestorsAndSetNamePath(path.uuid, dispatch);
+      getAncestorsAndSetNamePath(path.uuid, dispatch, workspacesSelectors.getSelectedWorkspace(getState())).catch(
+        (error) => errorService.reportError(error),
+      );
     }
   },
 );

--- a/src/views/Drive/components/DriveExplorer/DriveExplorer.tsx
+++ b/src/views/Drive/components/DriveExplorer/DriveExplorer.tsx
@@ -415,7 +415,7 @@ const DriveExplorer = (props: DriveExplorerProps): JSX.Element => {
       if (isFileViewerOpen) {
         dispatch(uiActions.setCurrentEditingNameDirty(newItem.plainName ?? newItem.name));
       } else if (itemToRename && editNameItem.isFolder) {
-        getAncestorsAndSetNamePath(newItem.uuid, dispatch);
+        getAncestorsAndSetNamePath(newItem.uuid, dispatch, selectedWorkspace);
       }
     }
     dispatch(storageActions.setItemToRename(null));


### PR DESCRIPTION
## Description

getAncestorsAndSetNamePath called the useSelector hook from a plain async function invoked outside React's render context. This threw an "Invalid hook call" error that was silently swallowed (the call site had no await/.catch), so the folder's ancestor chain was never written to namePath.

Normal click-through navigation masked this bug because namePath was already built incrementally as the user browsed. But opening a folder directly via its UUID (e.g. a shared/deep link) relies entirely on this ancestor fetch, leaving the breadcrumb showing only the target folder, with no way to navigate up to parent folders.

Fix: pass the selected workspace in as a parameter instead of reading it via a hook, and handle errors at the fire-and-forget call site with errorService.reportError.

<!-- Provide a clear and concise summary of the changes. Include the reason and context, if applicable. -->

## Related Issues

<!-- Link any related GitHub issues "Fixes #<issue_number>" or "Relates to #<issue_number>". -->

## Related Pull Requests

<!-- List any related PRs in the format below:
- [Repository/Branch](link-to-PR)
-->

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

<!-- Describe the testing process, including steps, configurations, and tools used to verify the changes. -->

## Additional Notes

<!-- Include any additional context, potential impacts, or implementation details that reviewers should be aware of. -->
