### PR TITLE
[PB-6531]: extract name collision move actions out of the container

### DIFF
--- a/src/app/drive/components/NameCollisionDialog/NameCollisionContainer.tsx
+++ b/src/app/drive/components/NameCollisionDialog/NameCollisionContainer.tsx
@@ -3,7 +3,6 @@ import NameCollisionDialog, { OnSubmitPressed } from '.';
 import { moveItemsToTrash } from 'views/Trash/services';
 import { RootState } from 'app/store';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
-import { storageActions } from 'app/store/slices/storage';
 import storageThunks from 'app/store/slices/storage/storage.thunks';
 import { fetchSortedFolderContentThunk } from 'app/store/slices/storage/storage.thunks/fetchSortedFolderContentThunk';
 import { uiActions } from 'app/store/slices/ui';
@@ -15,12 +14,8 @@ import replaceFileService from 'views/Drive/services/replaceFile.service';
 import { Network, getEnvironmentConfig } from 'app/drive/services/network.service';
 import { fileVersionsActions, fileVersionsSelectors } from 'app/store/slices/fileVersions';
 import { isVersioningExtensionAllowed } from 'views/Drive/components/VersionHistory/utils';
-import { checkFolderDuplicated } from 'app/store/slices/storage/folderUtils/checkFolderDuplicated';
-import { getUniqueFolderName } from 'app/store/slices/storage/folderUtils/getUniqueFolderName';
-import { getUniqueFilename } from 'app/store/slices/storage/fileUtils/getUniqueFilename';
-import { checkDuplicatedFiles } from 'app/store/slices/storage/fileUtils/checkDuplicatedFiles';
 import { CollisionGroup } from 'app/store/slices/storage/storage.model';
-import { MoveItemPayload } from 'app/store/slices/storage/storage.thunks/moveItemsThunk';
+import { NameCollisionContext, resolveMoveCollision } from './nameCollision.actions';
 
 const NameCollisionContainer: FC = () => {
   const dispatch = useAppDispatch();
@@ -37,45 +32,10 @@ const NameCollisionContainer: FC = () => {
   const maxUploadFileSize = useAppSelector(fileVersionsSelectors.getMaxFileSizeLimit);
   const isVersioningEnabled = limits?.versioning?.enabled ?? false;
 
+  const context: NameCollisionContext = { dispatch, selectedWorkspace, maxUploadFileSize, isVersioningEnabled };
+
   const closeDialog = () => {
     dispatch(uiActions.setIsNameCollisionDialogOpen({ open: false, info: undefined }));
-  };
-
-  const replaceAndMoveItem = async (group: CollisionGroup) => {
-    await moveItemsToTrash(group.existingItems);
-    await dispatch(
-      storageThunks.moveItemsThunk({
-        items: group.duplicatedItems as DriveItemData[],
-        destinationFolderId: group.destinationUuid,
-      }),
-    );
-  };
-
-  const keepAndMoveItem = async (group: CollisionGroup) => {
-    for (const item of group.duplicatedItems as DriveItemData[]) {
-      let itemParsed: MoveItemPayload;
-
-      if (item.isFolder) {
-        const { duplicatedFoldersResponse } = await checkFolderDuplicated([item], group.destinationUuid);
-        const finalName = await getUniqueFolderName(
-          item.plainName ?? item.name,
-          duplicatedFoldersResponse as DriveItemData[],
-          group.destinationUuid,
-        );
-        itemParsed = { ...item, name: finalName, plain_name: finalName, newItemName: finalName };
-      } else {
-        const { duplicatedFilesResponse } = await checkDuplicatedFiles([item], group.destinationUuid);
-        const finalName = await getUniqueFilename(item.name, item.type, duplicatedFilesResponse, group.destinationUuid);
-        itemParsed = { ...item, name: finalName, plainName: finalName, plain_name: finalName, newItemName: finalName };
-      }
-
-      await dispatch(
-        storageThunks.moveItemsThunk({
-          items: [itemParsed],
-          destinationFolderId: group.destinationUuid,
-        }),
-      );
-    }
   };
 
   const uploadFileAndGetFileId = async (file: File, itemToReplace: DriveItemData) => {
@@ -156,21 +116,23 @@ const NameCollisionContainer: FC = () => {
 
   const triggerSelectedOptionsOnSubmit = async ({ operationType, operation }: OnSubmitPressed) => {
     for (const group of collisionGroups) {
-      switch (operationType + operation) {
-        case 'move' + 'keep':
-          await keepAndMoveItem(group);
-          dispatch(storageActions.popItemsToDelete(group.duplicatedItems as DriveItemData[]));
-          break;
-        case 'move' + 'replace':
-          await replaceAndMoveItem(group);
-          dispatch(storageActions.popItemsToDelete(group.duplicatedItems as DriveItemData[]));
-          break;
-        case 'upload' + 'keep':
-          await keepAndUploadItem(group);
-          break;
-        case 'upload' + 'replace':
-          await replaceAndUploadItem(group);
-          break;
+      if (operationType === 'move') {
+        await resolveMoveCollision(
+          {
+            operation,
+            items: group.duplicatedItems as DriveItemData[],
+            existingItems: group.existingItems,
+            destinationUuid: group.destinationUuid,
+          },
+          context,
+        );
+        continue;
+      }
+
+      if (operation === 'keep') {
+        await keepAndUploadItem(group);
+      } else {
+        await replaceAndUploadItem(group);
       }
     }
     closeDialog();

--- a/src/app/drive/components/NameCollisionDialog/nameCollision.actions.test.ts
+++ b/src/app/drive/components/NameCollisionDialog/nameCollision.actions.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { getDriveItemData } from 'testUtils/fixtures/drive.fixtures';
+import { NameCollisionContext, ResolveMoveCollisionParams, resolveMoveCollision } from './nameCollision.actions';
+
+const mocks = vi.hoisted(() => ({
+  moveItemsToTrash: vi.fn(),
+  moveItemsThunk: vi.fn(),
+  popItemsToDelete: vi.fn(),
+  checkDuplicatedFiles: vi.fn(),
+  getUniqueFilename: vi.fn(),
+  checkFolderDuplicated: vi.fn(),
+  getUniqueFolderName: vi.fn(),
+}));
+
+vi.mock('views/Trash/services', () => ({ moveItemsToTrash: mocks.moveItemsToTrash }));
+vi.mock('app/store/slices/storage/storage.thunks', () => ({ default: { moveItemsThunk: mocks.moveItemsThunk } }));
+vi.mock('app/store/slices/storage', () => ({ storageActions: { popItemsToDelete: mocks.popItemsToDelete } }));
+vi.mock('app/store/slices/storage/fileUtils/checkDuplicatedFiles', () => ({
+  checkDuplicatedFiles: mocks.checkDuplicatedFiles,
+}));
+vi.mock('app/store/slices/storage/fileUtils/getUniqueFilename', () => ({ getUniqueFilename: mocks.getUniqueFilename }));
+vi.mock('app/store/slices/storage/folderUtils/checkFolderDuplicated', () => ({
+  checkFolderDuplicated: mocks.checkFolderDuplicated,
+}));
+vi.mock('app/store/slices/storage/folderUtils/getUniqueFolderName', () => ({
+  getUniqueFolderName: mocks.getUniqueFolderName,
+}));
+
+const DESTINATION = 'destination-uuid';
+
+const getContext = (): NameCollisionContext => ({
+  dispatch: vi.fn() as unknown as NameCollisionContext['dispatch'],
+  selectedWorkspace: null,
+  maxUploadFileSize: 5000,
+  isVersioningEnabled: false,
+});
+
+const resolve = (params: Omit<ResolveMoveCollisionParams, 'destinationUuid'>) =>
+  resolveMoveCollision({ ...params, destinationUuid: DESTINATION }, getContext());
+
+/**
+ * Mocks are reset by hand because the browser test project does not do it between tests.
+ */
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.checkDuplicatedFiles.mockResolvedValue({ duplicatedFilesResponse: ['file-dup'] });
+  mocks.getUniqueFilename.mockResolvedValue('report (1)');
+  mocks.checkFolderDuplicated.mockResolvedValue({ duplicatedFoldersResponse: ['folder-dup'] });
+  mocks.getUniqueFolderName.mockResolvedValue('Photos (1)');
+});
+
+describe('resolveMoveCollision', () => {
+  test('when keeping both, then each item is moved under a unique name and leaves the pending deletion list', async () => {
+    const file = getDriveItemData({ plainName: 'report', name: 'report', type: 'pdf', isFolder: false });
+    const folder = getDriveItemData({ plainName: 'Photos', name: 'Photos', isFolder: true });
+
+    await resolve({ operation: 'keep', items: [file, folder], existingItems: [] });
+
+    expect(mocks.getUniqueFilename).toHaveBeenCalledWith('report', 'pdf', ['file-dup'], DESTINATION);
+    expect(mocks.getUniqueFolderName).toHaveBeenCalledWith('Photos', ['folder-dup'], DESTINATION);
+    expect(mocks.moveItemsThunk).toHaveBeenNthCalledWith(1, {
+      items: [
+        { ...file, name: 'report (1)', plainName: 'report (1)', plain_name: 'report (1)', newItemName: 'report (1)' },
+      ],
+      destinationFolderId: DESTINATION,
+    });
+    expect(mocks.moveItemsThunk).toHaveBeenNthCalledWith(2, {
+      items: [{ ...folder, name: 'Photos (1)', plain_name: 'Photos (1)', newItemName: 'Photos (1)' }],
+      destinationFolderId: DESTINATION,
+    });
+    expect(mocks.moveItemsToTrash).not.toHaveBeenCalled();
+    expect(mocks.popItemsToDelete).toHaveBeenCalledWith([file, folder]);
+  });
+
+  test('when replacing, then existing items are trashed before moving and moved items leave the pending deletion list', async () => {
+    const item = getDriveItemData({ uuid: 'new' });
+    const existing = getDriveItemData({ uuid: 'existing' });
+    const callOrder: string[] = [];
+    mocks.moveItemsToTrash.mockImplementation(async () => callOrder.push('trash'));
+    mocks.moveItemsThunk.mockImplementation(() => callOrder.push('move'));
+
+    await resolve({ operation: 'replace', items: [item], existingItems: [existing] });
+
+    expect(mocks.moveItemsToTrash).toHaveBeenCalledWith([existing]);
+    expect(mocks.moveItemsThunk).toHaveBeenCalledWith({ items: [item], destinationFolderId: DESTINATION });
+    expect(callOrder).toEqual(['trash', 'move']);
+    expect(mocks.popItemsToDelete).toHaveBeenCalledWith([item]);
+  });
+});

--- a/src/app/drive/components/NameCollisionDialog/nameCollision.actions.ts
+++ b/src/app/drive/components/NameCollisionDialog/nameCollision.actions.ts
@@ -1,0 +1,86 @@
+import { WorkspaceData } from '@internxt/sdk/dist/workspaces';
+import { DriveItemData } from 'app/drive/types';
+import { AppDispatch } from 'app/store';
+import { storageActions } from 'app/store/slices/storage';
+import { checkDuplicatedFiles } from 'app/store/slices/storage/fileUtils/checkDuplicatedFiles';
+import { getUniqueFilename } from 'app/store/slices/storage/fileUtils/getUniqueFilename';
+import { checkFolderDuplicated } from 'app/store/slices/storage/folderUtils/checkFolderDuplicated';
+import { getUniqueFolderName } from 'app/store/slices/storage/folderUtils/getUniqueFolderName';
+import storageThunks from 'app/store/slices/storage/storage.thunks';
+import { MoveItemPayload } from 'app/store/slices/storage/storage.thunks/moveItemsThunk';
+import { moveItemsToTrash } from 'views/Trash/services';
+
+export type CollisionOperation = 'keep' | 'replace';
+
+export interface NameCollisionContext {
+  dispatch: AppDispatch;
+  selectedWorkspace: WorkspaceData | null;
+  maxUploadFileSize: number;
+  isVersioningEnabled: boolean;
+}
+
+export interface ResolveMoveCollisionParams {
+  operation: CollisionOperation;
+  items: DriveItemData[];
+  existingItems: DriveItemData[];
+  destinationUuid: string;
+}
+
+const getUniqueNameMovePayload = async (item: DriveItemData, destinationUuid: string): Promise<MoveItemPayload> => {
+  if (item.isFolder) {
+    const { duplicatedFoldersResponse } = await checkFolderDuplicated([item], destinationUuid);
+    const finalName = await getUniqueFolderName(
+      item.plainName ?? item.name,
+      duplicatedFoldersResponse as DriveItemData[],
+      destinationUuid,
+    );
+    return { ...item, name: finalName, plain_name: finalName, newItemName: finalName };
+  }
+
+  const { duplicatedFilesResponse } = await checkDuplicatedFiles([item], destinationUuid);
+  const finalName = await getUniqueFilename(item.name, item.type, duplicatedFilesResponse, destinationUuid);
+  return { ...item, name: finalName, plainName: finalName, plain_name: finalName, newItemName: finalName };
+};
+
+/**
+ * Moves each item to the destination under a name that does not collide with anything there.
+ */
+const keepAndMoveItems = async (
+  items: DriveItemData[],
+  destinationUuid: string,
+  { dispatch }: NameCollisionContext,
+) => {
+  for (const item of items) {
+    const itemParsed = await getUniqueNameMovePayload(item, destinationUuid);
+    await dispatch(storageThunks.moveItemsThunk({ items: [itemParsed], destinationFolderId: destinationUuid }));
+  }
+};
+
+/**
+ * Trashes the colliding drive items and then moves the incoming ones into their place.
+ */
+const replaceAndMoveItems = async (
+  items: DriveItemData[],
+  existingItems: DriveItemData[],
+  destinationUuid: string,
+  { dispatch }: NameCollisionContext,
+) => {
+  await moveItemsToTrash(existingItems);
+  await dispatch(storageThunks.moveItemsThunk({ items, destinationFolderId: destinationUuid }));
+};
+
+/**
+ * Applies the chosen resolution to items that collide while being moved, then removes them
+ * from the pending-deletion list.
+ */
+export const resolveMoveCollision = async (
+  { operation, items, existingItems, destinationUuid }: ResolveMoveCollisionParams,
+  context: NameCollisionContext,
+): Promise<void> => {
+  if (operation === 'keep') {
+    await keepAndMoveItems(items, destinationUuid, context);
+  } else {
+    await replaceAndMoveItems(items, existingItems, destinationUuid, context);
+  }
+  context.dispatch(storageActions.popItemsToDelete(items));
+};


### PR DESCRIPTION
## Description

First of a stack that ends in #2039 (skip option) and #2129 (merge folders on skip). Pure refactor, no behaviour change.

The name-collision container held every side effect inline. This moves the move-collision handling (keep both with a unique name, replace by trashing the existing item) into `nameCollision.actions.ts` behind `resolveMoveCollision`, which takes the items plus a small context (dispatch, workspace, upload limit, versioning flag) instead of closing over component state. Upload collisions stay in the container for now and move in the next PR.

Unit tests cover both move resolutions.

## Related Issues

## Related Pull Requests

- Next: refactor\/extract-name-collision-upload-actions

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [ ] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

`yarn vitest run src/app/drive/components/NameCollisionDialog`, plus the manual upload/move collision flows (keep both, replace, with and without versioning).
